### PR TITLE
ci: add build_and_test summary job for stable required-check name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,14 @@ on:
   merge_group:
 
 jobs:
-  # Required, BLOCKING gate. This job must be able to fail a merge — do not add
-  # `continue-on-error` here. Advisory/infra-dependent jobs below keep it.
-  build_and_test:
+  # Matrix executes the actual build/test work. Renamed from `build_and_test`
+  # so the canonical required-check name (`build_and_test`, the summary job
+  # below) is stable regardless of matrix axis size. Branch protection in
+  # .github/rulesets/main.json targets the summary job by name.
+  #
+  # BLOCKING gate (must be able to fail a merge — do not add `continue-on-error`
+  # here). Advisory/infra-dependent jobs further below keep it.
+  build_and_test_matrix:
     runs-on: ubuntu-latest
 
     strategy:
@@ -70,9 +75,29 @@ jobs:
     - name: Gate 07 — Claim Drift Check
       run: npm run validate:claims
 
+  # Stable required-check name for branch protection. Aggregates the matrix
+  # result so the required context (`build_and_test`) never changes shape
+  # even if the matrix axis grows (e.g. adding Node 22.x for fan-out tests).
+  # `if: always()` is mandatory — without it, a matrix failure produces a
+  # SKIPPED summary, which leaves required-check status pending forever
+  # (silent-deadlock failure mode).
+  build_and_test:
+    runs-on: ubuntu-latest
+    needs: [build_and_test_matrix]
+    if: always()
+    steps:
+    - name: Gate verdict
+      run: |
+        result="${{ needs.build_and_test_matrix.result }}"
+        if [[ "$result" != "success" ]]; then
+          echo "::error::build_and_test_matrix concluded '$result' — gate failed."
+          exit 1
+        fi
+        echo "build_and_test_matrix succeeded — gate passed."
+
   beta_readiness:
     runs-on: ubuntu-latest
-    needs: build_and_test
+    needs: build_and_test_matrix
     continue-on-error: true
     steps:
     - name: Checkout Repository
@@ -131,7 +156,7 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    needs: [build_and_test, beta_readiness]
+    needs: [build_and_test_matrix, beta_readiness]
     continue-on-error: true
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Adds a stable `build_and_test` summary job so `.github/rulesets/main.json` can use a non-matrix-coupled required-check context.

## Problem

The `build_and_test` job in `ci.yml` ran under a matrix (`node-version: [20.x]`), so GitHub rendered the check name as `build_and_test (20.x)`. Branch protection in `.github/rulesets/main.json` targeted bare `build_and_test`. Applying the ruleset as-written would have left every merge waiting on a check that never reports under that name (silent deadlock — independent of, and additive to, the workflow's `disabled_manually` state).

This blocker is invisible at the YAML / ruleset-JSON level individually; only the *interaction* deadlocks.

## Fix

| Job | Before | After |
|---|---|---|
| Matrix work | `build_and_test` | `build_and_test_matrix` (renamed) |
| Stable gate name | — | `build_and_test` (new summary job, `needs: [build_and_test_matrix]`, `if: always()`) |
| `beta_readiness.needs` | `build_and_test` | `build_and_test_matrix` |
| `e2e.needs` | `[build_and_test, beta_readiness]` | `[build_and_test_matrix, beta_readiness]` |

`if: always()` on the summary is mandatory — without it, a matrix failure produces a *skipped* summary, which leaves a required-check pending forever.

## Why summary-job (vs. dropping the matrix or updating the ruleset)

Picked the summary-job pattern over the two alternatives because:
- **Dropping the matrix** flattens the structure but throws away the option to expand axes (Node 22, additional OS) without re-touching branch protection.
- **Updating the ruleset to `build_and_test (20.x)`** couples branch protection to the matrix axis value — silent re-deadlock on any future axis bump.
- **Summary job** keeps the matrix and decouples the required-check name from its shape. Matrix can grow to `[18.x, 20.x, 22.x]` without re-touching the ruleset.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses clean.
- All three `needs:` references updated; structure verified post-edit:
  ```
  build_and_test_matrix    needs=—                                        continue-on-error=False
  build_and_test           needs=build_and_test_matrix                    continue-on-error=False
  beta_readiness           needs=build_and_test_matrix                    continue-on-error=True
  terraform_validate       needs=—                                        continue-on-error=True
  e2e                      needs=build_and_test_matrix, beta_readiness    continue-on-error=True
  ```

## Follow-on (handled in same session, not in this PR)

1. Re-enable the `ci.yml` workflow on the repo (currently `disabled_manually` since 2026-03-04).
2. Apply `.github/rulesets/main.json` via `POST /repos/.../rulesets`.
3. `ENTERPRISE_SSO_SECRET` per env — handled by user in GitHub UI.
4. Migration 030 — automatic via deploy pipeline.
5. CodeQL false-positive — user's one-click dismissal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)