### PR TITLE
docs: cross-link adr/ and architecture/ via index READMEs (closes #595)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,11 @@
+# Architecture Decision Records (ADRs)
+
+Records of significant architecture decisions for Styx — each captures the **context**, **decision**, and **consequences** of one choice. For the broader technical-feasibility analyses and specs these decisions sit within, see [`docs/architecture/`](../architecture/).
+
+| ADR | Decision | Related architecture / spec |
+|-----|----------|------------------------------|
+| [ADR-001](adr--001-dual-layer-services-modules.md) | Dual-Layer Architecture (Services / Modules) | [Technical Architecture & Feasibility](../architecture/architecture--technical-feasibility.md) |
+| [ADR-002](adr--002-fbo-escrow-model.md) | FBO Escrow Model (Stripe For Benefit Of) | [Technical Architecture & Feasibility](../architecture/architecture--technical-feasibility.md) |
+| [ADR-003](adr--003-linguistic-cloaker.md) | Linguistic Cloaker (runtime vocabulary transformation) | — |
+| [ADR-004](adr--004-fury-consensus-engine.md) | Fury Consensus Engine (3-auditor anonymous routing) | [Spec: The Fury Router](../architecture/spec--fury-router.md) |
+| [ADR-005](adr--005-dual-rate-limiting.md) | Dual Rate Limiting (API throttle + edge limiting) | — |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,18 @@
+# Architecture & Technical Specs
+
+Technical-feasibility analyses, specs, and operational docs for Styx. For the *decisions* behind this architecture — and the reasoning — see the [Architecture Decision Records](../adr/) (`docs/adr/`).
+
+| Document | Purpose |
+|----------|---------|
+| [Technical Architecture & Feasibility](architecture--technical-feasibility.md) | Core technical architecture & feasibility |
+| [Feasibility Stack (Pillar 5)](architecture--feasibility-stack.md) | Technical-feasibility pillar |
+| [Truth-Blockchain Feasibility](architecture--truth-blockchain.md) · [v2](architecture--truth-blockchain-v2.md) | Truth-blockchain feasibility reports |
+| [Aegis / Tier Reconciliation](architecture--aegis-tier-reconciliation.md) | Aegis protocol & tier-system reconciliation |
+| [Alpha-to-Omega Plan](architecture--alpha-to-omega-plan.md) | Alpha→Omega roadmap (v3) |
+| [Spec: The Fury Router](spec--fury-router.md) | Fury Router spec — decision recorded in [ADR-004](../adr/adr--004-fury-consensus-engine.md) |
+| [Spec: Digital Exhaust Intake](spec--digital-exhaust-intake.md) | Digital-exhaust intake spec |
+| [Branching & Release Strategy](branching-and-release-strategy.md) | Branching / merge / release |
+| [Test Strategy](test-strategy.md) | Testing tiers, validation gates, CI |
+| [Load Test Report](load-test-report.md) | Load-test results |
+
+Decision records: [`docs/adr/`](../adr/) · Network map: [`network-map.yaml`](network-map.yaml).


### PR DESCRIPTION
`docs/architecture/` and `docs/adr/` were orphaned (no cross-references). Adds an index README to each dir that lists its contents and links the other, plus the topical link **ADR-004 (Fury Consensus) ↔ spec--fury-router**. Additive (two new files), no existing content changed. Closes #595.