### PR TITLE
fix(terraform): align render_web_service with provider schema, drop v5-only R2 lifecycle

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -82,6 +82,12 @@ variable "environment" {
   default = "production"
 }
 
+variable "repo_url" {
+  type        = string
+  description = "Git repository URL Render builds the Docker services from."
+  default     = "https://github.com/a-organvm/peer-audited--behavioral-blockchain"
+}
+
 # --- Providers ---
 
 provider "render" {
@@ -95,23 +101,28 @@ provider "cloudflare" {
 # --- Render: API Service ---
 
 resource "render_web_service" "styx_api" {
-  name           = "styx-api"
-  region         = "oregon"
-  plan           = "starter"
-  runtime        = "docker"
-  docker_path    = "./src/api/Dockerfile"
-  docker_context = "."
-  branch         = "main"
+  name   = "styx-api"
+  region = "oregon"
+  plan   = "starter"
+
+  runtime_source = {
+    docker = {
+      repo_url        = var.repo_url
+      branch          = "main"
+      dockerfile_path = "./src/api/Dockerfile"
+      context         = "."
+    }
+  }
 
   env_vars = {
-    NODE_ENV          = var.environment
-    DATABASE_URL      = var.database_url
-    REDIS_URL         = var.redis_url
-    STRIPE_SECRET_KEY = var.stripe_secret_key
-    JWT_SECRET        = var.jwt_secret
-    ANONYMIZE_SALT    = var.anonymize_salt
-    R2_ENDPOINT       = "https://${var.cloudflare_account_id}.r2.cloudflarestorage.com"
-    R2_BUCKET         = cloudflare_r2_bucket.styx_proofs.name
+    NODE_ENV          = { value = var.environment }
+    DATABASE_URL      = { value = var.database_url }
+    REDIS_URL         = { value = var.redis_url }
+    STRIPE_SECRET_KEY = { value = var.stripe_secret_key }
+    JWT_SECRET        = { value = var.jwt_secret }
+    ANONYMIZE_SALT    = { value = var.anonymize_salt }
+    R2_ENDPOINT       = { value = "https://${var.cloudflare_account_id}.r2.cloudflarestorage.com" }
+    R2_BUCKET         = { value = cloudflare_r2_bucket.styx_proofs.name }
   }
 
   health_check_path = "/health"
@@ -120,17 +131,22 @@ resource "render_web_service" "styx_api" {
 # --- Render: Web Dashboard ---
 
 resource "render_web_service" "styx_web" {
-  name           = "styx-web"
-  region         = "oregon"
-  plan           = "starter"
-  runtime        = "docker"
-  docker_path    = "./src/web/Dockerfile"
-  docker_context = "."
-  branch         = "main"
+  name   = "styx-web"
+  region = "oregon"
+  plan   = "starter"
+
+  runtime_source = {
+    docker = {
+      repo_url        = var.repo_url
+      branch          = "main"
+      dockerfile_path = "./src/web/Dockerfile"
+      context         = "."
+    }
+  }
 
   env_vars = {
-    NODE_ENV            = var.environment
-    NEXT_PUBLIC_API_URL = "https://${render_web_service.styx_api.name}.onrender.com"
+    NODE_ENV            = { value = var.environment }
+    NEXT_PUBLIC_API_URL = { value = "https://${render_web_service.styx_api.name}.onrender.com" }
   }
 }
 
@@ -142,42 +158,14 @@ resource "cloudflare_r2_bucket" "styx_proofs" {
   location   = "WNAM"
 }
 
-# R2 Lifecycle: auto-delete proof media 30 days after final review
-# Prevents unbounded storage growth and maintains GDPR compliance.
-resource "cloudflare_r2_bucket_lifecycle" "proofs_cleanup" {
-  account_id = var.cloudflare_account_id
-  bucket     = cloudflare_r2_bucket.styx_proofs.name
-
-  rules {
-    id      = "auto-expire-proofs"
-    enabled = true
-
-    conditions {
-      prefix = "proofs/"
-    }
-
-    abort_multipart_uploads_after {
-      days = 1
-    }
-
-    delete_objects_after {
-      days = 30
-    }
-  }
-
-  rules {
-    id      = "auto-expire-honeypots"
-    enabled = true
-
-    conditions {
-      prefix = "honeypots/"
-    }
-
-    delete_objects_after {
-      days = 7
-    }
-  }
-}
+# R2 object-lifecycle policies — auto-expire proof media 30 days after final
+# review, honeypots after 7 (storage hygiene + GDPR data-minimization) — are NOT
+# managed here: the pinned Cloudflare provider (~> 4.0) has no
+# `cloudflare_r2_bucket_lifecycle` resource (it landed in provider v5). Until the
+# provider is upgraded, apply these rules out-of-band via the Cloudflare dashboard,
+# API, or `wrangler r2 bucket lifecycle`. Restoring Terraform management requires a
+# deliberate v4 -> v5 provider migration (also rewrites the cloudflare_ruleset WAF
+# resources) and is tracked as a separate change.
 
 # --- Outputs ---
 


### PR DESCRIPTION
## Summary

The `terraform_validate` CI job (`.github/workflows/ci.yml`) has been red on every PR and on `main`. It is **not** a required check (gating checks are `build_and_test`, `Analyze (javascript-typescript)`, `Secret Pattern Detection`) so it never blocked merges — but it failed on every run. Root cause: `infra/terraform/main.tf` was authored against provider schemas that don't match the pinned provider versions, so `terraform validate` exited 1. The `fmt -check` and `init -backend=false` steps passed; only `validate` failed (CI run 26643273769, job 78521864147).

## Changes

- **`render_web_service` (`render-oss/render ~> 1.0` → v1.8.0):** schema requires a nested `runtime_source` object and rejects the flat `runtime` / `docker_path` / `docker_context` / `branch` arguments. Reworked `styx_api` and `styx_web` to use `runtime_source.docker { repo_url, branch, dockerfile_path, context }`.
- **`env_vars`:** values are objects in this provider, not bare strings — wrapped each as `{ value = ... }`.
- **New `repo_url` variable** (defaults to this repo): the Render Docker git-deploy requires it and it was absent.
- **`cloudflare_r2_bucket_lifecycle`:** does not exist in `cloudflare/cloudflare ~> 4.0` (added in provider v5). Removed the resource and documented the constraint inline. The R2 auto-expire / GDPR data-minimization intent is preserved as a note plus a separately-tracked v4→v5 migration follow-up — that migration also rewrites the `cloudflare_ruleset` WAF resources, so it is deliberately out of scope for this CI-hygiene fix.

No change to `cloudflare-waf.tf` — those rulesets already validate clean under v4.

## Test Plan

Reproduced the CI sequence locally with terraform 1.9.8 (CI pins `~1.9`) in `infra/terraform`:

- [x] `terraform fmt -check -recursive -diff` → exit 0
- [x] `terraform init -backend=false -input=false` → resolves cloudflare v4.52.7 + render v1.8.0 (same as CI; no committed lock file)
- [x] `terraform validate` → **Success! The configuration is valid.** (was exit 1)

## Checklist

- [x] No secrets or credentials committed (schema-shape fixes only; `repo_url` default is the public repo URL)
- [x] Validated against the actually-pinned provider schemas via `terraform providers schema -json`, not guessed
- [ ] N/A — Terraform-only change; `make test` / `turbo lint` / redacted-build-check unaffected, no app behavior changed
- [ ] Follow-up: R2 lifecycle (GDPR auto-expire) to be restored via the cloudflare v4→v5 provider migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)