### PR TITLE
docs: fix AGENTS.md CI test command — drop build-breaking --coverage --ci (closes #596)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ npm run format                          # Prettier: **/*.{ts,tsx,md}
 ### CI Pipeline Order (`.github/workflows/ci.yml`)
 
 1. `npm ci` + `npm audit --audit-level=high`
-2. `turbo run test -- --coverage --ci`
+2. `turbo run test` — **no** `--coverage --ci`: those are jest-only flags that make the Vitest workspaces (`ask-styx`, `test-harness`) throw `CACError: Unknown option --ci` and break API suite-loading (ci.yml carries an explicit NOTE; coverage gating is a tracked follow-up)
 3. `turbo run build`
 4. `turbo run lint`
 5. Gate 04: redacted build check (no gambling vocabulary in production build)


### PR DESCRIPTION
## What

#596 recorded an AGENTS.md developer-guidance rewrite (commit `85d1ded`). The guidance landed and is otherwise accurate — but one line was actively harmful, so the doc wasn't truly *verified*.

## The fix (one line)

`AGENTS.md` step 2 of the CI pipeline said:

```
2. `turbo run test -- --coverage --ci`
```

But `ci.yml` carries an explicit NOTE **against** those flags and runs bare `npx turbo run test`:

> do not forward `--coverage --ci` here. Those are jest-only flags: `--ci` makes the vitest workspaces (ask-styx, test-harness) throw `CACError: Unknown option --ci`, and `--coverage` currently fails api…

So the doc told developers to run the exact command the pipeline warns breaks the build. Corrected to bare `turbo run test`, matching ci.yml (same drift class as #621's test-strategy fix; #596's rewrite predated the 2026-05-26 ci.yml fix).

## Verified

Cross-checked **all 12** CI steps in AGENTS.md against `ci.yml` — step 2 was the only inaccuracy; steps 1, 3–12 (audit → build → lint → gates 04–07 → beta → terraform → e2e → CodeQL) all match. Edit is outside the `ORGANVM:AUTO` markers (hand-editable region — auto block untouched).

Closes #596.