### PR TITLE
ruleset: drop unsupported automatic_copilot_code_review_enabled field

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -21,7 +21,6 @@
         "require_code_owner_review": true,
         "require_last_push_approval": false,
         "required_review_thread_resolution": true,
-        "automatic_copilot_code_review_enabled": false,
         "allowed_merge_methods": ["squash"]
       }
     },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,16 @@ jobs:
       run: npm audit --audit-level=high || echo "::warning::npm audit reported high-severity advisories; review but not blocking the merge."
 
     - name: Execute Tests with Coverage (Turborepo)
-      run: npx turbo run test -- --coverage --ci
+      # NOTE: `--ci` is intentionally NOT passed. It is jest-only; vitest's
+      # CLI rejects it as an unknown option (CAC checkUnknownOptions). With
+      # heterogeneous workspaces (jest in @styx/shared, vitest in
+      # @styx/test-harness, etc.), portable CI-mode detection comes from the
+      # `CI=true` env var that GitHub Actions sets automatically — both jest
+      # and vitest honor it. Reintroducing `--ci` here will break vitest
+      # workspaces; if jest's strict-snapshot semantics ever drift away from
+      # what `CI=true` provides, set them in each jest workspace's package
+      # script instead.
+      run: npx turbo run test -- --coverage
 
     - name: Upload Coverage Reports
       if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,16 +39,7 @@ jobs:
       run: npm audit --audit-level=high || echo "::warning::npm audit reported high-severity advisories; review but not blocking the merge."
 
     - name: Execute Tests with Coverage (Turborepo)
-      # NOTE: `--ci` is intentionally NOT passed. It is jest-only; vitest's
-      # CLI rejects it as an unknown option (CAC checkUnknownOptions). With
-      # heterogeneous workspaces (jest in @styx/shared, vitest in
-      # @styx/test-harness, etc.), portable CI-mode detection comes from the
-      # `CI=true` env var that GitHub Actions sets automatically — both jest
-      # and vitest honor it. Reintroducing `--ci` here will break vitest
-      # workspaces; if jest's strict-snapshot semantics ever drift away from
-      # what `CI=true` provides, set them in each jest workspace's package
-      # script instead.
-      run: npx turbo run test -- --coverage
+      run: npx turbo run test -- --coverage --ci
 
     - name: Upload Coverage Reports
       if: always()


### PR DESCRIPTION
## Narrowly scoped: reconciles ruleset JSON with applied API state

**Net diff vs main: one line removed** from `.github/rulesets/main.json`.

```diff
         "required_review_thread_resolution": true,
-        "automatic_copilot_code_review_enabled": false,
         "allowed_merge_methods": ["squash"]
```

## Why

The committed `.github/rulesets/main.json` carried `automatic_copilot_code_review_enabled: false` under the `pull_request` rule. GitHub's REST `POST /repos/.../rulesets` endpoint rejects this field as `Unexpected parameter` (HTTP 422). It's UI-only today; the API schema has not caught up. Default behavior (`false`) is identical, so live behavior is unchanged.

The ruleset was applied earlier (ID 16889701, active) using a `jq del`-stripped payload. This PR makes the on-disk JSON match the applied state, so future re-applies don't fail with the same 422.

## Cross-PR coordination

This PR previously also contained a one-line `ci.yml` fix dropping `--ci` from the turbo passthrough. **That work is superseded by [#611](https://github.com/a-organvm/peer-audited--behavioral-blockchain/pull/611)**, which solves the same problem more thoroughly (drops both `--coverage` and `--ci`, adds the missing `src/shared/jest.config.cjs`, and fixes the `@styx/test-harness` lint script). To avoid conflict, the ci.yml change here was reverted (commit `3e3b78f` undoes `9ebf07d`). On squash-merge, the noise collapses; net effect = the one-line JSON edit above.

## Status of required checks (will materialize once #611 lands and this rebases)

Currently `build_and_test_matrix (20.x)` and `build_and_test` fail because main still has the broken `--coverage --ci` passthrough. Once #611 merges, those checks will go green here. Merge order:

1. Approve + merge #611 (test-pipeline fix)
2. Rebase this branch on main (will auto-resolve to just the JSON one-liner)
3. CI re-runs green, approve + merge here

## Verification

- `jq -e . .github/rulesets/main.json > /dev/null` parses clean.
- Removed field's `false` value matched GitHub's default behavior; observable behavior of the live ruleset is identical pre- and post-edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)