### PR TITLE
docs(research): add provenance frontmatter to AI-generated research docs (closes #593)

### DIFF
--- a/docs/research/research--academic-market-syllabus.md
+++ b/docs/research/research--academic-market-syllabus.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Styx Academic & Market Research Syllabus
 
 > **Project:** Styx -- Peer-Audited Behavioral Market

--- a/docs/research/research--app-verification-tech-privacy-law.md
+++ b/docs/research/research--app-verification-tech-privacy-law.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # **Cryptographic Verification, Platform Governance, and the Jurisprudential Viability of Randomized Screen Recording in Behavioral Compliance Architectures**
 
 The conceptualization of a "Randomized Verification Lottery" (RVL) represents a highly aggressive paradigm within the domain of digital behavioral compliance. Deployed across high-stakes environments—ranging from court-ordered "no contact" mandates and probationary oversight to corporate non-disclosure agreements and insider-threat mitigation—this theoretical architecture demands that users periodically and randomly upload live screen recordings of third-party communications applications. By capturing the interface of applications such as Apple iMessage, Meta's WhatsApp, or Instagram Direct Messages, the RVL system seeks to cryptographically prove an individual's adherence to specific behavioral restrictions.

--- a/docs/research/research--b2b-expansion-heartbreak-niche.md
+++ b/docs/research/research--b2b-expansion-heartbreak-niche.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # **Strategic Go-To-Market Plan: Transitioning Behavioral Recovery Applications to Enterprise B2B2C Models**
 
 The digital therapeutics and behavioral health market is undergoing a structural evolution, shifting from fragmented direct-to-consumer (B2C) applications toward integrated business-to-business-to-consumer (B2B2C) ecosystems. The current operational baseline involves a Phase 1 minimum viable product (MVP) serving an initial beta audience of 18,000 highly engaged users within the relationship recovery and heartbreak niche. These users currently leverage the platform to stake financial resources on their own "No Contact" behavioral goals. This mechanism relies on the principles of gamification, behavioral economics, and positive reinforcement to drive psychological recovery, utilizing financial loss aversion as the primary catalyst for adherence.1

--- a/docs/research/research--behavior-change-app-design.md
+++ b/docs/research/research--behavior-change-app-design.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # **The Architecture of Behavioral Change: Integrating Psychological Efficacy and Relational Database Schema in Digital Therapeutics**
 
 ## **Introduction to Digital Therapeutics and Behavioral Architecture**

--- a/docs/research/research--behavioral-economics.md
+++ b/docs/research/research--behavioral-economics.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # **The Behavioral Economics of Habit Formation: Synthesizing Loss Aversion, Endowed Progress, and Motivational Dynamics in Financial Commitment Applications**
 
 ## **Introduction to Behavioral Design in Digital Habit Formation**

--- a/docs/research/research--behavioral-engineering-masters.md
+++ b/docs/research/research--behavioral-engineering-masters.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Styx: Behavioral Engineering - The Master Synthesis
 
 ## Overview

--- a/docs/research/research--behavioral-physics-manifesto.md
+++ b/docs/research/research--behavioral-physics-manifesto.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 ## Q: 
 satanism argues the inherent balance of humanity through the self-governance of the seven deadly sins
 

--- a/docs/research/research--bounty-shame-protocol-safety-legality.md
+++ b/docs/research/research--bounty-shame-protocol-safety-legality.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # **Accountability and The "Bounty/Shame" Protocol: A Multidisciplinary Analysis of User Safety, Psychological Efficacy, and Decentralized Legal Frameworks**
 
 ## **1\. App Store Safety Guidelines and the Viability of Punitive User-Generated Content Mechanics**

--- a/docs/research/research--breakup-psychology-loss-aversion.md
+++ b/docs/research/research--breakup-psychology-loss-aversion.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # **Psychological Pain-Point Mapping: The 90-Day Breakup Recovery Timeline and Loss Aversion Interventions**
 
 ## **Introduction to Attachment-Driven Relapse and Behavioral Economics**

--- a/docs/research/research--commitment-device-market-analysis.md
+++ b/docs/research/research--commitment-device-market-analysis.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # **Market Gap Analysis: The Digital Detox Angle and the Blockchain of Truth Architecture**
 
 ## **1\. Executive Summary: The Structural Failure of the Behavioral Health Ecosystem**

--- a/docs/research/research--competitor-accountable-ai-deep-dive.md
+++ b/docs/research/research--competitor-accountable-ai-deep-dive.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Market-Gap Analysis: Accountable AI & App-Gating Deep Dive
 
 **Status:** Completed | **Version:** 1.0.0 | **Date:** March 6, 2026

--- a/docs/research/research--competitor-beeminder-deep-dive.md
+++ b/docs/research/research--competitor-beeminder-deep-dive.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Market-Gap Analysis: Beeminder Deep Dive
 
 **Status:** Completed | **Version:** 1.0.0 | **Date:** March 6, 2026

--- a/docs/research/research--competitor-bibliography.md
+++ b/docs/research/research--competitor-bibliography.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Research: Competitor Annotated Bibliography
 
 **Status:** Completed | **Version:** 2.0.0 | **Date:** March 6, 2026

--- a/docs/research/research--competitor-focusmate-deep-dive.md
+++ b/docs/research/research--competitor-focusmate-deep-dive.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Market-Gap Analysis: Focusmate Deep Dive
 
 **Status:** Completed | **Version:** 1.0.0 | **Date:** March 6, 2026

--- a/docs/research/research--competitor-forfeit-deep-dive.md
+++ b/docs/research/research--competitor-forfeit-deep-dive.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Market-Gap Analysis: Forfeit Deep Dive
 
 **Status:** Completed | **Version:** 1.0.0 | **Date:** March 6, 2026

--- a/docs/research/research--competitor-genealogy.md
+++ b/docs/research/research--competitor-genealogy.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Research: Competitor Genealogy (Life Course & Maturity Analysis)
 
 **Status:** Completed | **Version:** 1.0.0 | **Date:** March 6, 2026

--- a/docs/research/research--competitor-habitica-deep-dive.md
+++ b/docs/research/research--competitor-habitica-deep-dive.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Market-Gap Analysis: Habitica Deep Dive
 
 **Status:** Completed | **Version:** 1.0.0 | **Date:** March 6, 2026

--- a/docs/research/research--competitor-no-contact-niche-deep-dive.md
+++ b/docs/research/research--competitor-no-contact-niche-deep-dive.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Market-Gap Analysis: Relationship Recovery & No Contact Niche
 
 **Status:** Completed | **Version:** 1.0.0 | **Date:** March 6, 2026

--- a/docs/research/research--competitor-pavlok-deep-dive.md
+++ b/docs/research/research--competitor-pavlok-deep-dive.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Market-Gap Analysis: Pavlok Deep Dive
 
 **Status:** Completed | **Version:** 1.0.0 | **Date:** March 6, 2026

--- a/docs/research/research--competitor-stickk-deep-dive.md
+++ b/docs/research/research--competitor-stickk-deep-dive.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Market-Gap Analysis: stickK.com Deep Dive
 
 **Status:** Completed | **Version:** 1.0.0 | **Date:** March 6, 2026

--- a/docs/research/research--competitor-taskratchet-deep-dive.md
+++ b/docs/research/research--competitor-taskratchet-deep-dive.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Market-Gap Analysis: TaskRatchet Deep Dive
 
 **Status:** Completed | **Version:** 1.0.0 | **Date:** March 6, 2026

--- a/docs/research/research--competitor-teardown-v2.md
+++ b/docs/research/research--competitor-teardown-v2.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Market Differentiation & Competitor Analysis: A Strategic Teardown of the Gamified Habit-Tracking and Financial-Stakes Ecosystem
 
 The intersection of behavioral economics, digital gamification, and

--- a/docs/research/research--competitor-teardown.md
+++ b/docs/research/research--competitor-teardown.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # **Market Differentiation & Competitor Analysis: A Strategic Teardown of the Gamified Habit-Tracking and Financial-Stakes Ecosystem**
 
 The intersection of behavioral economics, digital gamification, and financial commitment contracts has spawned a highly lucrative, yet fundamentally flawed, ecosystem of habit-tracking and personal productivity applications. These platforms attempt to bridge the intention-behavior gap—the cognitive dissonance between a user's long-term aspirational goals and their short-term impulsive actions—by applying extrinsic motivators to daily routines. The digital productivity market is broadly divided into two distinct paradigms: virtual progression models, which utilize psychological rewards and variable schedules of reinforcement, and punitive financial models, which weaponize loss aversion to force behavioral compliance.

--- a/docs/research/research--competitor-waybetter-deep-dive.md
+++ b/docs/research/research--competitor-waybetter-deep-dive.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Market-Gap Analysis: HealthyWage & WayBetter Deep Dive
 
 **Status:** Completed | **Version:** 1.0.0 | **Date:** March 6, 2026

--- a/docs/research/research--differentiation-competitor.md
+++ b/docs/research/research--differentiation-competitor.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 <img src="https://r2cdn.perplexity.ai/pplx-full-logo-primary-dark%402x.png" style="height:64px;margin-right:32px"/>
 
 # Pillar 2: Market Differentiation \& Competitor Analysis

--- a/docs/research/research--digital-exhaust-no-contact-contracts.md
+++ b/docs/research/research--digital-exhaust-no-contact-contracts.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # **Quantifying "No Contact": Leveraging Digital Exhaust for Behavioral Commitment Contracts**
 
 ## **Introduction to Telemetry-Driven Behavioral Enforcement and Digital Exhaust**

--- a/docs/research/research--evaluation-to-growth--behavioral-physics.md
+++ b/docs/research/research--evaluation-to-growth--behavioral-physics.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Styx: Behavioral Physics Manifesto - Evaluation to Growth Review
 
 ## Overview

--- a/docs/research/research--evaluation-to-growth--strategic-review.md
+++ b/docs/research/research--evaluation-to-growth--strategic-review.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Styx: Evaluation to Growth Strategic Review
 
 ## Evaluation Phase

--- a/docs/research/research--gamified-behavior-change-app-design.md
+++ b/docs/research/research--gamified-behavior-change-app-design.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 ## Q: 
 You said
 

--- a/docs/research/research--habit-application.md
+++ b/docs/research/research--habit-application.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Pillar 1: User Psychology & Behavior
 
 **Loss aversion:**  Prospect theory shows people dread losses about twice as much as they enjoy gains. For example, Kahneman & Tversky note that “the pain from losing $1,000 could only be compensated by the pleasure of earning $2,000”【9†L161-L168】.  In habit-building apps this means users will work hard to avoid losing a deposited stake.  In practice, trials confirm this: one pedometer-based gamified study found that participants who risked their own money on step goals met their targets significantly more often【2†L332-L336】.  Crucially, loss-aversion only kicks in if the stakes are perceived as *earned* rather than arbitrarily given.  As one study notes, users only showed strong motivation “so long as the loss relates to something that was earned rather than endowed”【2†L332-L336】.  In other words, framing the money as *the user’s own* deposit (a personal endowment) is key to triggering loss aversion.  

--- a/docs/research/research--market-analysis-v2.md
+++ b/docs/research/research--market-analysis-v2.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # The Gamification and Habit Tracking App Market: 2025--2035 Strategic Outlook
 
 ## Executive Overview

--- a/docs/research/research--market-analysis.md
+++ b/docs/research/research--market-analysis.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # **The Gamification and Habit Tracking App Market: 2025–2035 Strategic Outlook**
 
 ## **Executive Overview**

--- a/docs/research/research--market-synthesis-matrix.md
+++ b/docs/research/research--market-synthesis-matrix.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Research: Market Synthesis Matrix
 
 **Status:** Completed | **Version:** 2.0.0 | **Date:** March 6, 2026

--- a/docs/research/research--prediction-markets-regulation-finance.md
+++ b/docs/research/research--prediction-markets-regulation-finance.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # **Spectator Prediction Markets in 2026: The Convergence of Federal Derivatives Regulation, State Gaming Law, and Decentralized Tokenomics**
 
 ## **Introduction to the Information Finance Paradigm**

--- a/docs/research/research--psychology-behavior.md
+++ b/docs/research/research--psychology-behavior.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 <img src="https://r2cdn.perplexity.ai/pplx-full-logo-primary-dark%402x.png" style="height:64px;margin-right:32px"/>
 
 # Pillar 1: User Psychology \& Behavior

--- a/docs/research/research--smart-contracts-behavioral-wagers-v2.md
+++ b/docs/research/research--smart-contracts-behavioral-wagers-v2.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Architecture and Legal Classification of Milestone-Based Commitment Contracts
 
 ## Introduction

--- a/docs/research/research--smart-contracts-behavioral-wagers.md
+++ b/docs/research/research--smart-contracts-behavioral-wagers.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # **Architecture and Legal Classification of Milestone-Based Commitment Contracts**
 
 ## **Introduction**

--- a/docs/research/research--sop-gold-path.md
+++ b/docs/research/research--sop-gold-path.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # SOP: Styx Gold Path (Research to Implementation)
 
 > **Note:** This is a project-specific instance of the universal SOP at `meta-organvm/SOP--research-to-implementation-pipeline.md`. It is governed by the structural and philosophical standards in `meta-organvm/METADOC--research-standards.md`.

--- a/docs/research/research--sop-product-teardown.md
+++ b/docs/research/research--sop-product-teardown.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # SOP: Deep-Dive Product & Competitor Analysis
 
 > **Note:** This is a project-specific instance of the system-wide SOP at `meta-organvm/SOP--market-gap-analysis.md`. Customize the Reporting Template columns for your product.

--- a/docs/research/research--styx-alchemy-differentiation.md
+++ b/docs/research/research--styx-alchemy-differentiation.md
@@ -1,3 +1,10 @@
+---
+generated: true
+type: research
+provenance: ai-synthesis
+authoritative: false
+---
+
 # Research: Styx Alchemy & Differentiation
 
 **Status:** Completed | **Version:** 2.0.0 | **Date:** March 6, 2026


### PR DESCRIPTION
Flags the `docs/research/` corpus (AI-generated synthesis) as non-authoritative so it's not mistaken for spec. Prepends a minimal provenance block to the **40** docs that lacked frontmatter:

```yaml
generated: true
type: research
provenance: ai-synthesis
authoritative: false
```

Additive, docs-only; no content changed. Schema is intentionally minimal — easy to extend if you prefer a richer convention. Closes #593.