### PR TITLE
ruleset: drop non-functional merge_queue rule to match live main-protection

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -35,18 +35,6 @@
           { "context": "Secret Pattern Detection" }
         ]
       }
-    },
-    {
-      "type": "merge_queue",
-      "parameters": {
-        "merge_method": "SQUASH",
-        "grouping_strategy": "ALLGREEN",
-        "min_entries_to_merge": 1,
-        "max_entries_to_merge": 5,
-        "min_entries_to_merge_wait_minutes": 5,
-        "max_entries_to_build": 5,
-        "check_response_timeout_minutes": 60
-      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

The LIVE `main-protection` ruleset (id `16889701`) no longer has a `merge_queue` rule — it was removed 2026-05-29 because the queue was **non-functional**. But the tracked `.github/rulesets/main.json` still carried the `merge_queue` block (it landed via #612), so a future file→live sync would silently re-break merges. This PR removes the block so the tracked base matches live.

**Why the queue was non-functional:** a `merge_queue` rule waits for *all* required status checks to report on the `merge_group` event. Only `ci.yml` (→ `build_and_test`) triggers on `merge_group`; `codeql.yml` (→ `Analyze (javascript-typescript)`) and `secret-scan.yml` (→ `Secret Pattern Detection`) do **not**. So every PR stalled in `AWAITING_CHECKS` for the 60-min `check_response_timeout_minutes`, then dequeued. The solo-conductor repo does not require a merge queue.

## Changes

- Remove the `merge_queue` rule block from `.github/rulesets/main.json` (only change; 12 deletions).
- Tracked rule set is now `deletion`, `non_fast_forward`, `required_linear_history`, `pull_request`, `required_status_checks` — **exactly matching the live ruleset `16889701`**.

## Test Plan

- [x] `jq` confirms the edited file is valid JSON
- [x] `diff` confirms tracked-file rule set == live ruleset (`16889701`) rule set (verified MATCH)
- [ ] `make test` / `npx turbo run lint` / `04-redacted-build-check.sh` — **not run locally**: config-only change to a declarative ruleset definition that is not consumed by the build. The PR's three required checks (`build_and_test`, `Analyze (javascript-typescript)`, `Secret Pattern Detection`) run on this PR and cover validation.

## Checklist

- [x] No secrets or credentials committed
- [ ] Tests added/updated — N/A: declarative ruleset config, no behavior code to test
- [ ] CLAUDE.md updated — N/A: no architecture change
- [ ] API spec (`docs/api/spec.md`) updated — N/A: no endpoint change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
