### PR TITLE
docs: as-built note on draft spec--fury-router → ADR-004 (#592)

### DIFF
--- a/docs/specs/spec--fury-router.md
+++ b/docs/specs/spec--fury-router.md
@@ -7,6 +7,8 @@
 
 ---
 
+> **As-built note ([ADR-004](../adr/adr--004-fury-consensus-engine.md)):** This is a **Draft** forward-spec. The **accepted, as-built** consensus rule is ADR-004's: **3 auditors assigned to every proof, with 2-of-3 or 3-of-3 agreement** (a 3-way split escalates to the senior pool; there is **no** $1000 threshold). The "1 primary auditor" (§4.3) and "2-of-3 only for $1000+ contracts" (§4.5, FR-5) described below are an earlier draft design that ADR-004 superseded.
+
 ## 1. Objective
 To build a decentralized, anonymous, and financially incentivized audit distribution engine. The Fury Router assigns "Truth Claims" to peer auditors who earn bounties for validating breaches.
 


### PR DESCRIPTION
Completes #592's named-source reconciliation. `docs/specs/spec--fury-router.md` is a **Draft** forward-spec whose "1 primary auditor" (§4.3) + "2-of-3 only for $1000+ contracts" (§4.5, FR-5) design contradicts the accepted **ADR-004** (3 auditors always, 2-of-3-or-3/3, no $1000 threshold).

Rather than rewrite a forward-design draft, this adds a top-of-file **as-built note** pointing readers to ADR-004 as the authoritative current rule.

With #629 (test-strategy / feature-matrix / completion-matrix / FEATURE-BACKLOG), **all three sources #592 named are now reconciled** to ADR-004. #592 stays open only for the two items that need your intent (both surfaced on the issue): the **5-auditor post-beta** product-vision call, and the **consensus.resolver.ts asymmetry** (2/3-clean → UNCERTAIN).

Addresses #592.