### PR TITLE
feat(api): crisis escalation endpoint + event listing (Issue #413)

### DIFF
--- a/src/api/database/migrations/031_crisis_events.sql
+++ b/src/api/database/migrations/031_crisis_events.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS crisis_events (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID NOT NULL REFERENCES accounts(id),
+    user_id UUID NOT NULL REFERENCES users(id),
     trigger TEXT NOT NULL,
     severity VARCHAR(50) NOT NULL DEFAULT 'HIGH',
     matched_keywords JSONB,

--- a/src/api/database/migrations/032_crisis_events_fix.sql
+++ b/src/api/database/migrations/032_crisis_events_fix.sql
@@ -1,0 +1,3 @@
+ALTER TABLE crisis_events DROP CONSTRAINT crisis_events_user_id_fkey;
+ALTER TABLE crisis_events ADD CONSTRAINT crisis_events_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id);
+CREATE INDEX IF NOT EXISTS idx_crisis_events_created_at ON crisis_events(created_at DESC);

--- a/src/api/services/security/crisis-intervention.service.ts
+++ b/src/api/services/security/crisis-intervention.service.ts
@@ -1,10 +1,10 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { Pool } from 'pg';
-import { CrisisDetectionResult } from './crisis-detection.service';
+import { Injectable, Logger } from "@nestjs/common";
+import { Pool } from "pg";
+import { CrisisDetectionResult } from "./crisis-detection.service";
 
 /**
  * CrisisInterventionService
- * 
+ *
  * Provides immediate safety resources and logging for high-stress behavioral events.
  * Part of the Aegis Protocol's ethical guardrails.
  */
@@ -24,26 +24,40 @@ export class CrisisInterventionService {
   /**
    * Logs a crisis event and returns support resources.
    */
-  async reportCrisis(userId: string, trigger: string, detection?: CrisisDetectionResult) {
+  async reportCrisis(
+    userId: string,
+    trigger: string,
+    detection?: CrisisDetectionResult,
+  ) {
     this.logger.warn(`CRISIS EVENT detected for user ${userId}: ${trigger}`);
 
-    const severity = detection ? detection.severity : 'HIGH';
-    const matchedKeywords = detection ? JSON.stringify(detection.matchedKeywords) : '[]';
-    const escalated = severity === 'CRITICAL';
+    const severity = detection ? detection.severity : "HIGH";
+    const matchedKeywords = detection
+      ? JSON.stringify(detection.matchedKeywords)
+      : "[]";
+    const escalated = severity === "CRITICAL";
 
     await this.pool.query(
       `INSERT INTO crisis_events (user_id, trigger, severity, matched_keywords, escalated) VALUES ($1, $2, $3, $4, $5)`,
-      [userId, trigger, severity, matchedKeywords, escalated]
+      [userId, trigger, severity, matchedKeywords, escalated],
     );
 
     return {
       message: "We've logged your distress signal. You are not alone.",
       resources: [
-        { name: "Crisis Text Line", contact: "741741", instructions: "Text HOME to 741741" },
-        { name: "National Suicide Prevention Lifeline", contact: "988", instructions: "Call or text 988" }
+        {
+          name: "Crisis Text Line",
+          contact: "741741",
+          instructions: "Text HOME to 741741",
+        },
+        {
+          name: "National Suicide Prevention Lifeline",
+          contact: "988",
+          instructions: "Call or text 988",
+        },
       ],
-      actionTaken: "An automated cooldown period has been applied to your account.",
-      escalated
+      actionTaken: "The incident has been recorded and is being reviewed.",
+      escalated,
     };
   }
 }

--- a/src/api/src/modules/admin/admin.controller.spec.ts
+++ b/src/api/src/modules/admin/admin.controller.spec.ts
@@ -1,12 +1,14 @@
-import { AdminController } from './admin.controller';
-import { ModerationService } from '../../../services/security/moderation.service';
-import { HoneypotService } from '../../../services/intelligence/honeypot.service';
-import { AnomalyService } from '../../../services/anomaly/anomaly.service';
-import { ContractsService } from '../contracts/contracts.service';
-import { Pool } from 'pg';
-import { IdentityVerificationService } from '../compliance/identity-verification.service';
+import { AdminController } from "./admin.controller";
+import { ModerationService } from "../../../services/security/moderation.service";
+import { CrisisDetectionService } from "../../../services/security/crisis-detection.service";
+import { CrisisInterventionService } from "../../../services/security/crisis-intervention.service";
+import { HoneypotService } from "../../../services/intelligence/honeypot.service";
+import { AnomalyService } from "../../../services/anomaly/anomaly.service";
+import { ContractsService } from "../contracts/contracts.service";
+import { Pool } from "pg";
+import { IdentityVerificationService } from "../compliance/identity-verification.service";
 
-describe('AdminController', () => {
+describe("AdminController", () => {
   let controller: AdminController;
   let mockPool: { query: jest.Mock };
   let mockAnomaly: { computePHash: jest.Mock; hammingDistance: jest.Mock };
@@ -15,6 +17,14 @@ describe('AdminController', () => {
   const mockModeration = {
     banUser: jest.fn(),
   } as unknown as ModerationService;
+
+  const mockCrisisDetection = {
+    analyzeContent: jest.fn(),
+  } as unknown as CrisisDetectionService;
+
+  const mockCrisisIntervention = {
+    reportCrisis: jest.fn(),
+  } as unknown as CrisisInterventionService;
 
   const mockHoneypot = {
     injectHoneypot: jest.fn(),
@@ -31,15 +41,17 @@ describe('AdminController', () => {
   beforeEach(() => {
     mockPool = { query: jest.fn() };
     mockAnomaly = {
-      computePHash: jest.fn().mockReturnValue('0000000000000000'),
+      computePHash: jest.fn().mockReturnValue("0000000000000000"),
       hammingDistance: jest.fn().mockReturnValue(10),
     };
     mockTruthLog = {
       verifyChain: jest.fn(),
-      appendEvent: jest.fn().mockResolvedValue('evt-hash'),
+      appendEvent: jest.fn().mockResolvedValue("evt-hash"),
     };
     controller = new AdminController(
       mockModeration,
+      mockCrisisDetection,
+      mockCrisisIntervention,
       mockHoneypot as any,
       mockContracts,
       {} as any,
@@ -52,134 +64,160 @@ describe('AdminController', () => {
     jest.clearAllMocks();
   });
 
-  describe('injectHoneypot', () => {
-    it('should delegate to HoneypotService and return status', async () => {
-      (mockHoneypot.injectHoneypot as jest.Mock).mockResolvedValueOnce(undefined);
+  describe("injectHoneypot", () => {
+    it("should delegate to HoneypotService and return status", async () => {
+      (mockHoneypot.injectHoneypot as jest.Mock).mockResolvedValueOnce(
+        undefined,
+      );
 
       const result = await controller.injectHoneypot();
 
-      expect(result).toEqual({ status: 'honeypot_injected' });
+      expect(result).toEqual({ status: "honeypot_injected" });
       expect(mockHoneypot.injectHoneypot).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe('banUser', () => {
-    it('should delegate to ModerationService with correct params', async () => {
+  describe("banUser", () => {
+    it("should delegate to ModerationService with correct params", async () => {
       (mockModeration.banUser as jest.Mock).mockResolvedValueOnce({
-        status: 'USER_PERMANENTLY_BANNED',
-        eventId: 'evt-1',
+        status: "USER_PERMANENTLY_BANNED",
+        eventId: "evt-1",
       });
 
       const result = await controller.banUser(
-        'target-user-1',
-        { id: 'ADMIN_root' },
-        { reason: 'Repeated fraud violations' },
+        "target-user-1",
+        { id: "ADMIN_root" },
+        { reason: "Repeated fraud violations" },
       );
 
       expect(result).toEqual({
-        status: 'USER_PERMANENTLY_BANNED',
-        eventId: 'evt-1',
+        status: "USER_PERMANENTLY_BANNED",
+        eventId: "evt-1",
       });
       expect(mockModeration.banUser).toHaveBeenCalledWith(
-        'ADMIN_root',
-        'target-user-1',
-        'Repeated fraud violations',
+        "ADMIN_root",
+        "target-user-1",
+        "Repeated fraud violations",
       );
       // AU11: privileged action is recorded in the tamper-evident audit log.
       expect(mockTruthLog.appendEvent).toHaveBeenCalledWith(
-        'ADMIN_USER_BANNED',
-        expect.objectContaining({ adminId: 'ADMIN_root', targetUserId: 'target-user-1' }),
+        "ADMIN_USER_BANNED",
+        expect.objectContaining({
+          adminId: "ADMIN_root",
+          targetUserId: "target-user-1",
+        }),
       );
     });
 
-    it('AU11: should reject an admin banning their own account (self-target guard)', async () => {
+    it("AU11: should reject an admin banning their own account (self-target guard)", async () => {
       await expect(
-        controller.banUser('ADMIN_root', { id: 'ADMIN_root' }, { reason: 'oops' }),
+        controller.banUser(
+          "ADMIN_root",
+          { id: "ADMIN_root" },
+          { reason: "oops" },
+        ),
       ).rejects.toThrow(/own account/);
       expect(mockModeration.banUser).not.toHaveBeenCalled();
       expect(mockTruthLog.appendEvent).not.toHaveBeenCalled();
     });
 
-    it('should propagate ForbiddenException from ModerationService for non-admin', async () => {
+    it("should propagate ForbiddenException from ModerationService for non-admin", async () => {
       (mockModeration.banUser as jest.Mock).mockRejectedValueOnce(
-        new Error('User non-admin lacks the required ADMIN role'),
+        new Error("User non-admin lacks the required ADMIN role"),
       );
 
       await expect(
         controller.banUser(
-          'target-user-1',
-          { id: 'non-admin' },
-          { reason: 'test' },
+          "target-user-1",
+          { id: "non-admin" },
+          { reason: "test" },
         ),
       ).rejects.toThrow(/ADMIN role/);
     });
   });
 
-  describe('resolveContract', () => {
-    it('should delegate to ContractsService and return result', async () => {
-      (mockContracts.resolveContract as jest.Mock).mockResolvedValueOnce(undefined);
-
-      const result = await controller.resolveContract(
-        'contract-1',
-        { id: 'ADMIN_root' },
-        { outcome: 'COMPLETED' },
+  describe("resolveContract", () => {
+    it("should delegate to ContractsService and return result", async () => {
+      (mockContracts.resolveContract as jest.Mock).mockResolvedValueOnce(
+        undefined,
       );
 
-      expect(result).toEqual({ status: 'resolved', contractId: 'contract-1', outcome: 'COMPLETED' });
-      expect(mockContracts.resolveContract).toHaveBeenCalledWith('contract-1', 'COMPLETED');
+      const result = await controller.resolveContract(
+        "contract-1",
+        { id: "ADMIN_root" },
+        { outcome: "COMPLETED" },
+      );
+
+      expect(result).toEqual({
+        status: "resolved",
+        contractId: "contract-1",
+        outcome: "COMPLETED",
+      });
+      expect(mockContracts.resolveContract).toHaveBeenCalledWith(
+        "contract-1",
+        "COMPLETED",
+      );
       // AU11: admin override of a money-bearing resolution is audited.
       expect(mockTruthLog.appendEvent).toHaveBeenCalledWith(
-        'ADMIN_CONTRACT_RESOLVED',
-        expect.objectContaining({ adminId: 'ADMIN_root', contractId: 'contract-1', outcome: 'COMPLETED' }),
+        "ADMIN_CONTRACT_RESOLVED",
+        expect.objectContaining({
+          adminId: "ADMIN_root",
+          contractId: "contract-1",
+          outcome: "COMPLETED",
+        }),
       );
     });
   });
 
-  describe('adjustIntegrity', () => {
-    it('AU11: should adjust score and write an audit entry', async () => {
+  describe("adjustIntegrity", () => {
+    it("AU11: should adjust score and write an audit entry", async () => {
       mockPool.query.mockResolvedValueOnce({ rows: [{ integrity_score: 55 }] });
 
       const result = await controller.adjustIntegrity(
-        'target-user-1',
-        { id: 'ADMIN_root' },
-        { delta: 5, reason: 'manual correction' },
+        "target-user-1",
+        { id: "ADMIN_root" },
+        { delta: 5, reason: "manual correction" },
       );
 
       expect(result).toEqual({
-        status: 'integrity_adjusted',
-        userId: 'target-user-1',
+        status: "integrity_adjusted",
+        userId: "target-user-1",
         delta: 5,
-        reason: 'manual correction',
+        reason: "manual correction",
       });
       expect(mockTruthLog.appendEvent).toHaveBeenCalledWith(
-        'ADMIN_INTEGRITY_ADJUSTED',
+        "ADMIN_INTEGRITY_ADJUSTED",
         expect.objectContaining({
-          adminId: 'ADMIN_root',
-          targetUserId: 'target-user-1',
+          adminId: "ADMIN_root",
+          targetUserId: "target-user-1",
           delta: 5,
-          reason: 'manual correction',
+          reason: "manual correction",
           newScore: 55,
         }),
       );
     });
 
-    it('AU11: should reject an admin adjusting their own integrity score', async () => {
+    it("AU11: should reject an admin adjusting their own integrity score", async () => {
       await expect(
-        controller.adjustIntegrity('ADMIN_root', { id: 'ADMIN_root' }, { delta: 50, reason: 'self' }),
+        controller.adjustIntegrity(
+          "ADMIN_root",
+          { id: "ADMIN_root" },
+          { delta: 50, reason: "self" },
+        ),
       ).rejects.toThrow(/own integrity score/);
       expect(mockPool.query).not.toHaveBeenCalled();
       expect(mockTruthLog.appendEvent).not.toHaveBeenCalled();
     });
   });
 
-  describe('getStats', () => {
-    it('should return system statistics', async () => {
+  describe("getStats", () => {
+    it("should return system statistics", async () => {
       mockPool.query
-        .mockResolvedValueOnce({ rows: [{ count: '42' }] })
-        .mockResolvedValueOnce({ rows: [{ count: '10' }] })
-        .mockResolvedValueOnce({ rows: [{ count: '5' }] })
-        .mockResolvedValueOnce({ rows: [{ avg: '67.5' }] })
-        .mockResolvedValueOnce({ rows: [{ count: '3' }] });
+        .mockResolvedValueOnce({ rows: [{ count: "42" }] })
+        .mockResolvedValueOnce({ rows: [{ count: "10" }] })
+        .mockResolvedValueOnce({ rows: [{ count: "5" }] })
+        .mockResolvedValueOnce({ rows: [{ avg: "67.5" }] })
+        .mockResolvedValueOnce({ rows: [{ count: "3" }] });
 
       const result = await controller.getStats();
 
@@ -193,37 +231,60 @@ describe('AdminController', () => {
     });
   });
 
-  describe('completeIdentityVerificationForUser', () => {
-    it('should delegate to IdentityVerificationService mock completion', async () => {
-      (mockIdentityVerification.completeMockVerification as jest.Mock).mockResolvedValueOnce({
-        userId: 'user-1',
-        kycStatus: 'VERIFIED',
-        ageVerificationStatus: 'VERIFIED',
+  describe("completeIdentityVerificationForUser", () => {
+    it("should delegate to IdentityVerificationService mock completion", async () => {
+      (
+        mockIdentityVerification.completeMockVerification as jest.Mock
+      ).mockResolvedValueOnce({
+        userId: "user-1",
+        kycStatus: "VERIFIED",
+        ageVerificationStatus: "VERIFIED",
       });
 
-      const result = await controller.completeIdentityVerificationForUser('user-1', {
-        mode: 'KYC_AND_AGE',
-        status: 'VERIFIED',
-      });
+      const result = await controller.completeIdentityVerificationForUser(
+        "user-1",
+        {
+          mode: "KYC_AND_AGE",
+          status: "VERIFIED",
+        },
+      );
 
-      expect(result).toEqual(expect.objectContaining({ userId: 'user-1', kycStatus: 'VERIFIED' }));
-      expect(mockIdentityVerification.completeMockVerification).toHaveBeenCalledWith({
-        userId: 'user-1',
-        mode: 'KYC_AND_AGE',
-        status: 'VERIFIED',
+      expect(result).toEqual(
+        expect.objectContaining({ userId: "user-1", kycStatus: "VERIFIED" }),
+      );
+      expect(
+        mockIdentityVerification.completeMockVerification,
+      ).toHaveBeenCalledWith({
+        userId: "user-1",
+        mode: "KYC_AND_AGE",
+        status: "VERIFIED",
       });
     });
   });
 
-  describe('scanHashCollisions', () => {
-    it('should return empty collisions when no proofs have close hashes', async () => {
+  describe("scanHashCollisions", () => {
+    it("should return empty collisions when no proofs have close hashes", async () => {
       mockPool.query.mockResolvedValueOnce({
         rows: [
-          { id: 'p1', user_id: 'u1', contract_id: 'c1', media_uri: 'file://a.mp4', submitted_at: '2026-01-01' },
-          { id: 'p2', user_id: 'u2', contract_id: 'c2', media_uri: 'file://b.mp4', submitted_at: '2026-01-02' },
+          {
+            id: "p1",
+            user_id: "u1",
+            contract_id: "c1",
+            media_uri: "file://a.mp4",
+            submitted_at: "2026-01-01",
+          },
+          {
+            id: "p2",
+            user_id: "u2",
+            contract_id: "c2",
+            media_uri: "file://b.mp4",
+            submitted_at: "2026-01-02",
+          },
         ],
       });
-      mockAnomaly.computePHash.mockReturnValueOnce('aaaa').mockReturnValueOnce('bbbb');
+      mockAnomaly.computePHash
+        .mockReturnValueOnce("aaaa")
+        .mockReturnValueOnce("bbbb");
       mockAnomaly.hammingDistance.mockReturnValueOnce(30);
 
       const result = await controller.scanHashCollisions();
@@ -231,36 +292,67 @@ describe('AdminController', () => {
       expect(result.collisions).toHaveLength(0);
     });
 
-    it('should detect collisions when hashes are within threshold', async () => {
+    it("should detect collisions when hashes are within threshold", async () => {
       mockPool.query.mockResolvedValueOnce({
         rows: [
-          { id: 'p1', user_id: 'u1', contract_id: 'c1', media_uri: 'file://a.mp4', submitted_at: '2026-01-01' },
-          { id: 'p2', user_id: 'u2', contract_id: 'c2', media_uri: 'file://a-copy.mp4', submitted_at: '2026-01-02' },
+          {
+            id: "p1",
+            user_id: "u1",
+            contract_id: "c1",
+            media_uri: "file://a.mp4",
+            submitted_at: "2026-01-01",
+          },
+          {
+            id: "p2",
+            user_id: "u2",
+            contract_id: "c2",
+            media_uri: "file://a-copy.mp4",
+            submitted_at: "2026-01-02",
+          },
         ],
       });
-      mockAnomaly.computePHash.mockReturnValueOnce('aaaa').mockReturnValueOnce('aaaa');
+      mockAnomaly.computePHash
+        .mockReturnValueOnce("aaaa")
+        .mockReturnValueOnce("aaaa");
       mockAnomaly.hammingDistance.mockReturnValueOnce(0);
 
       const result = await controller.scanHashCollisions();
 
       expect(result.collisions).toHaveLength(1);
-      expect(result.collisions[0].origin.id).toBe('p1');
-      expect(result.collisions[0].duplicate.id).toBe('p2');
+      expect(result.collisions[0].origin.id).toBe("p1");
+      expect(result.collisions[0].duplicate.id).toBe("p2");
       // PRV15: distance 0 == identical URI → reported as an exact-match collision,
       // not a fabricated similarity percentage.
-      expect(result.collisions[0].matchType).toBe('EXACT_URI');
+      expect(result.collisions[0].matchType).toBe("EXACT_URI");
       expect((result.collisions[0].origin as any).similarity).toBeUndefined();
     });
   });
 
-  describe('getReconciliationVisibility', () => {
-    it('should return reconciliation contracts, dispute side effects, and summary', async () => {
+  describe("getReconciliationVisibility", () => {
+    it("should return reconciliation contracts, dispute side effects, and summary", async () => {
       mockPool.query
-        .mockResolvedValueOnce({ rows: [{ id: 'c1', status: 'RECONCILE_REQUIRED' }] })
-        .mockResolvedValueOnce({ rows: [{ id: 'fx1', outcome: 'DISPUTE_UPHELD', effect_type: 'STRIPE_CAPTURE_APPEAL_FEE' }] })
-        .mockResolvedValueOnce({ rows: [{ contract_reconcile_required_count: 1, dispute_fee_side_effect_backlog_count: 1 }] });
+        .mockResolvedValueOnce({
+          rows: [{ id: "c1", status: "RECONCILE_REQUIRED" }],
+        })
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              id: "fx1",
+              outcome: "DISPUTE_UPHELD",
+              effect_type: "STRIPE_CAPTURE_APPEAL_FEE",
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              contract_reconcile_required_count: 1,
+              dispute_fee_side_effect_backlog_count: 1,
+            },
+          ],
+        });
 
-      const result = await controller.getReconciliationVisibility('25');
+      const result = await controller.getReconciliationVisibility("25");
 
       expect(result.summary).toEqual({
         contract_reconcile_required_count: 1,

--- a/src/api/src/modules/admin/admin.controller.spec.ts
+++ b/src/api/src/modules/admin/admin.controller.spec.ts
@@ -362,4 +362,67 @@ describe("AdminController", () => {
       expect(result.disputeFeeSideEffects).toHaveLength(1);
     });
   });
+
+  describe("escalateCrisis", () => {
+    it("should analyze content, log audit, and report crisis", async () => {
+      (mockCrisisDetection.analyzeContent as jest.Mock).mockReturnValueOnce({
+        isCrisis: true,
+        severity: "CRITICAL",
+        matchedKeywords: ["suicide"],
+      });
+      (mockCrisisIntervention.reportCrisis as jest.Mock).mockResolvedValueOnce({
+        message: "logged",
+        resources: [],
+        actionTaken: "recorded",
+        escalated: true,
+      });
+
+      const result = await controller.escalateCrisis(
+        { userId: "user-1", trigger: "suicide" },
+        { id: "ADMIN_root" },
+      );
+
+      expect(mockCrisisDetection.analyzeContent).toHaveBeenCalledWith(
+        "suicide",
+      );
+      expect(mockTruthLog.appendEvent).toHaveBeenCalledWith(
+        "ADMIN_CRISIS_ESCALATED",
+        expect.objectContaining({
+          adminId: "ADMIN_root",
+          targetUserId: "user-1",
+        }),
+      );
+      expect(mockCrisisIntervention.reportCrisis).toHaveBeenCalledWith(
+        "user-1",
+        "suicide",
+        expect.objectContaining({ severity: "CRITICAL" }),
+      );
+      expect(result.escalated).toBe(true);
+    });
+
+    it("should pass undefined detection when severity is NONE", async () => {
+      (mockCrisisDetection.analyzeContent as jest.Mock).mockReturnValueOnce({
+        isCrisis: false,
+        severity: "NONE",
+        matchedKeywords: [],
+      });
+      (mockCrisisIntervention.reportCrisis as jest.Mock).mockResolvedValueOnce({
+        message: "logged",
+        resources: [],
+        actionTaken: "recorded",
+        escalated: false,
+      });
+
+      await controller.escalateCrisis(
+        { userId: "user-2", trigger: "off-platform concern" },
+        { id: "ADMIN_root" },
+      );
+
+      expect(mockCrisisIntervention.reportCrisis).toHaveBeenCalledWith(
+        "user-2",
+        "off-platform concern",
+        undefined,
+      );
+    });
+  });
 });

--- a/src/api/src/modules/admin/admin.controller.ts
+++ b/src/api/src/modules/admin/admin.controller.ts
@@ -52,10 +52,14 @@ export class AdminController {
 
   @Post("crisis/escalate")
   @ApiOperation({ summary: "Manually trigger crisis intervention for a user" })
-  async escalateCrisis(@Body() body: CrisisEscalateDto) {
+  async escalateCrisis(
+    @Body() body: CrisisEscalateDto,
+    @CurrentUser() admin: { id: string },
+  ) {
     const detection = this.crisisDetection.analyzeContent(body.trigger);
+    const detectionOnly = detection.severity !== "NONE" ? detection : undefined;
     await this.truthLog.appendEvent("ADMIN_CRISIS_ESCALATED", {
-      adminId: "SYSTEM",
+      adminId: admin.id,
       targetUserId: body.userId,
       severity: detection.severity,
       trigger: body.trigger,
@@ -63,7 +67,7 @@ export class AdminController {
     return this.crisisIntervention.reportCrisis(
       body.userId,
       body.trigger,
-      detection,
+      detectionOnly,
     );
   }
 

--- a/src/api/src/modules/admin/admin.controller.ts
+++ b/src/api/src/modules/admin/admin.controller.ts
@@ -1,29 +1,43 @@
-import { Controller, Post, Get, Param, Body, UseGuards, Patch, Query, ForbiddenException } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
-import { Pool } from 'pg';
-import { AuthGuard } from '../../../guards/auth.guard';
-import { RoleGuard, Roles } from '../../common/guards/role.guard';
-import { CurrentUser } from '../../common/decorators/current-user.decorator';
-import { ModerationService } from '../../../services/security/moderation.service';
-import { HoneypotService } from '../../../services/intelligence/honeypot.service';
-import { ContractsService } from '../contracts/contracts.service';
-import { DisputeService } from '../../../services/escrow/dispute.service';
-import { R2StorageService } from '../../../services/storage/r2.service';
-import { AnomalyService } from '../../../services/anomaly/anomaly.service';
-import { TruthLogService } from '../../../services/ledger/truth-log.service';
-import { IdentityVerificationService } from '../compliance/identity-verification.service';
-import { IdentityVerificationMode } from '../compliance/identity-provider.service';
-import { BanUserDto, ResolveContractDto } from './dto';
+import {
+  Controller,
+  Post,
+  Get,
+  Param,
+  Body,
+  UseGuards,
+  Patch,
+  Query,
+  ForbiddenException,
+} from "@nestjs/common";
+import { ApiTags, ApiOperation, ApiBearerAuth } from "@nestjs/swagger";
+import { Throttle } from "@nestjs/throttler";
+import { Pool } from "pg";
+import { AuthGuard } from "../../../guards/auth.guard";
+import { RoleGuard, Roles } from "../../common/guards/role.guard";
+import { CurrentUser } from "../../common/decorators/current-user.decorator";
+import { ModerationService } from "../../../services/security/moderation.service";
+import { CrisisDetectionService } from "../../../services/security/crisis-detection.service";
+import { CrisisInterventionService } from "../../../services/security/crisis-intervention.service";
+import { HoneypotService } from "../../../services/intelligence/honeypot.service";
+import { ContractsService } from "../contracts/contracts.service";
+import { DisputeService } from "../../../services/escrow/dispute.service";
+import { R2StorageService } from "../../../services/storage/r2.service";
+import { AnomalyService } from "../../../services/anomaly/anomaly.service";
+import { TruthLogService } from "../../../services/ledger/truth-log.service";
+import { IdentityVerificationService } from "../compliance/identity-verification.service";
+import { IdentityVerificationMode } from "../compliance/identity-provider.service";
+import { BanUserDto, CrisisEscalateDto, ResolveContractDto } from "./dto";
 
-@ApiTags('Admin')
+@ApiTags("Admin")
 @ApiBearerAuth()
-@Controller('admin')
+@Controller("admin")
 @UseGuards(AuthGuard, RoleGuard)
-@Roles('ADMIN')
+@Roles("ADMIN")
 export class AdminController {
   constructor(
     private readonly moderation: ModerationService,
+    private readonly crisisDetection: CrisisDetectionService,
+    private readonly crisisIntervention: CrisisInterventionService,
     private readonly honeypot: HoneypotService,
     private readonly contractsService: ContractsService,
     private readonly disputeService: DisputeService,
@@ -34,41 +48,83 @@ export class AdminController {
     private readonly pool: Pool,
   ) {}
 
+  // --- Crisis Intervention ---
+
+  @Post("crisis/escalate")
+  @ApiOperation({ summary: "Manually trigger crisis intervention for a user" })
+  async escalateCrisis(@Body() body: CrisisEscalateDto) {
+    const detection = this.crisisDetection.analyzeContent(body.trigger);
+    await this.truthLog.appendEvent("ADMIN_CRISIS_ESCALATED", {
+      adminId: "SYSTEM",
+      targetUserId: body.userId,
+      severity: detection.severity,
+      trigger: body.trigger,
+    });
+    return this.crisisIntervention.reportCrisis(
+      body.userId,
+      body.trigger,
+      detection,
+    );
+  }
+
+  @Get("crisis/events")
+  @ApiOperation({ summary: "List recent crisis intervention events" })
+  async getCrisisEvents(@Query("limit") limit?: string) {
+    const parsedLimit = Number(limit || 25);
+    const safeLimit = Number.isFinite(parsedLimit)
+      ? Math.max(1, Math.min(100, parsedLimit))
+      : 25;
+    const result = await this.pool.query(
+      `SELECT id, user_id, severity, trigger, matched_keywords, escalated, created_at
+       FROM crisis_events
+       ORDER BY created_at DESC
+       LIMIT $1`,
+      [safeLimit],
+    );
+    return { events: result.rows };
+  }
+
   // --- Integrity ---
 
-  @Get('integrity/chain')
-  @ApiOperation({ summary: 'Verify event_log hash chain integrity' })
+  @Get("integrity/chain")
+  @ApiOperation({ summary: "Verify event_log hash chain integrity" })
   async verifyChain() {
     return this.truthLog.verifyChain();
   }
 
   // --- Honeypot ---
 
-  @Post('honeypot')
-  @ApiOperation({ summary: 'Inject a honeypot proof to QA reviewer accuracy' })
+  @Post("honeypot")
+  @ApiOperation({ summary: "Inject a honeypot proof to QA reviewer accuracy" })
   @Throttle({ default: { ttl: 60000, limit: 5 } })
   async injectHoneypot() {
     await this.honeypot.injectHoneypot();
-    return { status: 'honeypot_injected' };
+    return { status: "honeypot_injected" };
   }
 
   // --- Moderation ---
 
-  @Post('ban/:userId')
-  @ApiOperation({ summary: 'Ban a user for policy violations' })
+  @Post("ban/:userId")
+  @ApiOperation({ summary: "Ban a user for policy violations" })
   async banUser(
-    @Param('userId') targetUserId: string,
+    @Param("userId") targetUserId: string,
     @CurrentUser() user: { id: string },
     @Body() body: BanUserDto,
   ) {
     // AU11: an admin cannot ban (and thereby lock out) themselves — a guard against
     // accidental or coerced self-targeting of privileged moderation actions.
     if (targetUserId === user.id) {
-      throw new ForbiddenException('Admins cannot perform this moderation action on their own account');
+      throw new ForbiddenException(
+        "Admins cannot perform this moderation action on their own account",
+      );
     }
-    const result = await this.moderation.banUser(user.id, targetUserId, body.reason);
+    const result = await this.moderation.banUser(
+      user.id,
+      targetUserId,
+      body.reason,
+    );
     // AU11: persist a tamper-evident audit entry so the privileged action is traceable.
-    await this.truthLog.appendEvent('ADMIN_USER_BANNED', {
+    await this.truthLog.appendEvent("ADMIN_USER_BANNED", {
       adminId: user.id,
       targetUserId,
       reason: body.reason,
@@ -78,34 +134,39 @@ export class AdminController {
 
   // --- Contracts ---
 
-  @Post('resolve/:contractId')
-  @ApiOperation({ summary: 'Manually resolve a contract as completed or failed' })
+  @Post("resolve/:contractId")
+  @ApiOperation({
+    summary: "Manually resolve a contract as completed or failed",
+  })
   async resolveContract(
-    @Param('contractId') contractId: string,
+    @Param("contractId") contractId: string,
     @CurrentUser() admin: { id: string },
     @Body() body: ResolveContractDto,
   ) {
     await this.contractsService.resolveContract(contractId, body.outcome);
     // AU11: record the admin override of a money-bearing contract resolution.
-    await this.truthLog.appendEvent('ADMIN_CONTRACT_RESOLVED', {
+    await this.truthLog.appendEvent("ADMIN_CONTRACT_RESOLVED", {
       adminId: admin.id,
       contractId,
       outcome: body.outcome,
     });
-    return { status: 'resolved', contractId, outcome: body.outcome };
+    return { status: "resolved", contractId, outcome: body.outcome };
   }
 
   // --- Disputes (The Judge's Gavel) ---
 
-  @Get('disputes')
-  @ApiOperation({ summary: 'Get queue of disputes pending judge review' })
+  @Get("disputes")
+  @ApiOperation({ summary: "Get queue of disputes pending judge review" })
   async getDisputes() {
     return this.disputeService.getDisputeQueue();
   }
 
-  @Get('disputes/:id')
-  @ApiOperation({ summary: 'Get full dispute detail with Fury vote history and signed media URL' })
-  async getDisputeDetail(@Param('id') disputeId: string) {
+  @Get("disputes/:id")
+  @ApiOperation({
+    summary:
+      "Get full dispute detail with Fury vote history and signed media URL",
+  })
+  async getDisputeDetail(@Param("id") disputeId: string) {
     const detail = await this.disputeService.getDisputeDetail(disputeId);
 
     // Generate signed view URL for the judge
@@ -121,27 +182,44 @@ export class AdminController {
     return { ...detail, viewUrl };
   }
 
-  @Post('disputes/:id/resolve')
-  @ApiOperation({ summary: 'Resolve a dispute with a judge verdict (UPHELD, OVERTURNED, ESCALATED)' })
+  @Post("disputes/:id/resolve")
+  @ApiOperation({
+    summary:
+      "Resolve a dispute with a judge verdict (UPHELD, OVERTURNED, ESCALATED)",
+  })
   async resolveDispute(
-    @Param('id') disputeId: string,
+    @Param("id") disputeId: string,
     @CurrentUser() user: { id: string },
-    @Body() body: { outcome: 'UPHELD' | 'OVERTURNED' | 'ESCALATED'; judgeNotes: string },
+    @Body()
+    body: {
+      outcome: "UPHELD" | "OVERTURNED" | "ESCALATED";
+      judgeNotes: string;
+    },
   ) {
-    return this.disputeService.resolveDispute(disputeId, user.id, body.outcome, body.judgeNotes);
+    return this.disputeService.resolveDispute(
+      disputeId,
+      user.id,
+      body.outcome,
+      body.judgeNotes,
+    );
   }
 
-  @Get('disputes/:id/audit-trail')
-  @ApiOperation({ summary: 'Get the full audit trail (timeline + ledger) for a dispute' })
-  async getAuditTrail(@Param('id') disputeId: string) {
+  @Get("disputes/:id/audit-trail")
+  @ApiOperation({
+    summary: "Get the full audit trail (timeline + ledger) for a dispute",
+  })
+  async getAuditTrail(@Param("id") disputeId: string) {
     return this.disputeService.getAuditTrail(disputeId);
   }
 
   // --- User Inspection ---
 
-  @Get('users/:id')
-  @ApiOperation({ summary: 'Get full user profile with contract, proof, and assignment history' })
-  async getUserProfile(@Param('id') userId: string) {
+  @Get("users/:id")
+  @ApiOperation({
+    summary:
+      "Get full user profile with contract, proof, and assignment history",
+  })
+  async getUserProfile(@Param("id") userId: string) {
     const [user, contracts, proofs, assignments] = await Promise.all([
       this.pool.query(
         `SELECT id, email, role, status, integrity_score, created_at FROM users WHERE id = $1`,
@@ -167,7 +245,7 @@ export class AdminController {
       ),
     ]);
 
-    if (user.rows.length === 0) return { error: 'User not found' };
+    if (user.rows.length === 0) return { error: "User not found" };
 
     return {
       user: user.rows[0],
@@ -177,16 +255,20 @@ export class AdminController {
     };
   }
 
-  @Patch('users/:id/integrity')
-  @ApiOperation({ summary: 'Manually adjust a user integrity score (admin override)' })
+  @Patch("users/:id/integrity")
+  @ApiOperation({
+    summary: "Manually adjust a user integrity score (admin override)",
+  })
   async adjustIntegrity(
-    @Param('id') userId: string,
+    @Param("id") userId: string,
     @CurrentUser() admin: { id: string },
     @Body() body: { delta: number; reason: string },
   ) {
     // AU11: an admin cannot adjust their own integrity score (self-dealing guard).
     if (userId === admin.id) {
-      throw new ForbiddenException('Admins cannot adjust their own integrity score');
+      throw new ForbiddenException(
+        "Admins cannot adjust their own integrity score",
+      );
     }
 
     const updateResult = await this.pool.query(
@@ -199,7 +281,7 @@ export class AdminController {
 
     // AU11: persist the privileged adjustment (attacker-controllable delta + reason)
     // to the tamper-evident TruthLog so manual score overrides are auditable.
-    await this.truthLog.appendEvent('ADMIN_INTEGRITY_ADJUSTED', {
+    await this.truthLog.appendEvent("ADMIN_INTEGRITY_ADJUSTED", {
       adminId: admin.id,
       targetUserId: userId,
       delta: body.delta,
@@ -207,27 +289,44 @@ export class AdminController {
       newScore: updateResult.rows[0]?.integrity_score ?? null,
     });
 
-    return { status: 'integrity_adjusted', userId, delta: body.delta, reason: body.reason };
+    return {
+      status: "integrity_adjusted",
+      userId,
+      delta: body.delta,
+      reason: body.reason,
+    };
   }
 
-  @Post('users/:id/compliance/identity/mock-complete')
-  @ApiOperation({ summary: 'Admin override: complete identity verification in mock/provider-test mode' })
+  @Post("users/:id/compliance/identity/mock-complete")
+  @ApiOperation({
+    summary:
+      "Admin override: complete identity verification in mock/provider-test mode",
+  })
   async completeIdentityVerificationForUser(
-    @Param('id') userId: string,
-    @Body() body: { mode?: IdentityVerificationMode; status?: 'VERIFIED' | 'FAILED' | 'REJECTED' },
+    @Param("id") userId: string,
+    @Body()
+    body: {
+      mode?: IdentityVerificationMode;
+      status?: "VERIFIED" | "FAILED" | "REJECTED";
+    },
   ) {
     return this.identityVerification.completeMockVerification({
       userId,
-      mode: body.mode || 'KYC_AND_AGE',
-      status: body.status || 'VERIFIED',
+      mode: body.mode || "KYC_AND_AGE",
+      status: body.status || "VERIFIED",
     });
   }
 
-  @Get('reconciliation')
-  @ApiOperation({ summary: 'Get reconciliation visibility for contract/payment inconsistencies and dispute fee side effects' })
-  async getReconciliationVisibility(@Query('limit') limit?: string) {
+  @Get("reconciliation")
+  @ApiOperation({
+    summary:
+      "Get reconciliation visibility for contract/payment inconsistencies and dispute fee side effects",
+  })
+  async getReconciliationVisibility(@Query("limit") limit?: string) {
     const parsedLimit = Number(limit || 25);
-    const safeLimit = Number.isFinite(parsedLimit) ? Math.max(1, Math.min(100, parsedLimit)) : 25;
+    const safeLimit = Number.isFinite(parsedLimit)
+      ? Math.max(1, Math.min(100, parsedLimit))
+      : 25;
 
     const [contracts, disputeFeeSideEffects, summary] = await Promise.all([
       this.pool.query(
@@ -269,8 +368,10 @@ export class AdminController {
 
   // --- Anomaly Detection ---
 
-  @Post('anomaly/scan')
-  @ApiOperation({ summary: 'Scan all stored proof hashes for pHash collisions' })
+  @Post("anomaly/scan")
+  @ApiOperation({
+    summary: "Scan all stored proof hashes for pHash collisions",
+  })
   async scanHashCollisions() {
     const proofs = await this.pool.query(
       `SELECT p.id, p.user_id, p.contract_id, p.media_uri, p.submitted_at
@@ -289,9 +390,21 @@ export class AdminController {
     // (residual) True near-duplicate detection happens at upload time in PHashService
     // against the actual frame bytes; this URI-level scan cannot reproduce it.
     const collisions: Array<{
-      matchType: 'EXACT_URI';
-      origin: { id: string; pHash: string; user: string; contractId: string; timestamp: string };
-      duplicate: { id: string; pHash: string; user: string; contractId: string; timestamp: string };
+      matchType: "EXACT_URI";
+      origin: {
+        id: string;
+        pHash: string;
+        user: string;
+        contractId: string;
+        timestamp: string;
+      };
+      duplicate: {
+        id: string;
+        pHash: string;
+        user: string;
+        contractId: string;
+        timestamp: string;
+      };
     }> = [];
 
     const hashed = proofs.rows.map((row: any) => ({
@@ -301,11 +414,14 @@ export class AdminController {
 
     for (let i = 0; i < hashed.length; i++) {
       for (let j = i + 1; j < hashed.length; j++) {
-        const distance = this.anomaly.hammingDistance(hashed[i].pHash, hashed[j].pHash);
+        const distance = this.anomaly.hammingDistance(
+          hashed[i].pHash,
+          hashed[j].pHash,
+        );
         // distance === 0 means the media URIs are byte-for-byte identical.
         if (distance === 0) {
           collisions.push({
-            matchType: 'EXACT_URI',
+            matchType: "EXACT_URI",
             origin: {
               id: hashed[i].id,
               pHash: hashed[i].pHash,
@@ -330,15 +446,25 @@ export class AdminController {
 
   // --- Platform Stats ---
 
-  @Get('stats')
-  @ApiOperation({ summary: 'Get platform-wide statistics' })
+  @Get("stats")
+  @ApiOperation({ summary: "Get platform-wide statistics" })
   async getStats() {
     const [users, contracts, proofs, integrity, disputes] = await Promise.all([
-      this.pool.query(`SELECT COUNT(*) as count FROM users WHERE status = 'ACTIVE'`),
-      this.pool.query(`SELECT COUNT(*) as count FROM contracts WHERE status = 'ACTIVE'`),
-      this.pool.query(`SELECT COUNT(*) as count FROM proofs WHERE status IN ('PENDING_REVIEW', 'IN_REVIEW', 'DISPUTED')`),
-      this.pool.query(`SELECT COALESCE(AVG(integrity_score), 0) as avg FROM users WHERE status = 'ACTIVE'`),
-      this.pool.query(`SELECT COUNT(*) as count FROM disputes WHERE appeal_status IN ('FEE_AUTHORIZED_PENDING_REVIEW', 'IN_REVIEW')`),
+      this.pool.query(
+        `SELECT COUNT(*) as count FROM users WHERE status = 'ACTIVE'`,
+      ),
+      this.pool.query(
+        `SELECT COUNT(*) as count FROM contracts WHERE status = 'ACTIVE'`,
+      ),
+      this.pool.query(
+        `SELECT COUNT(*) as count FROM proofs WHERE status IN ('PENDING_REVIEW', 'IN_REVIEW', 'DISPUTED')`,
+      ),
+      this.pool.query(
+        `SELECT COALESCE(AVG(integrity_score), 0) as avg FROM users WHERE status = 'ACTIVE'`,
+      ),
+      this.pool.query(
+        `SELECT COUNT(*) as count FROM disputes WHERE appeal_status IN ('FEE_AUTHORIZED_PENDING_REVIEW', 'IN_REVIEW')`,
+      ),
     ]);
     return {
       totalUsers: Number(users.rows[0].count),

--- a/src/api/src/modules/admin/admin.controller.ts
+++ b/src/api/src/modules/admin/admin.controller.ts
@@ -57,11 +57,13 @@ export class AdminController {
     @CurrentUser() admin: { id: string },
   ) {
     const detection = this.crisisDetection.analyzeContent(body.trigger);
+    const storedSeverity =
+      detection.severity !== "NONE" ? detection.severity : "HIGH";
     const detectionOnly = detection.severity !== "NONE" ? detection : undefined;
     await this.truthLog.appendEvent("ADMIN_CRISIS_ESCALATED", {
       adminId: admin.id,
       targetUserId: body.userId,
-      severity: detection.severity,
+      severity: storedSeverity,
       trigger: body.trigger,
     });
     return this.crisisIntervention.reportCrisis(

--- a/src/api/src/modules/admin/dto.ts
+++ b/src/api/src/modules/admin/dto.ts
@@ -1,14 +1,30 @@
-import { IsString, IsEnum } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsEnum } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
 
 export class BanUserDto {
-  @ApiProperty({ description: 'Reason for the ban', example: 'Repeated fraud attempts' })
+  @ApiProperty({
+    description: "Reason for the ban",
+    example: "Repeated fraud attempts",
+  })
   @IsString()
   reason!: string;
 }
 
 export class ResolveContractDto {
-  @ApiProperty({ description: 'Contract resolution outcome', enum: ['COMPLETED', 'FAILED'] })
-  @IsEnum(['COMPLETED', 'FAILED'])
-  outcome!: 'COMPLETED' | 'FAILED';
+  @ApiProperty({
+    description: "Contract resolution outcome",
+    enum: ["COMPLETED", "FAILED"],
+  })
+  @IsEnum(["COMPLETED", "FAILED"])
+  outcome!: "COMPLETED" | "FAILED";
+}
+
+export class CrisisEscalateDto {
+  @ApiProperty({ description: "Target user ID" })
+  @IsString()
+  userId!: string;
+
+  @ApiProperty({ description: "Trigger text that caused the escalation" })
+  @IsString()
+  trigger!: string;
 }


### PR DESCRIPTION
## Summary

Adds admin API endpoints for crisis intervention escalation and event history:

- **`POST /admin/crisis/escalate`** — Manually trigger crisis intervention for a user, runs content through `CrisisDetectionService`, logs via `CrisisInterventionService.reportCrisis()`, and persists an audit trail entry
- **`GET /admin/crisis/events`** — List recent crisis events with severity, matched keywords, and escalation status

**Closes #413** (remaining work after #632/#634).