### PR TITLE
fix(deps): bump lucide-react ^0.284.0 -> ^0.468.0 for react@19 compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2393,7 +2393,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2410,7 +2409,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2427,7 +2425,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2444,7 +2441,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2461,7 +2457,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2478,7 +2473,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2495,7 +2489,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2512,7 +2505,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2529,7 +2521,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2546,7 +2537,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2563,7 +2553,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2580,7 +2569,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2597,7 +2585,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2614,7 +2601,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2631,7 +2617,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2648,7 +2633,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2665,7 +2649,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2682,7 +2665,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2699,7 +2681,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2716,7 +2697,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2733,7 +2713,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2750,7 +2729,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2767,7 +2745,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2784,7 +2761,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2801,7 +2777,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2818,7 +2793,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15077,12 +15051,12 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.284.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.284.0.tgz",
-      "integrity": "sha512-dVSMHYAya/TeY3+vsk+VQJEKNQN2AhIo0+Dp09B2qpzvcBuu93H98YZykFcjIAfmanFiDd8nqfXFR38L757cyQ==",
+      "version": "0.468.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz",
+      "integrity": "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==",
       "license": "ISC",
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/luxon": {
@@ -17958,16 +17932,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/react-refresh": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
-      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -20281,7 +20245,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -22129,7 +22092,7 @@
       "name": "@styx/desktop",
       "version": "0.0.1",
       "dependencies": {
-        "lucide-react": "^0.284.0",
+        "lucide-react": "^0.468.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -23716,15 +23679,6 @@
         "vite": "^6.0.7"
       }
     },
-    "src/pitch/node_modules/lucide-react": {
-      "version": "0.468.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz",
-      "integrity": "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
-      }
-    },
     "src/shared": {
       "name": "@styx/shared",
       "version": "0.0.1",
@@ -23758,7 +23712,7 @@
       "name": "@styx/web",
       "version": "0.0.1",
       "dependencies": {
-        "lucide-react": "^0.284.0",
+        "lucide-react": "^0.468.0",
         "next": "16.2.6",
         "omggif": "^1.0.10",
         "openai": "^4.80.0",

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "lucide-react": "^0.284.0"
+    "lucide-react": "^0.468.0"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.0.0-beta",

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "lucide-react": "^0.284.0",
+    "lucide-react": "^0.468.0",
     "next": "16.2.6",
     "omggif": "^1.0.10",
     "p5": "2.2.1",


### PR DESCRIPTION
## Problem
npm install fails on main — lucide-react@0.284.0 needs react@18 as peer, expo/mobile pulls react@19 → ERESOLVE.

## Fix
Bump lucide-react from `^0.284.0` to `^0.468.0` in `src/web` and `src/desktop` (matching `src/pitch`). Newer lucide-react peer-dep accepts `^16 || ^17 || ^18 || ^19`.

Closes #632 (root cause). Required before rebasing #632.