### PR TITLE
docs: reconcile Fury consensus claims to ADR-004 (2-of-3 of 3 auditors) — addresses #592

### DIFF
--- a/docs/FEATURE-BACKLOG.md
+++ b/docs/FEATURE-BACKLOG.md
@@ -383,7 +383,7 @@ Advanced features requiring external dependencies or significant R&D: EVM smart 
 - **Priority**: P0
 - **Source**: `architecture--feasibility-stack.md` §S4.3, `planning--roadmap.md` §Gamma (checked)
 - **Existing Code**: `src/api/services/fury-router/fury-router.service.ts`, `src/api/services/fury-router/fury-router.worker.ts`, `src/api/src/modules/fury/`
-- **Spec**: Anonymized BullMQ distribution to 3 random Furies. Double-anonymized: author hidden from reviewers, reviewers hidden from each other. Consensus: 3/3 pass → user passes; 3/3 fail → stake liquidated; split → Judge escalation. All identifying metadata stripped via FFmpeg.
+- **Spec**: Anonymized BullMQ distribution to 3 random Furies. Double-anonymized: author hidden from reviewers, reviewers hidden from each other. Consensus (per ADR-004): 2-of-3 or 3-of-3 pass → user passes; 2-of-3 or 3-of-3 fail → stake liquidated; 3-way split → Judge escalation. All identifying metadata stripped via FFmpeg.
 - **Dependencies**: Redis, BullMQ, F-INFRA-03
 
 #### F-FURY-02: Fury Accuracy Score & Demotion
@@ -433,7 +433,7 @@ Advanced features requiring external dependencies or significant R&D: EVM smart 
 - **Priority**: P0
 - **Source**: `architecture--feasibility-stack.md` §S4.3
 - **Existing Code**: `src/api/src/modules/fury/consensus.engine.ts`, `src/api/src/modules/fury/consensus.engine.spec.ts`
-- **Spec**: Aggregates verdicts from 3 Furies. 3/3 pass → user passes. 3/3 fail → liquidation (house 15%, Furies 85%). Split → Judge escalation.
+- **Spec**: Aggregates verdicts from 3 Furies (per ADR-004). 2-of-3 or 3-of-3 pass → user passes. 2-of-3 or 3-of-3 fail → liquidation (house 15%, Furies 85%). 3-way split → Judge escalation.
 - **Dependencies**: F-FURY-01
 
 #### F-FURY-07: Master Fury Career Path / Economy

--- a/docs/architecture/test-strategy.md
+++ b/docs/architecture/test-strategy.md
@@ -196,7 +196,7 @@ Additional CI workflows:
 ## 7. Testing Principles
 
 1. **Financial correctness over speed.** Every test involving money must assert ledger balance invariants. A fast test that misses a penny is worse than a slow test that catches it.
-2. **Fury consensus is non-negotiable.** No test may bypass the 3-of-5 quorum requirement. If a test needs a quick pass, it must simulate 3 agreeing auditors.
+2. **Fury consensus is non-negotiable.** No test may bypass the consensus rule: **3 assigned auditors, 2-of-3 or 3-of-3 agreement** (per [ADR-004](../adr/adr--004-fury-consensus-engine.md) — a 3-way split escalates to the senior pool; there is no $1000 threshold). If a test needs a quick pass, it must simulate 2 of 3 agreeing auditors.
 3. **Aegis is a safety system.** Tests for biological oaths must always verify BMI floor and velocity cap enforcement. Skipping Aegis checks in tests is a blocking code review finding.
 4. **Recovery contracts are sensitive.** Tests involving no-contact targets must verify guardrails (max 30 days, max 3 targets, cooldown enforcement).
 5. **The linguistic cloaker is testable.** Verify that user-facing strings use the approved vocabulary (vault, not bet; oath, not wager) in all test assertions.

--- a/docs/planning/feature-matrix.md
+++ b/docs/planning/feature-matrix.md
@@ -95,7 +95,7 @@ Comprehensive feature inventory for Styx with implementation status, phase gatin
 |---------|--------|-------|----------|-------|
 | Fury application and vetting | Built | Beta | P0 | Minimum integrity score threshold |
 | Auditor stake ($2 per assignment) | Built | Beta | P0 | |
-| 3-of-5 quorum consensus | Built | Beta | P0 | Gate 03 validates |
+| 2-of-3 consensus (3 auditors, per ADR-004) | Built | Beta | P0 | Gate 03 validates |
 | Round-robin assignment | Built | Beta | P0 | Gate 08 validates fairness |
 | Conflict-of-interest detection | Built | Beta | P0 | Social graph + geographic |
 | Vote casting (PASS/FAIL/NEEDS_MORE_INFO) | Built | Beta | P0 | |

--- a/docs/planning/planning--alpha-omega-completion-matrix.md
+++ b/docs/planning/planning--alpha-omega-completion-matrix.md
@@ -57,7 +57,7 @@ For the Phase 1 Beta (Test-Money Pilot, iOS, No-Contact Recovery, US-only), the 
 | :--- | :--- | :--- | :--- | :--- |
 | `F-FURY-01` | Fury Router (BullMQ) | `IMPLEMENTED` | **[BETA-BLOCKER]** | Anonymized distribution to 3 reviewers. |
 | `F-FURY-02` | Fury Accuracy & Demotion | `IMPLEMENTED` | **[BETA-BLOCKER]** | Burn-in logic (10 audits) and 80% threshold verified. |
-| `F-FURY-06` | Consensus Engine | `IMPLEMENTED` | **[BETA-BLOCKER]** | 3/3 pass/fail logic + Judge escalation. |
+| `F-FURY-06` | Consensus Engine | `IMPLEMENTED` | **[BETA-BLOCKER]** | 2-of-3-or-3/3 pass/fail logic (per ADR-004) + Judge escalation. |
 | `F-FURY-05` | Honeypot Injection | `IMPLEMENTED` | **[BETA-BLOCKER]** | Anti-cheat for reviewers. Tests Fury vigilance. |
 | `F-SOCIAL-02`| Whistleblower Bounty Links | `IMPLEMENTED` | **[BETA-BLOCKER]** | The Ex-Bounty. Asymmetric information gathering. |
 | `F-VERIFY-01`| pHash Duplicate Detection | `IMPLEMENTED` | `[BETA-ENHANCER]` | Blocks re-upload of identical proof media. |


### PR DESCRIPTION
## What

The Fury consensus rule is specified inconsistently across the corpus (#592). I traced it to the authority: **ADR-004 (Accepted)** decides **3 assigned auditors, 2-of-3 or 3-of-3 agreement** (3-way split → senior pool; **no** \$1000 threshold), and the **code matches** — `src/shared/fury-logic/consensus.resolver.ts` resolves an integrity-weighted majority (`breach >0.66 → BREACH`), which is 2/3-or-3/3 for 3 equal-weight auditors. So the **code is correct**; the stale docs are the problem.

## Fixed — stale as-built / test claims → ADR-004

| File | Was | Now |
|------|-----|-----|
| `docs/architecture/test-strategy.md` §7.2 | "3-of-5 quorum … simulate 3 agreeing" | 2-of-3 of 3 (per ADR-004) — *the issue's #1 risk: wrong test invariant* |
| `docs/planning/feature-matrix.md` | "3-of-5 quorum consensus \| Built" | "2-of-3 (3 auditors)" |
| `docs/planning/planning--alpha-omega-completion-matrix.md` | "3/3 pass/fail logic" | "2-of-3-or-3/3" |
| `docs/FEATURE-BACKLOG.md` (×2) | "3/3 pass / 3/3 fail" | "2-of-3 or 3-of-3" |

## Deliberately NOT changed — surfaced for your call (no unilateral product rewrite)

- **PRD / ux-audit "3-of-5"** — this is **product vision**, not as-built drift. ADR-004 *Alternative #2* explicitly **defers the 5-auditor panel to post-beta** ("3 is sufficient for micro-stakes"). So beta=3, post-beta=5 is a coherent reading — but the docs don't say which horizon. **Decision needed:** is 5-auditor still the vision, or abandoned? I'll reconcile the PRD/ux-audit once you confirm.
- **`docs/specs/spec--fury-router.md`** (Status: **Draft**) — describes 1 primary auditor + 2-of-3 only for >\$1000. Superseded by ADR-004; it's a forward-design draft (now in `docs/specs/`), so I left it but it should be reconciled or marked.
- **⚠️ Possible code bug** — `consensus.resolver.ts` thresholds are **asymmetric**: `breach >0.66 → BREACH` but `breach <0.33 → CLEAN`. A 2-of-3 **CLEAN** majority computes `0.333`, which is *not* `< 0.33`, so it returns **UNCERTAIN**, not CLEAN — i.e., 2/3-breach is accepted but 2/3-clean escalates. Diverges from ADR-004's symmetric "2/3 → accepted". Intentional conservatism or a bug? Needs your intent.
- ADR-004 step 1 (extract the threshold into a shared constant) — optional refactor, left as follow-up.

**Addresses #592** — left open for the product-vision reconciliation (5-auditor horizon) + the code asymmetry decision.