### PR TITLE
feat(web): crisis intervention UI with support resources and cooldown (Issue #412)

### DIFF
--- a/src/api/src/app.module.ts
+++ b/src/api/src/app.module.ts
@@ -20,6 +20,7 @@ import { ComplianceModule } from './modules/compliance/compliance.module';
 import { BetaModule } from './modules/beta/beta.module';
 import { OraclesModule } from './modules/oracles/oracles.module';
 import { SocialModule } from './modules/social/social.module';
+import { CrisisModule } from './modules/crisis/crisis.module';
 import { DashboardModule } from './modules/dashboard/dashboard.module';
 import { RealmsModule } from './modules/realms/realms.module';
 
@@ -54,6 +55,7 @@ import { RealmsModule } from './modules/realms/realms.module';
     FeedModule,
     DashboardModule,
     SocialModule,
+    CrisisModule,
     RealmsModule,
   ],
   providers: [

--- a/src/api/src/modules/crisis/crisis.controller.ts
+++ b/src/api/src/modules/crisis/crisis.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Post, Body, UseGuards } from "@nestjs/common";
+import { ApiTags, ApiBearerAuth, ApiOperation } from "@nestjs/swagger";
+import { AuthGuard } from "../../../guards/auth.guard";
+import { CurrentUser } from "../../common/decorators/current-user.decorator";
+import { CrisisInterventionService } from "../../../services/security/crisis-intervention.service";
+import { CrisisDetectionService } from "../../../services/security/crisis-detection.service";
+import { CrisisEscalateDto } from "./dto";
+
+@ApiTags("Crisis")
+@ApiBearerAuth()
+@Controller("crisis")
+@UseGuards(AuthGuard)
+export class CrisisController {
+  constructor(
+    private readonly crisisDetection: CrisisDetectionService,
+    private readonly crisisIntervention: CrisisInterventionService,
+  ) {}
+
+  @Post("escalate")
+  @ApiOperation({ summary: "Submit a self-report crisis escalation" })
+  async escalate(
+    @Body() body: CrisisEscalateDto,
+    @CurrentUser() user: { id: string },
+  ) {
+    const targetUserId = body.userId || user.id;
+    const trigger = body.trigger || "self-report";
+    const detection = this.crisisDetection.analyzeContent(trigger);
+    const storedSeverity =
+      detection.severity !== "NONE" ? detection.severity : "HIGH";
+    const detectionOnly = detection.severity !== "NONE" ? detection : undefined;
+    return this.crisisIntervention.reportCrisis(
+      targetUserId,
+      trigger,
+      detectionOnly,
+    );
+  }
+}

--- a/src/api/src/modules/crisis/crisis.controller.ts
+++ b/src/api/src/modules/crisis/crisis.controller.ts
@@ -22,7 +22,7 @@ export class CrisisController {
     @Body() body: CrisisEscalateDto,
     @CurrentUser() user: { id: string },
   ) {
-    const targetUserId = body.userId || user.id;
+    const targetUserId = user.id;
     const trigger = body.trigger || "self-report";
     const detection = this.crisisDetection.analyzeContent(trigger);
     const storedSeverity =

--- a/src/api/src/modules/crisis/crisis.module.ts
+++ b/src/api/src/modules/crisis/crisis.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { CrisisController } from "./crisis.controller";
+import { CrisisDetectionService } from "../../../services/security/crisis-detection.service";
+import { CrisisInterventionService } from "../../../services/security/crisis-intervention.service";
+
+@Module({
+  controllers: [CrisisController],
+  providers: [CrisisDetectionService, CrisisInterventionService],
+})
+export class CrisisModule {}

--- a/src/api/src/modules/crisis/dto.ts
+++ b/src/api/src/modules/crisis/dto.ts
@@ -1,0 +1,19 @@
+import { IsString, IsOptional } from "class-validator";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+
+export class CrisisEscalateDto {
+  @ApiProperty({
+    description: "User ID to escalate crisis for",
+    example: "user_abc123",
+  })
+  @IsString()
+  userId!: string;
+
+  @ApiPropertyOptional({
+    description: "Trigger text that caused the crisis detection",
+    example: "I want to hurt myself",
+  })
+  @IsOptional()
+  @IsString()
+  trigger?: string;
+}

--- a/src/api/src/modules/crisis/dto.ts
+++ b/src/api/src/modules/crisis/dto.ts
@@ -2,13 +2,6 @@ import { IsString, IsOptional } from "class-validator";
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 
 export class CrisisEscalateDto {
-  @ApiProperty({
-    description: "User ID to escalate crisis for",
-    example: "user_abc123",
-  })
-  @IsString()
-  userId!: string;
-
   @ApiPropertyOptional({
     description: "Trigger text that caused the crisis detection",
     example: "I want to hurt myself",

--- a/src/web/app/guardrails/page.tsx
+++ b/src/web/app/guardrails/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import React from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import CrisisIntervention from "../../components/guardrails/CrisisIntervention";
+import { useAuth } from "../../contexts/AuthContext";
+
+export default function GuardrailsPage() {
+  const { user, isLoading: authLoading } = useAuth();
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const severityParam = searchParams.get("severity") as
+    | "info"
+    | "warning"
+    | "critical"
+    | null;
+  const trigger = searchParams.get("trigger");
+  const cooldownParam = searchParams.get("cooldown");
+
+  const severity = severityParam || "warning";
+  const cooldownMinutes = cooldownParam ? parseInt(cooldownParam, 10) : 15;
+
+  const handleDismiss = () => {
+    router.push("/dashboard");
+  };
+
+  if (authLoading) return null;
+
+  return (
+    <CrisisIntervention
+      severity={severity}
+      trigger={trigger || undefined}
+      cooldownMinutes={cooldownMinutes}
+      onDismiss={handleDismiss}
+      onContactSupport={handleDismiss}
+      userId={user?.id}
+    />
+  );
+}

--- a/src/web/app/guardrails/page.tsx
+++ b/src/web/app/guardrails/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import React from "react";
+import React, { Suspense } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
+import { Loader2 } from "lucide-react";
 import CrisisIntervention from "../../components/guardrails/CrisisIntervention";
 import { useAuth } from "../../contexts/AuthContext";
 
-export default function GuardrailsPage() {
+function GuardrailsContent() {
   const { user, isLoading: authLoading } = useAuth();
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -36,5 +37,20 @@ export default function GuardrailsPage() {
       onContactSupport={handleDismiss}
       userId={user?.id}
     />
+  );
+}
+
+export default function GuardrailsPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-black text-white flex items-center justify-center">
+          <Loader2 className="animate-spin mr-3" size={24} />
+          <span className="text-neutral-400 font-bold">Loading...</span>
+        </div>
+      }
+    >
+      <GuardrailsContent />
+    </Suspense>
   );
 }

--- a/src/web/app/guardrails/page.tsx
+++ b/src/web/app/guardrails/page.tsx
@@ -6,20 +6,20 @@ import { Loader2 } from "lucide-react";
 import CrisisIntervention from "../../components/guardrails/CrisisIntervention";
 import { useAuth } from "../../contexts/AuthContext";
 
+const VALID_SEVERITIES = new Set(["info", "warning", "critical"]);
+
 function GuardrailsContent() {
   const { user, isLoading: authLoading } = useAuth();
   const searchParams = useSearchParams();
   const router = useRouter();
 
-  const severityParam = searchParams.get("severity") as
-    | "info"
-    | "warning"
-    | "critical"
-    | null;
+  const severityRaw = searchParams.get("severity");
+  const severity = VALID_SEVERITIES.has(severityRaw ?? "")
+    ? (severityRaw as "info" | "warning" | "critical")
+    : "warning";
   const trigger = searchParams.get("trigger");
   const cooldownParam = searchParams.get("cooldown");
 
-  const severity = severityParam || "warning";
   const cooldownMinutes = cooldownParam ? parseInt(cooldownParam, 10) : 15;
 
   const handleDismiss = () => {
@@ -34,7 +34,6 @@ function GuardrailsContent() {
       trigger={trigger || undefined}
       cooldownMinutes={cooldownMinutes}
       onDismiss={handleDismiss}
-      onContactSupport={handleDismiss}
       userId={user?.id}
     />
   );

--- a/src/web/components/guardrails/CrisisIntervention.tsx
+++ b/src/web/components/guardrails/CrisisIntervention.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import {
+  AlertTriangle,
+  Heart,
+  Phone,
+  Clock,
+  Shield,
+  ArrowLeft,
+  ExternalLink,
+  Loader2,
+} from "lucide-react";
+import Link from "next/link";
+import { api } from "../../services/api-client";
+
+interface SupportResource {
+  name: string;
+  contact: string;
+  instructions: string;
+}
+
+interface CrisisInterventionProps {
+  severity?: "info" | "warning" | "critical";
+  trigger?: string;
+  resources?: SupportResource[];
+  cooldownMinutes?: number;
+  onDismiss?: () => void;
+  onContactSupport?: () => void;
+  embedded?: boolean;
+  userId?: string;
+}
+
+const SEVERITY_STYLES = {
+  info: {
+    border: "border-blue-800",
+    bg: "bg-blue-950/30",
+    badge: "bg-blue-900/50 text-blue-400 border-blue-700",
+    icon: "text-blue-500",
+    gradient: "from-blue-600 to-blue-800",
+  },
+  warning: {
+    border: "border-yellow-800",
+    bg: "bg-yellow-950/30",
+    badge: "bg-yellow-900/50 text-yellow-400 border-yellow-700",
+    icon: "text-yellow-500",
+    gradient: "from-yellow-600 to-yellow-800",
+  },
+  critical: {
+    border: "border-red-800",
+    bg: "bg-red-950/30",
+    badge: "bg-red-900/50 text-red-400 border-red-700",
+    icon: "text-red-500",
+    gradient: "from-red-600 to-red-800",
+  },
+};
+
+const DEFAULT_RESOURCES: SupportResource[] = [
+  {
+    name: "National Crisis Hotline",
+    contact: "988",
+    instructions: "Call or text 988. Available 24/7 for emotional support.",
+  },
+  {
+    name: "Crisis Text Line",
+    contact: "Text HOME to 741741",
+    instructions: "Free crisis counseling via text message. Available 24/7.",
+  },
+  {
+    name: "SAMHSA Helpline",
+    contact: "1-800-662-4357",
+    instructions:
+      "Confidential referral for mental health and substance use treatment.",
+  },
+];
+
+export default function CrisisIntervention({
+  severity = "warning",
+  trigger,
+  resources,
+  cooldownMinutes = 15,
+  onDismiss,
+  onContactSupport,
+  embedded = false,
+  userId,
+}: CrisisInterventionProps) {
+  const [cooldownRemaining, setCooldownRemaining] = useState(
+    cooldownMinutes * 60,
+  );
+  const [escalating, setEscalating] = useState(false);
+  const [escalationResult, setEscalationResult] = useState<string | null>(null);
+  const style = SEVERITY_STYLES[severity];
+
+  useEffect(() => {
+    if (cooldownRemaining <= 0) return;
+    const interval = setInterval(() => {
+      setCooldownRemaining((prev) => Math.max(0, prev - 1));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [cooldownRemaining]);
+
+  const formatTime = (seconds: number) => {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${m}:${s.toString().padStart(2, "0")}`;
+  };
+
+  const handleEscalate = async () => {
+    if (!userId) return;
+    setEscalating(true);
+    try {
+      const result = await api.escalateCrisis(userId, trigger || "self-report");
+      setEscalationResult(
+        `Support resources dispatched. An escort will follow up.`,
+      );
+      if (onContactSupport) onContactSupport();
+    } catch (err) {
+      setEscalationResult(
+        err instanceof Error ? err.message : "Failed to escalate",
+      );
+    } finally {
+      setEscalating(false);
+    }
+  };
+
+  const displayResources = resources || DEFAULT_RESOURCES;
+
+  const content = (
+    <div className={`space-y-6 ${embedded ? "" : "max-w-2xl mx-auto"}`}>
+      <div
+        className={`p-6 rounded-2xl border ${style.border} ${style.bg} space-y-4`}
+      >
+        <div className="flex items-start gap-4">
+          <div className={`shrink-0 mt-1 ${style.icon}`}>
+            {severity === "critical" ? (
+              <AlertTriangle size={28} />
+            ) : (
+              <Heart size={28} />
+            )}
+          </div>
+          <div className="space-y-2 flex-1">
+            <div className="flex items-center gap-3 flex-wrap">
+              <h2 className="text-lg font-black text-white uppercase tracking-tight">
+                {severity === "critical"
+                  ? "Action Paused — Support Available"
+                  : "Pause — Check In With Yourself"}
+              </h2>
+              <span
+                className={`px-2 py-0.5 rounded text-xs font-bold uppercase tracking-wider border ${style.badge}`}
+              >
+                {severity}
+              </span>
+            </div>
+            <p className="text-sm text-neutral-300 leading-relaxed">
+              {trigger
+                ? `Your activity was paused because: "${trigger}". This is a protective measure.`
+                : "Your activity has been temporarily paused by Styx safety guardrails. This is a protective measure to ensure your wellbeing."}
+            </p>
+          </div>
+        </div>
+
+        {cooldownRemaining > 0 && (
+          <div className="flex items-center gap-3 p-3 rounded-xl bg-black/40 border border-neutral-800">
+            <Clock className={`shrink-0 ${style.icon}`} size={20} />
+            <div className="flex-1">
+              <p className="text-xs text-neutral-500 uppercase tracking-widest font-bold">
+                Cooldown Remaining
+              </p>
+              <p className="text-xl font-mono font-bold text-white tabular-nums">
+                {formatTime(cooldownRemaining)}
+              </p>
+            </div>
+            <div className="w-24 h-2 rounded-full bg-neutral-800 overflow-hidden">
+              <div
+                className={`h-full rounded-full bg-gradient-to-r ${style.gradient} transition-all duration-1000`}
+                style={{
+                  width: `${(cooldownRemaining / (cooldownMinutes * 60)) * 100}%`,
+                }}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="p-6 rounded-2xl border border-neutral-800 bg-neutral-900/50 space-y-4">
+        <div className="flex items-center gap-2">
+          <Phone className="text-green-500" size={20} />
+          <h3 className="font-bold text-white uppercase tracking-widest text-sm">
+            Support Resources
+          </h3>
+        </div>
+        <p className="text-xs text-neutral-500 leading-relaxed">
+          These resources are available 24/7 — reaching out is always the right
+          call. Styx will never penalize you for seeking help.
+        </p>
+        <div className="grid gap-3">
+          {displayResources.map((resource, i) => (
+            <div
+              key={i}
+              className="p-4 rounded-xl bg-black/40 border border-neutral-800 space-y-1.5"
+            >
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-bold text-white">{resource.name}</p>
+                <span className="text-xs font-mono text-green-400 bg-green-950/50 px-2 py-0.5 rounded border border-green-900/50">
+                  {resource.contact}
+                </span>
+              </div>
+              <p className="text-xs text-neutral-500">
+                {resource.instructions}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-3">
+        {userId && (
+          <button
+            onClick={handleEscalate}
+            disabled={escalating}
+            className="flex-1 py-3 bg-red-700 hover:bg-red-600 disabled:opacity-50 text-white font-bold rounded-xl transition-colors flex items-center justify-center gap-2 uppercase tracking-wider text-sm"
+          >
+            {escalating ? (
+              <Loader2 className="animate-spin" size={16} />
+            ) : (
+              <Shield size={16} />
+            )}
+            {escalating ? "Escalating..." : "Request Support Escalation"}
+          </button>
+        )}
+        {onDismiss && (
+          <button
+            onClick={onDismiss}
+            className="flex-1 py-3 bg-neutral-800 hover:bg-neutral-700 text-white font-bold rounded-xl transition-colors flex items-center justify-center gap-2 uppercase tracking-wider text-sm"
+          >
+            <ArrowLeft size={16} />
+            Return to Dashboard
+          </button>
+        )}
+      </div>
+
+      {escalationResult && (
+        <p className="text-xs text-neutral-500 text-center">
+          {escalationResult}
+        </p>
+      )}
+    </div>
+  );
+
+  if (embedded) return content;
+
+  return (
+    <div className="min-h-screen bg-black text-white font-sans p-6 md:p-12">
+      <Link
+        href="/dashboard"
+        className="inline-flex items-center gap-2 text-neutral-400 hover:text-white transition-colors mb-8"
+      >
+        <ArrowLeft size={18} />
+        <span className="text-sm font-bold uppercase tracking-wider">
+          Dashboard
+        </span>
+      </Link>
+      {content}
+    </div>
+  );
+}

--- a/src/web/services/api-client.ts
+++ b/src/web/services/api-client.ts
@@ -1,19 +1,29 @@
-import type { MobileBootstrapResponse, ReleaseInfoResponse } from '@styx/shared/index';
+import type {
+  MobileBootstrapResponse,
+  ReleaseInfoResponse,
+} from "@styx/shared/index";
 
 // In the browser, route through the Next.js /api rewrite proxy (same-origin)
 // to avoid cross-origin cookie/CORS issues.  On the server (SSR), call the
 // API directly since there's no browser cookie sandbox to worry about.
 const API_BASE =
-  typeof window !== 'undefined'
-    ? '/api'
-    : (process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000');
-const WEB_APP_VERSION = process.env.NEXT_PUBLIC_STYX_WEB_VERSION || process.env.NEXT_PUBLIC_APP_VERSION || '0.0.0-dev';
-const WEB_APP_BUILD = process.env.NEXT_PUBLIC_STYX_WEB_BUILD || process.env.NEXT_PUBLIC_BUILD_SHA || 'dev';
+  typeof window !== "undefined"
+    ? "/api"
+    : process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
+const WEB_APP_VERSION =
+  process.env.NEXT_PUBLIC_STYX_WEB_VERSION ||
+  process.env.NEXT_PUBLIC_APP_VERSION ||
+  "0.0.0-dev";
+const WEB_APP_BUILD =
+  process.env.NEXT_PUBLIC_STYX_WEB_BUILD ||
+  process.env.NEXT_PUBLIC_BUILD_SHA ||
+  "dev";
 
-let currentToken = '';
-let currentCsrfToken = '';
+let currentToken = "";
+let currentCsrfToken = "";
 
-export function setAuthToken(token: string) { // allow-secret
+export function setAuthToken(token: string) {
+  // allow-secret
   currentToken = token;
 }
 
@@ -30,26 +40,30 @@ export function getCsrfToken(): string {
 }
 
 function readCookie(name: string): string | null {
-  if (typeof document === 'undefined') return null;
-  const cookies = document.cookie.split(';');
+  if (typeof document === "undefined") return null;
+  const cookies = document.cookie.split(";");
   for (const cookie of cookies) {
-    const [rawKey, ...rawValue] = cookie.trim().split('=');
+    const [rawKey, ...rawValue] = cookie.trim().split("=");
     if (rawKey === name) {
-      return decodeURIComponent(rawValue.join('='));
+      return decodeURIComponent(rawValue.join("="));
     }
   }
   return null;
 }
 
 function getRequestId(res: Response): string | null {
-  return res.headers?.get?.('x-styx-request-id') || res.headers?.get?.('x-request-id') || null;
+  return (
+    res.headers?.get?.("x-styx-request-id") ||
+    res.headers?.get?.("x-request-id") ||
+    null
+  );
 }
 
 async function parseErrorMessage(res: Response): Promise<string> {
   let message = `API ${res.status}`;
   try {
-    const contentType = res.headers?.get?.('content-type') || '';
-    if (contentType.includes('application/json')) {
+    const contentType = res.headers?.get?.("content-type") || "";
+    if (contentType.includes("application/json")) {
       const payload = await res.json();
       const envelopeMessage =
         payload?.message ||
@@ -57,9 +71,7 @@ async function parseErrorMessage(res: Response): Promise<string> {
         payload?.error_description ||
         payload?.error;
       const errorCode =
-        payload?.error_code ||
-        payload?.code ||
-        payload?.error?.code;
+        payload?.error_code || payload?.code || payload?.error?.code;
       if (envelopeMessage) {
         message = `API ${res.status}: ${String(envelopeMessage)}`;
       }
@@ -73,7 +85,7 @@ async function parseErrorMessage(res: Response): Promise<string> {
       }
     }
   } catch {
-    const text = await res.text().catch(() => '');
+    const text = await res.text().catch(() => "");
     if (text) {
       message = `API ${res.status}: ${text}`;
     }
@@ -89,31 +101,37 @@ async function parseErrorMessage(res: Response): Promise<string> {
 let isRefreshing = false;
 
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
-  const method = String(options?.method || 'GET').toUpperCase();
-  const needsCsrf = method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE';
-  const csrfToken = currentCsrfToken || readCookie('styx_csrf_token') || '';
+  const method = String(options?.method || "GET").toUpperCase();
+  const needsCsrf =
+    method === "POST" ||
+    method === "PUT" ||
+    method === "PATCH" ||
+    method === "DELETE";
+  const csrfToken = currentCsrfToken || readCookie("styx_csrf_token") || "";
   const mergedHeaders = {
-    'Content-Type': 'application/json',
-    'x-styx-platform': 'web',
-    'x-styx-app-version': WEB_APP_VERSION,
-    'x-styx-build': WEB_APP_BUILD,
+    "Content-Type": "application/json",
+    "x-styx-platform": "web",
+    "x-styx-app-version": WEB_APP_VERSION,
+    "x-styx-build": WEB_APP_BUILD,
     ...(currentToken ? { Authorization: `Bearer ${currentToken}` } : {}),
-    ...(needsCsrf && csrfToken ? { 'x-csrf-token': csrfToken } : {}),
+    ...(needsCsrf && csrfToken ? { "x-csrf-token": csrfToken } : {}),
     ...options?.headers,
   };
   let res: Response;
   try {
     res = await fetch(`${API_BASE}${path}`, {
       ...options,
-      credentials: options?.credentials ?? 'include',
+      credentials: options?.credentials ?? "include",
       headers: mergedHeaders,
     });
   } catch {
-    throw new Error('Styx service is temporarily unavailable. Please try again shortly.');
+    throw new Error(
+      "Styx service is temporarily unavailable. Please try again shortly.",
+    );
   }
 
   // Auto-refresh on 401 (except for the refresh endpoint itself)
-  if (res.status === 401 && path !== '/auth/refresh' && !isRefreshing) {
+  if (res.status === 401 && path !== "/auth/refresh" && !isRefreshing) {
     isRefreshing = true;
     try {
       await refreshToken();
@@ -128,8 +146,8 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 
   if (!res.ok) throw new Error(await parseErrorMessage(res));
   if (res.status === 204) return undefined as T;
-  const contentType = res.headers?.get?.('content-type') || '';
-  if (contentType.includes('application/json') || contentType === '') {
+  const contentType = res.headers?.get?.("content-type") || "";
+  if (contentType.includes("application/json") || contentType === "") {
     return res.json();
   }
   return (await res.text()) as T;
@@ -137,11 +155,11 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 
 async function refreshToken(): Promise<void> {
   const res = await fetch(`${API_BASE}/auth/refresh`, {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
   });
-  if (!res.ok) throw new Error('Refresh failed');
+  if (!res.ok) throw new Error("Refresh failed");
 }
 
 export interface CreateContractDto {
@@ -162,7 +180,7 @@ export interface SubmitProofDto {
 
 export interface VerdictDto {
   assignmentId: string;
-  verdict: 'PASS' | 'FAIL';
+  verdict: "PASS" | "FAIL";
   confidence?: number;
   flagged?: boolean;
 }
@@ -175,30 +193,43 @@ export interface LeaderboardEntry {
 }
 
 export const api = {
-  health: () => request<{ status: string }>('/health'),
-  getMobileBootstrap: () => request<MobileBootstrapResponse>('/mobile/bootstrap'),
-  getReleaseInfo: () => request<ReleaseInfoResponse>('/meta/release'),
+  health: () => request<{ status: string }>("/health"),
+  getMobileBootstrap: () =>
+    request<MobileBootstrapResponse>("/mobile/bootstrap"),
+  getReleaseInfo: () => request<ReleaseInfoResponse>("/meta/release"),
 
   // Auth
-  register: (email: string, password: string, opts?: { ageConfirmation?: boolean; termsAccepted?: boolean; dateOfBirth?: string }) => // allow-secret
-    request<{ userId: string; token: string }>('/auth/register', { // allow-secret
-      method: 'POST',
+  register: (
+    email: string,
+    password: string,
+    opts?: {
+      ageConfirmation?: boolean;
+      termsAccepted?: boolean;
+      dateOfBirth?: string;
+    }, // allow-secret
+  ) =>
+    request<{ userId: string; token: string }>("/auth/register", {
+      // allow-secret
+      method: "POST",
       body: JSON.stringify({ email, password, ...opts }),
     }),
 
-  login: (email: string, password: string) => // allow-secret
-    request<{ userId: string; token: string }>('/auth/login', { // allow-secret
-      method: 'POST',
+  login: (
+    email: string,
+    password: string, // allow-secret
+  ) =>
+    request<{ userId: string; token: string }>("/auth/login", {
+      // allow-secret
+      method: "POST",
       body: JSON.stringify({ email, password }),
     }),
 
   logout: () =>
-    request<{ status: string }>('/auth/logout', {
-      method: 'POST',
+    request<{ status: string }>("/auth/logout", {
+      method: "POST",
     }),
 
-  getCsrf: () =>
-    request<{ csrfToken: string }>('/auth/csrf'),
+  getCsrf: () => request<{ csrfToken: string }>("/auth/csrf"),
 
   // Wallet — no more userId query params
   getBalance: () =>
@@ -209,20 +240,39 @@ export const api = {
       allowed_tiers: string[];
       ledger_balance: number;
       status: string;
-    }>('/wallet/balance'),
+    }>("/wallet/balance"),
 
   getHistory: (limit?: number) =>
-    request<{ transactions: Array<{
-      id: string;
-      type: string;
-      amount: number;
-      timestamp: string;
-      description: string;
-    }> }>(`/wallet/history${limit ? `?limit=${limit}` : ''}`),
+    request<{
+      transactions: Array<{
+        id: string;
+        type: string;
+        amount: number;
+        timestamp: string;
+        description: string;
+      }>;
+    }>(`/wallet/history${limit ? `?limit=${limit}` : ""}`),
 
   // Contracts — userId comes from JWT
   getUserContracts: () =>
-    request<Array<{
+    request<
+      Array<{
+        id: string;
+        user_id: string;
+        oath_category: string;
+        verification_method: string;
+        stake_amount: string;
+        status: string;
+        duration_days: number;
+        started_at: string;
+        ends_at: string;
+        created_at: string;
+        proof_count: number;
+      }>
+    >("/contracts"),
+
+  getContract: (id: string) =>
+    request<{
       id: string;
       user_id: string;
       oath_category: string;
@@ -233,123 +283,132 @@ export const api = {
       started_at: string;
       ends_at: string;
       created_at: string;
+      email: string;
+      integrity_score: number;
+      grace_days_used?: number;
       proof_count: number;
-    }>>('/contracts'),
-
-  getContract: (id: string) => request<{
-    id: string;
-    user_id: string;
-    oath_category: string;
-    verification_method: string;
-    stake_amount: string;
-    status: string;
-    duration_days: number;
-    started_at: string;
-    ends_at: string;
-    created_at: string;
-    email: string;
-    integrity_score: number;
-    grace_days_used?: number;
-    proof_count: number;
-    proofs: Array<{
-      id: string;
-      timestamp: string;
-      status: string;
-      media_url: string | null;
-    }>;
-    grace_days_max: number;
-  }>(`/contracts/${id}`),
+      proofs: Array<{
+        id: string;
+        timestamp: string;
+        status: string;
+        media_url: string | null;
+      }>;
+      grace_days_max: number;
+    }>(`/contracts/${id}`),
 
   createContract: (dto: CreateContractDto | Record<string, unknown>) =>
-    request<{ contractId: string; paymentIntentId: string }>('/contracts', {
-      method: 'POST',
+    request<{ contractId: string; paymentIntentId: string }>("/contracts", {
+      method: "POST",
       body: JSON.stringify(dto),
     }),
 
   submitProof: (contractId: string, dto: SubmitProofDto) =>
-    request<{ proofId: string; jobId: string; rejected?: boolean; reason?: string }>(`/contracts/${contractId}/proof`, {
-      method: 'POST',
+    request<{
+      proofId: string;
+      jobId: string;
+      rejected?: boolean;
+      reason?: string;
+    }>(`/contracts/${contractId}/proof`, {
+      method: "POST",
       body: JSON.stringify(dto),
     }),
 
   disputeContract: (contractId: string) =>
-    request<{ appealStatus: string; paymentIntentId: string }>(`/contracts/${contractId}/dispute`, {
-      method: 'POST',
-    }),
+    request<{ appealStatus: string; paymentIntentId: string }>(
+      `/contracts/${contractId}/dispute`,
+      {
+        method: "POST",
+      },
+    ),
 
   // Fury — userId comes from JWT
   getFuryAssignments: () =>
-    request<{ assignments: Array<{
-      assignmentId: string;
-      proofId: string;
-      assignedAt: string;
-      contractId: string;
-      submittedAt: string;
-      contentType: string | null;
-      description: string | null;
-      viewUrl: string | null;
-    }> }>('/fury/queue'),
+    request<{
+      assignments: Array<{
+        assignmentId: string;
+        proofId: string;
+        assignedAt: string;
+        contractId: string;
+        submittedAt: string;
+        contentType: string | null;
+        description: string | null;
+        viewUrl: string | null;
+      }>;
+    }>("/fury/queue"),
 
   submitVerdict: (dto: VerdictDto) =>
-    request<{ status: string; honeypotReveal?: { wasHoneypot: boolean; wasCorrect: boolean } }>('/fury/verdict', {
-      method: 'POST',
+    request<{
+      status: string;
+      honeypotReveal?: { wasHoneypot: boolean; wasCorrect: boolean };
+    }>("/fury/verdict", {
+      method: "POST",
       body: JSON.stringify(dto),
     }),
 
   // Users
-  getMe: () => request<{
-    id: string;
-    email: string;
-    integrity_score: number;
-    role: string;
-    status: string;
-    created_at: string;
-    compliance?: {
-      kyc_status: string;
-      age_verification_status: string;
-      identity_provider: string | null;
-      identity_verification_id: string | null;
-      identity_verified_at: string | null;
-      is_kyc_verified: boolean;
-      is_age_verified: boolean;
-    };
-  }>('/users/me'),
+  getMe: () =>
+    request<{
+      id: string;
+      email: string;
+      integrity_score: number;
+      role: string;
+      status: string;
+      created_at: string;
+      compliance?: {
+        kyc_status: string;
+        age_verification_status: string;
+        identity_provider: string | null;
+        identity_verification_id: string | null;
+        identity_verified_at: string | null;
+        is_kyc_verified: boolean;
+        is_age_verified: boolean;
+      };
+    }>("/users/me"),
 
   getLeaderboard: (limit?: number, period?: string) => {
     const params = new URLSearchParams();
-    if (limit) params.set('limit', String(limit));
-    if (period) params.set('period', period);
+    if (limit) params.set("limit", String(limit));
+    if (period) params.set("period", period);
     const qs = params.toString();
-    return request<LeaderboardEntry[]>(`/users/leaderboard${qs ? `?${qs}` : ''}`);
+    return request<LeaderboardEntry[]>(
+      `/users/leaderboard${qs ? `?${qs}` : ""}`,
+    );
   },
 
   // Notifications
   getNotifications: () =>
-    request<Array<{
-      id: string;
-      type: string;
-      title: string;
-      body: string | null;
-      read: boolean;
-      created_at: string;
-    }>>('/notifications'),
+    request<
+      Array<{
+        id: string;
+        type: string;
+        title: string;
+        body: string | null;
+        read: boolean;
+        created_at: string;
+      }>
+    >("/notifications"),
 
   getUnreadCount: () =>
-    request<{ count: number }>('/notifications/unread-count'),
+    request<{ count: number }>("/notifications/unread-count"),
 
   requestNotificationStreamTicket: () =>
-    request<{ ticket: string; expiresInSeconds: number }>('/notifications/stream-ticket', {
-      method: 'POST',
-    }),
+    request<{ ticket: string; expiresInSeconds: number }>(
+      "/notifications/stream-ticket",
+      {
+        method: "POST",
+      },
+    ),
 
   issueNotificationStreamCookie: () =>
-    request<{ expiresInSeconds: number }>('/notifications/stream-cookie', {
-      method: 'POST',
-      credentials: 'include',
+    request<{ expiresInSeconds: number }>("/notifications/stream-cookie", {
+      method: "POST",
+      credentials: "include",
     }),
 
   markNotificationRead: (id: string) =>
-    request<{ status: string }>(`/notifications/${id}/read`, { method: 'POST' }),
+    request<{ status: string }>(`/notifications/${id}/read`, {
+      method: "POST",
+    }),
 
   // B2B Enterprise
   getEnterpriseMetrics: (enterpriseId: string) =>
@@ -375,38 +434,45 @@ export const api = {
 
   // Billing — ticket purchase
   purchaseTicket: (contractId: string) =>
-    request<{ paymentIntentId: string; amount: number }>(`/contracts/${contractId}/ticket`, {
-      method: 'POST',
-    }),
+    request<{ paymentIntentId: string; amount: number }>(
+      `/contracts/${contractId}/ticket`,
+      {
+        method: "POST",
+      },
+    ),
 
   // Grace day
   useGraceDay: (contractId: string) =>
     request<{ newDeadline: string }>(`/contracts/${contractId}/grace-day`, {
-      method: 'POST',
+      method: "POST",
     }),
 
   // Proofs for a contract
   getContractProofs: (contractId: string) =>
-    request<Array<{
-      id: string;
-      status: string;
-      media_uri: string;
-      submitted_at: string;
-    }>>(`/contracts/${contractId}/proofs`),
+    request<
+      Array<{
+        id: string;
+        status: string;
+        media_uri: string;
+        submitted_at: string;
+      }>
+    >(`/contracts/${contractId}/proofs`),
 
   // Admin
   injectHoneypot: () =>
-    request<{ status: string; jobId: string }>('/admin/honeypot', { method: 'POST' }),
+    request<{ status: string; jobId: string }>("/admin/honeypot", {
+      method: "POST",
+    }),
 
   banUser: (userId: string, reason: string) =>
-    request('/admin/ban/' + userId, {
-      method: 'POST',
+    request("/admin/ban/" + userId, {
+      method: "POST",
       body: JSON.stringify({ reason }),
     }),
 
-  adminResolve: (contractId: string, outcome: 'COMPLETED' | 'FAILED') =>
-    request('/admin/resolve/' + contractId, {
-      method: 'POST',
+  adminResolve: (contractId: string, outcome: "COMPLETED" | "FAILED") =>
+    request("/admin/resolve/" + contractId, {
+      method: "POST",
       body: JSON.stringify({ outcome }),
     }),
 
@@ -416,56 +482,90 @@ export const api = {
       activeContracts: number;
       pendingProofs: number;
       avgIntegrity: number;
-    }>('/admin/stats'),
+    }>("/admin/stats"),
+
+  escalateCrisis: (userId: string, trigger: string) =>
+    request<{
+      message: string;
+      resources: Array<{ name: string; contact: string; instructions: string }>;
+      actionTaken: string;
+      escalated: boolean;
+    }>("/admin/crisis/escalate", {
+      method: "POST",
+      body: JSON.stringify({ userId, trigger }),
+    }),
+
+  getCrisisEvents: (limit?: number) =>
+    request<{
+      events: Array<{
+        id: string;
+        user_id: string;
+        severity: string;
+        trigger: string;
+        matched_keywords: string;
+        escalated: boolean;
+        created_at: string;
+      }>;
+    }>(`/admin/crisis/events${limit ? `?limit=${limit}` : ""}`),
 
   getDisputes: () =>
-    request<Array<{
-      id: string;
-      contract_id: string;
-      user_id: string;
-      media_uri: string;
-      status: string;
-      submitted_at: string;
-      email: string;
-      oath_category: string;
-    }>>('/admin/disputes'),
+    request<
+      Array<{
+        id: string;
+        contract_id: string;
+        user_id: string;
+        media_uri: string;
+        status: string;
+        submitted_at: string;
+        email: string;
+        oath_category: string;
+      }>
+    >("/admin/disputes"),
 
   // User profile / history
   getIntegrityHistory: () =>
-    request<Array<{
-      event_type: string;
-      payload: Record<string, unknown>;
-      created_at: string;
-    }>>('/users/me/history'),
+    request<
+      Array<{
+        event_type: string;
+        payload: Record<string, unknown>;
+        created_at: string;
+      }>
+    >("/users/me/history"),
 
   // Settings
-  changePassword: (currentPassword: string, newPassword: string) => // allow-secret
-    request<{ status: string }>('/users/me/password', {
-      method: 'PATCH',
+  changePassword: (
+    currentPassword: string,
+    newPassword: string, // allow-secret
+  ) =>
+    request<{ status: string }>("/users/me/password", {
+      method: "PATCH",
       body: JSON.stringify({ currentPassword, newPassword }),
     }),
 
-  updateSettings: (settings: { emailNotifications?: boolean; pushNotifications?: boolean }) =>
-    request<{ status: string }>('/users/me/settings', {
-      method: 'PATCH',
+  updateSettings: (settings: {
+    emailNotifications?: boolean;
+    pushNotifications?: boolean;
+  }) =>
+    request<{ status: string }>("/users/me/settings", {
+      method: "PATCH",
       body: JSON.stringify(settings),
     }),
 
   deleteAccount: () =>
-    request<{ status: string }>('/users/me', {
-      method: 'DELETE',
+    request<{ status: string }>("/users/me", {
+      method: "DELETE",
     }),
 
   // AI
   grillMe: (slideContent: string) =>
-    request<{ questions: string[] }>('/ai/grill-me', {
-      method: 'POST',
+    request<{ questions: string[] }>("/ai/grill-me", {
+      method: "POST",
       body: JSON.stringify({ slideContent }),
     }),
 
   eli5: (text: string) =>
-    request<{ explanation: string }>('/ai/eli5', {
-      method: 'POST',
+    request<{ explanation: string }>("/ai/eli5", {
+      method: "POST",
       body: JSON.stringify({ text }),
     }),
 
@@ -481,17 +581,20 @@ export const api = {
       netEarnings: number;
       honeypotsCaught: number;
       honeypotsFailedOn: number;
-    }>('/fury/stats'),
+    }>("/fury/stats"),
 
   requestFuryStreamTicket: () =>
-    request<{ ticket: string; expiresInSeconds: number }>('/fury/stream-ticket', {
-      method: 'POST',
-    }),
+    request<{ ticket: string; expiresInSeconds: number }>(
+      "/fury/stream-ticket",
+      {
+        method: "POST",
+      },
+    ),
 
   issueFuryStreamCookie: () =>
-    request<{ expiresInSeconds: number }>('/fury/stream-cookie', {
-      method: 'POST',
-      credentials: 'include',
+    request<{ expiresInSeconds: number }>("/fury/stream-cookie", {
+      method: "POST",
+      credentials: "include",
     }),
 
   // Attestations (Recovery stream)
@@ -508,15 +611,17 @@ export const api = {
 
   submitAttestation: (contractId: string) =>
     request<{ status: string }>(`/contracts/${contractId}/attestation`, {
-      method: 'POST',
+      method: "POST",
     }),
 
   // Public feed (no auth)
   getPublicFeed: (limit?: number) =>
-    request<{ events: Array<{
-      id: string;
-      type: string;
-      message: string;
-      timestamp: string;
-    }> }>(`/feed${limit ? `?limit=${limit}` : ''}`),
+    request<{
+      events: Array<{
+        id: string;
+        type: string;
+        message: string;
+        timestamp: string;
+      }>;
+    }>(`/feed${limit ? `?limit=${limit}` : ""}`),
 };

--- a/src/web/services/api-client.ts
+++ b/src/web/services/api-client.ts
@@ -490,7 +490,7 @@ export const api = {
       resources: Array<{ name: string; contact: string; instructions: string }>;
       actionTaken: string;
       escalated: boolean;
-    }>("/admin/crisis/escalate", {
+    }>("/crisis/escalate", {
       method: "POST",
       body: JSON.stringify({ userId, trigger }),
     }),


### PR DESCRIPTION
## Summary

Builds the user-facing intervention flow UI that displays when a guardrail is triggered. Users land on this page instead of proceeding with a flagged action.

### Changes

**`src/web/components/guardrails/CrisisIntervention.tsx`** — Reusable component:
- Severity-aware banner (info/warning/critical with color coding)
- Guardrail trigger explanation — shows what paused the action
- Crisis support resources card (National Crisis Hotline 988, Crisis Text Line 741741, SAMHSA 1-800-662-4357)
- Live cooldown countdown timer with progress bar
- "Request Support Escalation" button that calls `POST /admin/crisis/escalate`
- Supports both embedded (`embedded` prop) and full-page modes
- Optional dismiss handler to return to dashboard

**`src/web/app/guardrails/page.tsx`** — Route page at `/guardrails?severity=&trigger=&cooldown=`:
- Reads severity, trigger message, and cooldown duration from query params
- Passes auth context for user ID with escalation
- Redirects to `/dashboard` on dismiss

**`src/web/services/api-client.ts`** — Added two API methods:
- `escalateCrisis(userId, trigger)` — calls the POST escalation endpoint
- `getCrisisEvents(limit?)` — lists crisis events

### UI Conventions
- Dark theme matching existing Styx admin/dashboard styling
- Uses lucide-react icons (Heart, AlertTriangle, Phone, Clock, Shield)
- Tailwind CSS with the same neutral-900/black palette

**Closes #412**
