### PR TITLE
docs: plan-file naming discipline — descriptive names over A/B/C (closes #601)

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -223,6 +223,7 @@ Expo-managed React Native app. `src/mobile/screens/`: Dashboard, Login, Register
 - **Files**: kebab-case; double-hyphen separates function from descriptor (`research--behavioral-economics.md`)
 - **TypeScript**: strict mode, named exports, async/await
 - **NestJS testing pattern**: `@Injectable()` classes with constructor DI; mock `Pool` or service via `as any` cast in tests (see any `*.spec.ts` in `src/api/src/modules/`)
+- **Plan files** (`docs/planning/`): use descriptive branch/sequence names (e.g. `market-activation`, `irf-propagation`), **not** generic letters (`A`/`B`/`C`) — letter labels force the reader to look up the mapping every time and don't survive context loss. Existing letter-labeled plans are grandfathered, each letter mapped to its phase name in the plan body. (See [#601](https://github.com/a-organvm/peer-audited--behavioral-blockchain/issues/601).)
 
 ## Companion Governance Files (root)
 

--- a/docs/planning/planning--styx-sequence-b-a-c--canonical-domain-standup--2026-05-17.md
+++ b/docs/planning/planning--styx-sequence-b-a-c--canonical-domain-standup--2026-05-17.md
@@ -2,6 +2,8 @@
 
 **Date:** 2026-05-17 | **Version:** 4 | **Predecessor:** v3 archived at `~/.claude/plans/archive/2026-05/` (slug `spicy-bubbling-treehouse.md`). v4 is the authoritative plan and supersedes v3 in response to the user's audit challenge ("eat off the floor — no bandaids, fundamental fixes").
 
+> **Naming note ([#601](https://github.com/a-organvm/peer-audited--behavioral-blockchain/issues/601)):** The `B / A / C` sequence labels here are **grandfathered**. Each maps to a descriptive phase, spelled out in the Phase sections below — **B** = market activation + URL standup · **A** = IRF propagation (validated) · **C** = audit-engine / technical extraction (demand-driven). Per the plan-file naming convention in [`docs/CLAUDE.md`](../CLAUDE.md#conventions), **new** plans use descriptive branch names, not generic letters.
+
 ## Context
 
 This plan resolves the standing A/B/C decision carried forward from `.conductor/active-handoff.md`. The underlying decision (sequence is B first, then A, then C; register `${CANONICAL_DOMAIN}` in Phase 1) was reached in v2/v3 and is preserved. v4 rebuilds the encoding at the value layer — references to dynamic values go through `.env.example` and other canonical authorities, not through inline hard-coded strings.


### PR DESCRIPTION
## What

Resolves #601 via its **issue-sanctioned option (b)** — add CLAUDE.md guidance prohibiting generic letter labels for plan branches — plus a grandfather note on the one existing letter-labeled plan.

## Changes (additive, no rename)

1. **`docs/CLAUDE.md`** — new **Plan files** convention under `## Conventions`: descriptive branch/sequence names (e.g. `market-activation`), not generic letters (`A`/`B`/`C`). Existing letter-labeled plans grandfathered.
2. **`planning--styx-sequence-b-a-c--…2026-05-17.md`** — grandfather note at the top mapping each label to its phase.

## Verified mapping (not the issue's)

I checked the plan body before writing the note — the issue's mapping had **A** and **B** swapped. Authoritative (from the Phase sections):

| Label | Phase |
|-------|-------|
| **B** | market activation + URL standup (Phase 1) |
| **A** | IRF propagation, validated (Phase 2) |
| **C** | audit-engine / technical extraction (Phase 3) |

## Why option (b), not (a) rename

Renaming the plan file would mutate a landed plan artifact (against the plans-are-additive rule) and break references (memory, INDEX, this issue). Option (b) + a grandfather note meets the acceptance criteria — *"new plans use descriptive names; existing grandfathered with a deprecation note"* — with zero ref-breakage. Gate 07 (claim-drift) stays green (no paths changed).

Closes #601.