### PR TITLE
fix(ci): repair e2e and beta_readiness checks failing on every PR

### DIFF
--- a/.config/playwright/playwright.config.ts
+++ b/.config/playwright/playwright.config.ts
@@ -1,7 +1,18 @@
 import { defineConfig, devices } from '@playwright/test';
+import { join } from 'path';
+
+// This config lives in .config/playwright/ (Minimal-Root convention) but the
+// specs it runs (e2e/) and the web server it boots (src/web/) live at the repo
+// root. Playwright resolves a relative testDir/webServer.cwd against the config
+// file's own directory (.config/playwright/), which would point at the wrong
+// place. The CLI is always invoked from the repo root — the --config path is
+// itself repo-root-relative — so anchor both to process.cwd() as absolute
+// paths. (No import.meta/__dirname: Playwright's config loader rejects that
+// dual idiom with "exports is not defined in ES module scope".)
+const repoRoot = process.cwd();
 
 export default defineConfig({
-  testDir: './e2e',
+  testDir: join(repoRoot, 'e2e'),
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
@@ -32,7 +43,12 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: process.env.CI ? 'cd src/web && npm run start' : 'cd src/web && npm run dev',
+    // `next start` defaults to port 3000; pin it to 3001 to match `url` below
+    // (local `next dev -p 3001` already binds 3001). cwd is the web workspace
+    // at the repo root, resolved absolutely so it is independent of this
+    // config file's location.
+    command: process.env.CI ? 'npm run start -- -p 3001' : 'npm run dev',
+    cwd: join(repoRoot, 'src/web'),
     url: 'http://localhost:3001',
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
       run: cd src/web && npm run build
 
     - name: Run E2E Tests (${{ matrix.browser }})
-      run: npx playwright test --project=${{ matrix.browser }}
+      run: npx playwright test --config=.config/playwright/playwright.config.ts --project=${{ matrix.browser }}
       env:
         CI: true
 

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "validate:claims": "node scripts/validation/07-claim-drift-check.js",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "clean": "turbo run clean && rm -rf node_modules",
-    "test:e2e": "npx playwright test",
-    "test:e2e:ui": "npx playwright test --ui",
-    "test:e2e:headed": "npx playwright test --headed",
+    "test:e2e": "npx playwright test --config=.config/playwright/playwright.config.ts",
+    "test:e2e:ui": "npx playwright test --config=.config/playwright/playwright.config.ts --ui",
+    "test:e2e:headed": "npx playwright test --config=.config/playwright/playwright.config.ts --headed",
     "beta:readiness": "bash scripts/smoke/beta-readiness.sh",
     "beta:deploy-preflight": "bash scripts/smoke/beta-deploy-preflight.sh",
     "docs:ingest": "node scripts/analysis/ingest-doc-intelligence.js"

--- a/scripts/validation/06-security-invariant-check.ts
+++ b/scripts/validation/06-security-invariant-check.ts
@@ -144,7 +144,12 @@ function runSecurityInvariantCheck() {
 
   console.log(`Scanned ${filesScanned} files across ${SCAN_DIRS.length} build directories + source guards.`);
 
-  if (missingScanDirs.length > 0) {
+  // All build dirs missing = "not built in this context" (e.g. PR-stage beta
+  // readiness, which never builds) — that is not-applicable, not a violation,
+  // and is handled as a clean skip (exit 2) below. Only a PARTIAL build (some
+  // output present, some missing) is a real anomaly worth failing on here.
+  const allBuildDirsMissing = missingScanDirs.length === SCAN_DIRS.length;
+  if (missingScanDirs.length > 0 && !allBuildDirsMissing) {
     errors.push({
       file: 'validation',
       label: `MISSING_SCAN_DIRS (${missingScanDirs.join(', ')})`,
@@ -189,6 +194,18 @@ function runSecurityInvariantCheck() {
       console.error(`  🚨 ${v.label} in ${v.file}:${v.line}`);
     }
     process.exit(1);
+  }
+
+  // No violations. If there was simply no build output to scan (no build in
+  // this context), exit 2 = "skipped / not verified" so suite wrappers like
+  // scripts/smoke/beta-readiness.sh treat it as a clean skip rather than a red.
+  // A post-build invocation (the blocking build_and_test_matrix gate) always
+  // has the dirs present, so it still exits 0 and enforces the scan on shipped
+  // output — security coverage there is unchanged.
+  if (allBuildDirsMissing) {
+    const rel = SCAN_DIRS.map((d) => d.replace(`${REPO_ROOT}/`, '')).join(', ');
+    console.log(`\n⏭️  GATE 06 SKIPPED: no build output present to scan (${rel}). Run after a build to enforce.`);
+    process.exit(2);
   }
 
   console.log('\n✅ GATE 06 PASSED: No dev tokens or debug backdoors found in production output.');


### PR DESCRIPTION
## Summary

Two non-blocking CI checks — `e2e (chromium/firefox)` and `beta_readiness` — have failed on **every** PR for a while. Both are `continue-on-error: true`, so they never blocked a merge and so never got root-caused. The cost is signal loss: a reviewer can't tell a genuine regression from the standing red. This repairs both at the source.

## Changes

**`e2e` — `Project(s) "chromium" not found. Available projects: ""`**
- `npx playwright test` ran from the repo root, but the only config lives at `.config/playwright/playwright.config.ts` (Minimal-Root convention), so Playwright loaded an empty default config with zero projects.
- Pass `--config=.config/playwright/playwright.config.ts` in `ci.yml` and the three `package.json` `test:e2e*` scripts.
- Relocating the config had also broken its config-dir-relative paths — a cascade that only surfaces one layer at a time: `testDir './e2e'` → `.config/playwright/e2e` (nonexistent); `webServer 'cd src/web'` → under `.config/playwright/`; and CI `next start` binds `:3000` while `webServer.url` waits on `:3001`. Anchored `testDir`/`webServer.cwd` to `process.cwd()` as absolute paths and pinned the CI preview server to `:3001`.

**`beta_readiness` — `GATE 06 FAILED: MISSING_SCAN_DIRS (src/api/dist, src/web/.next)`**
- The `beta_readiness` job runs the security-invariant scan with no preceding build, so the build-output dirs don't exist — but GATE 06 treated "no output" as a *security violation* (contradicting its own `collectFiles` comment, "Directory doesn't exist (not built yet) — that's fine").
- Honor the suite's existing skip protocol (`run_gate` treats exit code 2 as "skipped / not verified"): when **all** build dirs are absent, exit 2. Real secret/token violations still exit 1; a partial build (some dirs missing) still errors.
- The blocking `build_and_test_matrix` gate runs this same scan **after** the build, where the dirs always exist, so it still exits 0/1 and enforces the scan on shipped output — **security coverage there is unchanged**.

## Test Plan

- [ ] `make test` passes (all workspaces) — _deferred to CI; no local node_modules install_
- [ ] `npx turbo run lint` clean — _deferred to CI_
- [x] `scripts/validation/04-redacted-build-check.sh` — unaffected by these changes
- [x] **Manual verification (local):**
  - **e2e:** `playwright test --config=.config/playwright/playwright.config.ts --list` resolves the `chromium` and `firefox` projects and discovers all **47 specs** in `e2e/` (previously: zero projects, hard error).
  - **GATE 06 truth table** (via `tsx`):
    - no build output → **exit 2** (skip) ← the beta_readiness PR context
    - clean build output → **exit 0** (pass)
    - leaked secret in build output → **exit 1** (fail — security preserved)

## Checklist

- [x] No secrets or credentials committed
- [ ] Tests added/updated for changed behavior — _n/a: restores the existing e2e suite to runnable and corrects a gate's exit semantics; no new behavior_
- [ ] CLAUDE.md updated if architecture changed — _n/a_
- [ ] API spec updated if endpoints changed — _n/a_

## Notes

- Two independent atomic commits; either can be reverted alone.
- No file overlap with open PRs #614/#615 (terraform).

## ✅ Verified CI results (post-push)

| Check | Result | Notes |
|---|---|---|
| `beta_readiness` | **pass** | was failing on every PR — **fixed** |
| `build_and_test_matrix` / `build_and_test` | **pass** | GATE 06 change did **not** weaken the blocking post-build gate |
| `e2e (chromium)` / `e2e (firefox)` | run, **40 passed / 7 failed** | infra **fixed** (was 0 tests, hard config error); 7 failures are pre-existing test debt — tracked in **#617** |
| `terraform_validate` | fail | pre-existing on `main`, **not** in this diff (no terraform files touched); fixed by #614/#615 |

The e2e job now executes the suite end-to-end for the first time in a while (web server boots on `:3001`, all 4 projects resolve). The 7 remaining failures are a **distinct** root cause (stale auth fixture — sets `localStorage.styx_token` while the app gates on the `styx_auth_token` cookie via `src/web/proxy.ts`), kept out of this PR for atomicity and tracked in #617.
