### PR TITLE
docs(readme): point CI badge at the actual remote namespace (closes #600)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A peer-audited behavioral market that uses loss aversion (coefficient 1.955) to enforce habit follow-through via financial stakes.
 
-![CI](https://github.com/organvm-iii-ergon/peer-audited--behavioral-blockchain/actions/workflows/ci.yml/badge.svg)
+![CI](https://github.com/a-organvm/peer-audited--behavioral-blockchain/actions/workflows/ci.yml/badge.svg)
 ![Tests](https://img.shields.io/badge/tests-1%2C107-brightgreen)
 ![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)
 ![Node](https://img.shields.io/badge/node-%3E%3D20-339933)


### PR DESCRIPTION
The README CI badge pointed at `github.com/organvm-iii-ergon/...`, but the repo's git remote is `a-organvm/peer-audited--behavioral-blockchain` — where CI actually runs. The badge therefore rendered the wrong/missing repo's status. Repointed to `a-organvm` so it shows real CI status.

README:248's `organvm-iii-ergon.github.io` org-pages link is canonical and left unchanged. One-line, docs-only. Closes #600.