### PR TITLE
feat: geofence policy registry — admin CRUD, compliance logging, admin UI

### DIFF
--- a/src/api/src/modules/admin/admin.controller.ts
+++ b/src/api/src/modules/admin/admin.controller.ts
@@ -32,6 +32,7 @@ import {
   ResolveContractDto,
   UpdateJurisdictionDto,
 } from "./dto";
+import { JurisdictionDispositionMapper } from "../compliance/jurisdiction-disposition.mapper";
 
 @ApiTags("Admin")
 @ApiBearerAuth()
@@ -175,6 +176,41 @@ export class AdminController {
     });
 
     return { jurisdiction: result.rows[0] };
+  }
+
+  // --- Kill Switch (Refund-Only Override) ---
+
+  @Get("kill-switch")
+  @ApiOperation({
+    summary: "Get current kill switch status (refund-only mode)",
+  })
+  getKillSwitch() {
+    return {
+      refundOnlyMode: JurisdictionDispositionMapper.isRefundOnlyMode(),
+    };
+  }
+
+  @Post("kill-switch")
+  @ApiOperation({
+    summary: "Toggle kill switch — force all settlements to REFUND mode",
+  })
+  async setKillSwitch(
+    @Body() body: { enabled: boolean },
+    @CurrentUser() admin: { id: string },
+  ) {
+    JurisdictionDispositionMapper.setRefundOnlyMode(body.enabled);
+
+    await this.truthLog.appendEvent("KILL_SWITCH_TOGGLED", {
+      adminId: admin.id,
+      enabled: body.enabled,
+    });
+
+    return {
+      refundOnlyMode: body.enabled,
+      message: body.enabled
+        ? "Kill switch ACTIVE — all settlements forced to REFUND mode"
+        : "Kill switch INACTIVE — settlements follow jurisdiction policy",
+    };
   }
 
   // --- Integrity ---

--- a/src/api/src/modules/admin/admin.controller.ts
+++ b/src/api/src/modules/admin/admin.controller.ts
@@ -26,7 +26,12 @@ import { AnomalyService } from "../../../services/anomaly/anomaly.service";
 import { TruthLogService } from "../../../services/ledger/truth-log.service";
 import { IdentityVerificationService } from "../compliance/identity-verification.service";
 import { IdentityVerificationMode } from "../compliance/identity-provider.service";
-import { BanUserDto, CrisisEscalateDto, ResolveContractDto } from "./dto";
+import {
+  BanUserDto,
+  CrisisEscalateDto,
+  ResolveContractDto,
+  UpdateJurisdictionDto,
+} from "./dto";
 
 @ApiTags("Admin")
 @ApiBearerAuth()
@@ -88,6 +93,88 @@ export class AdminController {
       [safeLimit],
     );
     return { events: result.rows };
+  }
+
+  // --- Jurisdictions (Policy Registry) ---
+
+  @Get("jurisdictions")
+  @ApiOperation({
+    summary: "List all jurisdictions with their current policy tier",
+  })
+  async getJurisdictions() {
+    const result = await this.pool.query(
+      `SELECT code, name, tier, disposition_mode, updated_at
+       FROM jurisdictions
+       ORDER BY code`,
+    );
+    return { jurisdictions: result.rows };
+  }
+
+  @Get("jurisdictions/:code")
+  @ApiOperation({ summary: "Get a single jurisdiction by state code" })
+  async getJurisdiction(@Param("code") code: string) {
+    const result = await this.pool.query(
+      `SELECT code, name, tier, disposition_mode, updated_at
+       FROM jurisdictions
+       WHERE code = $1`,
+      [code.toUpperCase()],
+    );
+    if (result.rows.length === 0) {
+      return { error: "Jurisdiction not found", code: code.toUpperCase() };
+    }
+    return { jurisdiction: result.rows[0] };
+  }
+
+  @Patch("jurisdictions/:code")
+  @ApiOperation({ summary: "Update a jurisdiction's tier or disposition mode" })
+  async updateJurisdiction(
+    @Param("code") code: string,
+    @Body() body: UpdateJurisdictionDto,
+    @CurrentUser() admin: { id: string },
+  ) {
+    const normalizedCode = code.toUpperCase();
+    const existing = await this.pool.query(
+      "SELECT code, tier, disposition_mode FROM jurisdictions WHERE code = $1",
+      [normalizedCode],
+    );
+    if (existing.rows.length === 0) {
+      return { error: "Jurisdiction not found", code: normalizedCode };
+    }
+
+    const updates: string[] = [];
+    const values: unknown[] = [];
+    let paramIndex = 1;
+
+    if (body.tier) {
+      updates.push(`tier = $${paramIndex++}`);
+      values.push(body.tier);
+    }
+    if (body.dispositionMode) {
+      updates.push(`disposition_mode = $${paramIndex++}`);
+      values.push(body.dispositionMode);
+    }
+    if (updates.length === 0) {
+      return { error: "No fields to update" };
+    }
+
+    updates.push(`updated_at = NOW()`);
+    values.push(normalizedCode);
+
+    const result = await this.pool.query(
+      `UPDATE jurisdictions SET ${updates.join(", ")} WHERE code = $${paramIndex} RETURNING *`,
+      values,
+    );
+
+    await this.truthLog.appendEvent("JURISDICTION_POLICY_CHANGED", {
+      adminId: admin.id,
+      code: normalizedCode,
+      previousTier: existing.rows[0].tier,
+      newTier: body.tier ?? existing.rows[0].tier,
+      previousDisposition: existing.rows[0].disposition_mode,
+      newDisposition: body.dispositionMode ?? existing.rows[0].disposition_mode,
+    });
+
+    return { jurisdiction: result.rows[0] };
   }
 
   // --- Integrity ---

--- a/src/api/src/modules/admin/dto.ts
+++ b/src/api/src/modules/admin/dto.ts
@@ -28,3 +28,21 @@ export class CrisisEscalateDto {
   @IsString()
   trigger!: string;
 }
+
+export class UpdateJurisdictionDto {
+  @ApiProperty({
+    description: "Jurisdiction tier",
+    enum: ["FULL_ACCESS", "REFUND_ONLY", "HARD_BLOCK"],
+    required: false,
+  })
+  @IsEnum(["FULL_ACCESS", "REFUND_ONLY", "HARD_BLOCK"])
+  tier?: "FULL_ACCESS" | "REFUND_ONLY" | "HARD_BLOCK";
+
+  @ApiProperty({
+    description: "Disposition mode for settlements",
+    enum: ["HOUSE_RETAINED", "REFUND_ONLY"],
+    required: false,
+  })
+  @IsEnum(["HOUSE_RETAINED", "REFUND_ONLY"])
+  dispositionMode?: "HOUSE_RETAINED" | "REFUND_ONLY";
+}

--- a/src/api/src/modules/compliance/compliance-policy.service.ts
+++ b/src/api/src/modules/compliance/compliance-policy.service.ts
@@ -1,35 +1,46 @@
-import { Injectable, Logger, OnModuleInit, Optional } from '@nestjs/common';
-import { Request } from 'express';
-import * as geoip from 'geoip-lite';
-import { Pool } from 'pg';
-import { JurisdictionTier, STATE_TIERS, normalizeStateCode } from '../../../services/geofencing';
-import { IdentityVerificationService } from './identity-verification.service';
+import { Injectable, Logger, OnModuleInit, Optional } from "@nestjs/common";
+import { Request } from "express";
+import * as geoip from "geoip-lite";
+import { Pool } from "pg";
+import {
+  JurisdictionTier,
+  STATE_TIERS,
+  normalizeStateCode,
+} from "../../../services/geofencing";
+import { IdentityVerificationService } from "./identity-verification.service";
 
-export type ComplianceMode = 'FULL_ACCESS' | 'REFUND_ONLY' | 'BLOCKED';
+export type ComplianceMode = "FULL_ACCESS" | "REFUND_ONLY" | "BLOCKED";
 export type ComplianceAction =
-  | 'CREATE_CONTRACT'
-  | 'FILE_DISPUTE'
-  | 'PURCHASE_TICKET'
-  | 'SUBMIT_PROOF'
-  | 'REQUEST_PROOF_UPLOAD_URL'
-  | 'CONFIRM_PROOF_UPLOAD'
-  | 'READ_ONLY'
-  | 'UNKNOWN';
+  | "CREATE_CONTRACT"
+  | "FILE_DISPUTE"
+  | "PURCHASE_TICKET"
+  | "SUBMIT_PROOF"
+  | "REQUEST_PROOF_UPLOAD_URL"
+  | "CONFIRM_PROOF_UPLOAD"
+  | "READ_ONLY"
+  | "UNKNOWN";
 
 export interface ComplianceDecision {
   allowed: boolean;
-  code?: 'JURISDICTION_BLOCKED' | 'JURISDICTION_REFUND_ONLY_RESTRICTED' | 'KYC_REQUIRED' | 'AGE_VERIFICATION_REQUIRED';
+  code?:
+    | "JURISDICTION_BLOCKED"
+    | "JURISDICTION_REFUND_ONLY_RESTRICTED"
+    | "KYC_REQUIRED"
+    | "AGE_VERIFICATION_REQUIRED";
   message?: string;
   requiredMode: ComplianceMode;
   action: ComplianceAction;
   tier: JurisdictionTier;
   state: string | null;
-  stateSource: 'cf-ipstate' | 'x-styx-state' | 'ip-lookup' | 'none';
+  stateSource: "cf-ipstate" | "x-styx-state" | "ip-lookup" | "none";
   missingLocation: boolean;
   overrideIgnoredInProduction: boolean;
 }
 
-type ComplianceActionDecisionCore = Pick<ComplianceDecision, 'allowed' | 'code' | 'message' | 'requiredMode'>;
+type ComplianceActionDecisionCore = Pick<
+  ComplianceDecision,
+  "allowed" | "code" | "message" | "requiredMode"
+>;
 
 const MINIMUM_AGE_YEARS = 18;
 
@@ -37,21 +48,23 @@ const MINIMUM_AGE_YEARS = 18;
 export class CompliancePolicyService implements OnModuleInit {
   private readonly logger = new Logger(CompliancePolicyService.name);
 
-  private static readonly RESTRICTED_REFUND_ONLY_ACTIONS = new Set<ComplianceAction>([
-    'CREATE_CONTRACT',
-    'FILE_DISPUTE',
-    'PURCHASE_TICKET',
-  ]);
+  private static readonly RESTRICTED_REFUND_ONLY_ACTIONS =
+    new Set<ComplianceAction>([
+      "CREATE_CONTRACT",
+      "FILE_DISPUTE",
+      "PURCHASE_TICKET",
+    ]);
 
   private static readonly KYC_GATED_ACTIONS = new Set<ComplianceAction>([
-    'CREATE_CONTRACT',
-    'FILE_DISPUTE',
-    'PURCHASE_TICKET',
+    "CREATE_CONTRACT",
+    "FILE_DISPUTE",
+    "PURCHASE_TICKET",
   ]);
 
   constructor(
     private readonly pool: Pool,
-    @Optional() private readonly identityVerification?: IdentityVerificationService,
+    @Optional()
+    private readonly identityVerification?: IdentityVerificationService,
   ) {}
 
   /**
@@ -65,14 +78,14 @@ export class CompliancePolicyService implements OnModuleInit {
     if (this.isKycEnforcementEnabled()) return;
 
     const message =
-      'KYC enforcement is DISABLED. Contracts above the TIER_1 ($20) micro-stake ' +
-      'threshold can be created WITHOUT identity verification. The unconditional age ' +
-      'gate (>=18) still applies.';
+      "KYC enforcement is DISABLED. Contracts above the TIER_1 ($20) micro-stake " +
+      "threshold can be created WITHOUT identity verification. The unconditional age " +
+      "gate (>=18) still applies.";
 
     // In production the default is ON, so a disabled state can only mean someone set
     // KYC_ENFORCEMENT_ENABLED=false explicitly — that is a dangerous, deliberate
     // compliance decision and must be an error-level signal.
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env.NODE_ENV === "production") {
       this.logger.error(
         `${message} PRODUCTION has KYC_ENFORCEMENT_ENABLED=false — confirm this is an intentional, compliant decision.`,
       );
@@ -83,10 +96,12 @@ export class CompliancePolicyService implements OnModuleInit {
     }
   }
 
-  async getJurisdictionPolicy(code: string): Promise<{ tier: JurisdictionTier; dispositionMode: string } | null> {
+  async getJurisdictionPolicy(
+    code: string,
+  ): Promise<{ tier: JurisdictionTier; dispositionMode: string } | null> {
     const result = await this.pool.query(
-      'SELECT tier, disposition_mode FROM jurisdictions WHERE code = $1',
-      [code.toUpperCase()]
+      "SELECT tier, disposition_mode FROM jurisdictions WHERE code = $1",
+      [code.toUpperCase()],
     );
     if (result.rows.length === 0) return null;
     return {
@@ -96,13 +111,15 @@ export class CompliancePolicyService implements OnModuleInit {
   }
 
   isKycEnforcementEnabled(): boolean {
-    const flag = String(process.env.KYC_ENFORCEMENT_ENABLED ?? '').toLowerCase();
-    if (process.env.NODE_ENV === 'production') {
+    const flag = String(
+      process.env.KYC_ENFORCEMENT_ENABLED ?? "",
+    ).toLowerCase();
+    if (process.env.NODE_ENV === "production") {
       // Fail closed in production: enforce KYC unless EXPLICITLY disabled.
-      return flag !== 'false';
+      return flag !== "false";
     }
     // Non-production: opt-in so dev/test/local flows are not blocked by default.
-    return flag === 'true';
+    return flag === "true";
   }
 
   isAgeEnforcementImplemented(): boolean {
@@ -114,9 +131,11 @@ export class CompliancePolicyService implements OnModuleInit {
    * registration) and computes whole years. Fails CLOSED: if the DOB is missing or
    * unparseable we treat the user as not age-verified and block the monetized action.
    */
-  async evaluateAgeRequirement(userId: string): Promise<{ allowed: boolean; reason?: string }> {
+  async evaluateAgeRequirement(
+    userId: string,
+  ): Promise<{ allowed: boolean; reason?: string }> {
     const result = await this.pool.query(
-      'SELECT date_of_birth FROM users WHERE id = $1',
+      "SELECT date_of_birth FROM users WHERE id = $1",
       [userId],
     );
 
@@ -127,7 +146,8 @@ export class CompliancePolicyService implements OnModuleInit {
       // Missing / unparseable DOB -> fail closed.
       return {
         allowed: false,
-        reason: 'Date of birth is required to verify you meet the minimum age requirement.',
+        reason:
+          "Date of birth is required to verify you meet the minimum age requirement.",
       };
     }
 
@@ -194,43 +214,69 @@ export class CompliancePolicyService implements OnModuleInit {
     // Fail CLOSED by default everywhere (including production). A missing/unparseable
     // geo signal must never silently grant FULL_ACCESS — production must not be more
     // permissive than dev. Opening up requires an explicit, deliberate opt-in.
-    const explicitAction = String(process.env.GEO_MISSING_HEADER_ACTION || '').trim().toLowerCase();
+    const explicitAction = String(process.env.GEO_MISSING_HEADER_ACTION || "")
+      .trim()
+      .toLowerCase();
     if (explicitAction) {
-      return explicitAction === 'allow' || explicitAction === 'open' || explicitAction === 'true';
+      return (
+        explicitAction === "allow" ||
+        explicitAction === "open" ||
+        explicitAction === "true"
+      );
     }
 
     const raw = process.env.GEOFENCE_FAIL_OPEN_ON_MISSING_HEADERS;
     if (raw == null) return false; // fail-closed by default (Phase Beta P0-004)
-    return String(raw).toLowerCase() === 'true';
+    return String(raw).toLowerCase() === "true";
   }
 
-  canCreateContract(input: { tier: JurisdictionTier; state: string | null }): ComplianceActionDecisionCore {
-    return this.evaluateActionPolicy('CREATE_CONTRACT', input.tier, input.state);
+  canCreateContract(input: {
+    tier: JurisdictionTier;
+    state: string | null;
+  }): ComplianceActionDecisionCore {
+    return this.evaluateActionPolicy(
+      "CREATE_CONTRACT",
+      input.tier,
+      input.state,
+    );
   }
 
-  canSubmitProof(input: { tier: JurisdictionTier; state: string | null }): ComplianceActionDecisionCore {
-    return this.evaluateActionPolicy('SUBMIT_PROOF', input.tier, input.state);
+  canSubmitProof(input: {
+    tier: JurisdictionTier;
+    state: string | null;
+  }): ComplianceActionDecisionCore {
+    return this.evaluateActionPolicy("SUBMIT_PROOF", input.tier, input.state);
   }
 
-  canPurchaseTicket(input: { tier: JurisdictionTier; state: string | null }): ComplianceActionDecisionCore {
-    return this.evaluateActionPolicy('PURCHASE_TICKET', input.tier, input.state);
+  canPurchaseTicket(input: {
+    tier: JurisdictionTier;
+    state: string | null;
+  }): ComplianceActionDecisionCore {
+    return this.evaluateActionPolicy(
+      "PURCHASE_TICKET",
+      input.tier,
+      input.state,
+    );
   }
 
   getEligibility(req: Request) {
     const location = this.resolveStateFromRequest(req);
-    const tier = location.state 
-      ? (STATE_TIERS[location.state] ?? JurisdictionTier.TIER_3) 
-      : (this.shouldFailOpenOnMissingLocation() ? JurisdictionTier.TIER_1 : JurisdictionTier.TIER_3);
+    const tier = location.state
+      ? (STATE_TIERS[location.state] ?? JurisdictionTier.TIER_3)
+      : this.shouldFailOpenOnMissingLocation()
+        ? JurisdictionTier.TIER_1
+        : JurisdictionTier.TIER_3;
 
     const create = this.canCreateContract({ tier, state: location.state });
     const proof = this.canSubmitProof({ tier, state: location.state });
     const ticket = this.canPurchaseTicket({ tier, state: location.state });
 
-    const requiredMode: ComplianceMode = tier === JurisdictionTier.TIER_3
-      ? 'BLOCKED'
-      : tier === JurisdictionTier.TIER_2
-        ? 'REFUND_ONLY'
-        : 'FULL_ACCESS';
+    const requiredMode: ComplianceMode =
+      tier === JurisdictionTier.TIER_3
+        ? "BLOCKED"
+        : tier === JurisdictionTier.TIER_2
+          ? "REFUND_ONLY"
+          : "FULL_ACCESS";
 
     return {
       requiredMode,
@@ -252,7 +298,42 @@ export class CompliancePolicyService implements OnModuleInit {
     };
   }
 
-  async evaluateUserComplianceForRequest(req: Request, userId: string): Promise<ComplianceActionDecisionCore> {
+  /**
+   * Log a compliance decision to the audit trail.
+   * Fire-and-forget — logging failures must never block the request.
+   */
+  private async logDecision(
+    userId: string | null,
+    action: ComplianceAction,
+    decision: ComplianceDecision,
+  ): Promise<void> {
+    try {
+      await this.pool.query(
+        `INSERT INTO compliance_decisions (user_id, action, jurisdiction_code, tier, allowed, reason_code, metadata)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [
+          userId,
+          action,
+          decision.state,
+          decision.tier,
+          decision.allowed,
+          decision.code ?? null,
+          JSON.stringify({
+            stateSource: decision.stateSource,
+            missingLocation: decision.missingLocation,
+            requiredMode: decision.requiredMode,
+          }),
+        ],
+      );
+    } catch (err) {
+      this.logger.error("Failed to log compliance decision", err);
+    }
+  }
+
+  async evaluateUserComplianceForRequest(
+    req: Request,
+    userId: string,
+  ): Promise<ComplianceActionDecisionCore> {
     const baseDecision = this.evaluateRequestPolicy(req);
     if (!baseDecision.allowed) {
       return {
@@ -265,8 +346,8 @@ export class CompliancePolicyService implements OnModuleInit {
 
     if (baseDecision.state) {
       await this.pool.query(
-        'UPDATE users SET last_known_state = $1 WHERE id = $2',
-        [baseDecision.state, userId]
+        "UPDATE users SET last_known_state = $1 WHERE id = $2",
+        [baseDecision.state, userId],
       );
     }
 
@@ -278,8 +359,10 @@ export class CompliancePolicyService implements OnModuleInit {
       if (!age.allowed) {
         return {
           allowed: false,
-          code: 'AGE_VERIFICATION_REQUIRED',
-          message: age.reason ?? 'Age verification is required before performing this monetized action.',
+          code: "AGE_VERIFICATION_REQUIRED",
+          message:
+            age.reason ??
+            "Age verification is required before performing this monetized action.",
           requiredMode: baseDecision.requiredMode,
         };
       }
@@ -300,14 +383,29 @@ export class CompliancePolicyService implements OnModuleInit {
       : null;
 
     if (!compliance?.isKycVerified) {
+      const decision: ComplianceDecision = {
+        ...baseDecision,
+        allowed: false,
+        code: "KYC_REQUIRED",
+        message:
+          "Identity verification is required before performing this monetized action.",
+        requiredMode: baseDecision.requiredMode,
+      };
+      await this.logDecision(userId, baseDecision.action, decision);
       return {
         allowed: false,
-        code: 'KYC_REQUIRED',
-        message: 'Identity verification is required before performing this monetized action.',
+        code: "KYC_REQUIRED",
+        message: decision.message,
         requiredMode: baseDecision.requiredMode,
       };
     }
 
+    const allowedDecision: ComplianceDecision = {
+      ...baseDecision,
+      allowed: true,
+      requiredMode: baseDecision.requiredMode,
+    };
+    await this.logDecision(userId, baseDecision.action, allowedDecision);
     return {
       allowed: true,
       requiredMode: baseDecision.requiredMode,
@@ -317,17 +415,19 @@ export class CompliancePolicyService implements OnModuleInit {
   evaluateRequestPolicy(req: Request): ComplianceDecision {
     const location = this.resolveStateFromRequest(req);
     const state = location.state;
-    const tier = state 
-      ? (STATE_TIERS[state] ?? JurisdictionTier.TIER_3) 
-      : (this.shouldFailOpenOnMissingLocation() ? JurisdictionTier.TIER_1 : JurisdictionTier.TIER_3);
+    const tier = state
+      ? (STATE_TIERS[state] ?? JurisdictionTier.TIER_3)
+      : this.shouldFailOpenOnMissingLocation()
+        ? JurisdictionTier.TIER_1
+        : JurisdictionTier.TIER_3;
     const action = this.resolveActionFromRequest(req);
 
     if (!state && !this.shouldFailOpenOnMissingLocation()) {
       return {
         allowed: false,
-        code: 'JURISDICTION_BLOCKED',
-        message: 'Location verification is required to access this endpoint.',
-        requiredMode: 'BLOCKED',
+        code: "JURISDICTION_BLOCKED",
+        message: "Location verification is required to access this endpoint.",
+        requiredMode: "BLOCKED",
         action,
         tier,
         state: null,
@@ -357,24 +457,29 @@ export class CompliancePolicyService implements OnModuleInit {
     if (tier === JurisdictionTier.TIER_3) {
       return {
         allowed: false,
-        code: 'JURISDICTION_BLOCKED',
-        message: 'Styx Protocol is legally restricted in your jurisdiction. Geofencing enforcement active.',
-        requiredMode: 'BLOCKED',
+        code: "JURISDICTION_BLOCKED",
+        message:
+          "Styx Protocol is legally restricted in your jurisdiction. Geofencing enforcement active.",
+        requiredMode: "BLOCKED",
       };
     }
 
-    if (tier === JurisdictionTier.TIER_2 && CompliancePolicyService.RESTRICTED_REFUND_ONLY_ACTIONS.has(action)) {
+    if (
+      tier === JurisdictionTier.TIER_2 &&
+      CompliancePolicyService.RESTRICTED_REFUND_ONLY_ACTIONS.has(action)
+    ) {
       return {
         allowed: false,
-        code: 'JURISDICTION_REFUND_ONLY_RESTRICTED',
-        message: `This action is unavailable in your jurisdiction while Styx is operating in refund-only mode${state ? ` (${state})` : ''}.`,
-        requiredMode: 'REFUND_ONLY',
+        code: "JURISDICTION_REFUND_ONLY_RESTRICTED",
+        message: `This action is unavailable in your jurisdiction while Styx is operating in refund-only mode${state ? ` (${state})` : ""}.`,
+        requiredMode: "REFUND_ONLY",
       };
     }
 
     return {
       allowed: true,
-      requiredMode: tier === JurisdictionTier.TIER_2 ? 'REFUND_ONLY' : 'FULL_ACCESS',
+      requiredMode:
+        tier === JurisdictionTier.TIER_2 ? "REFUND_ONLY" : "FULL_ACCESS",
     };
   }
 
@@ -386,12 +491,16 @@ export class CompliancePolicyService implements OnModuleInit {
    * opt-in (default OFF / fail-closed).
    */
   private trustProxyHeaders(): boolean {
-    return String(process.env.TRUST_PROXY_HEADERS || 'false').trim().toLowerCase() === 'true';
+    return (
+      String(process.env.TRUST_PROXY_HEADERS || "false")
+        .trim()
+        .toLowerCase() === "true"
+    );
   }
 
   private resolveStateFromRequest(req: Request): {
     state: string | null;
-    source: 'cf-ipstate' | 'x-styx-state' | 'ip-lookup' | 'none';
+    source: "cf-ipstate" | "x-styx-state" | "ip-lookup" | "none";
     overrideIgnoredInProduction: boolean;
   } {
     const trustProxy = this.trustProxyHeaders();
@@ -400,22 +509,26 @@ export class CompliancePolicyService implements OnModuleInit {
     // we are actually behind Cloudflare (TRUST_PROXY_HEADERS=true); otherwise a client
     // could spoof it to bypass a PROHIBITED jurisdiction block.
     if (trustProxy) {
-      const cfIpState = normalizeStateCode(this.toSingleHeaderValue(req.headers['cf-ipstate']));
+      const cfIpState = normalizeStateCode(
+        this.toSingleHeaderValue(req.headers["cf-ipstate"]),
+      );
       if (cfIpState) {
         return {
           state: cfIpState,
-          source: 'cf-ipstate',
+          source: "cf-ipstate",
           overrideIgnoredInProduction: false,
         };
       }
     }
 
-    const override = normalizeStateCode(this.toSingleHeaderValue(req.headers['x-styx-state']));
-    const isProduction = process.env.NODE_ENV === 'production';
+    const override = normalizeStateCode(
+      this.toSingleHeaderValue(req.headers["x-styx-state"]),
+    );
+    const isProduction = process.env.NODE_ENV === "production";
     if (override && !isProduction) {
       return {
         state: override,
-        source: 'x-styx-state',
+        source: "x-styx-state",
         overrideIgnoredInProduction: false,
       };
     }
@@ -424,44 +537,55 @@ export class CompliancePolicyService implements OnModuleInit {
     if (ipState) {
       return {
         state: ipState,
-        source: 'ip-lookup',
+        source: "ip-lookup",
         overrideIgnoredInProduction: !!override && isProduction,
       };
     }
 
     return {
       state: null,
-      source: 'none',
+      source: "none",
       overrideIgnoredInProduction: !!override && isProduction,
     };
   }
 
   private resolveActionFromRequest(req: Request): ComplianceAction {
-    const method = String(req.method || 'GET').toUpperCase();
-    const path = String(req.originalUrl || req.url || '');
+    const method = String(req.method || "GET").toUpperCase();
+    const path = String(req.originalUrl || req.url || "");
 
-    if (method === 'POST' && /^\/contracts\/?$/.test(path)) return 'CREATE_CONTRACT';
-    if (method === 'POST' && /^\/contracts\/[^/]+\/dispute\/?$/.test(path)) return 'FILE_DISPUTE';
-    if (method === 'POST' && /^\/contracts\/[^/]+\/ticket\/?$/.test(path)) return 'PURCHASE_TICKET';
-    if (method === 'POST' && /^\/contracts\/[^/]+\/proof\/?$/.test(path)) return 'SUBMIT_PROOF';
-    if (method === 'POST' && /^\/proofs\/upload-url\/?$/.test(path)) return 'REQUEST_PROOF_UPLOAD_URL';
-    if (method === 'POST' && /^\/proofs\/[^/]+\/confirm-upload\/?$/.test(path)) return 'CONFIRM_PROOF_UPLOAD';
-    if (method === 'GET' || method === 'HEAD') return 'READ_ONLY';
-    return 'UNKNOWN';
+    if (method === "POST" && /^\/contracts\/?$/.test(path))
+      return "CREATE_CONTRACT";
+    if (method === "POST" && /^\/contracts\/[^/]+\/dispute\/?$/.test(path))
+      return "FILE_DISPUTE";
+    if (method === "POST" && /^\/contracts\/[^/]+\/ticket\/?$/.test(path))
+      return "PURCHASE_TICKET";
+    if (method === "POST" && /^\/contracts\/[^/]+\/proof\/?$/.test(path))
+      return "SUBMIT_PROOF";
+    if (method === "POST" && /^\/proofs\/upload-url\/?$/.test(path))
+      return "REQUEST_PROOF_UPLOAD_URL";
+    if (method === "POST" && /^\/proofs\/[^/]+\/confirm-upload\/?$/.test(path))
+      return "CONFIRM_PROOF_UPLOAD";
+    if (method === "GET" || method === "HEAD") return "READ_ONLY";
+    return "UNKNOWN";
   }
 
-  private toSingleHeaderValue(value: string | string[] | undefined): string | null {
+  private toSingleHeaderValue(
+    value: string | string[] | undefined,
+  ): string | null {
     if (!value) return null;
     if (Array.isArray(value)) return value[0] ?? null;
     return value;
   }
 
-  private lookupStateFromRequestIp(req: Request, trustProxy: boolean): string | null {
+  private lookupStateFromRequestIp(
+    req: Request,
+    trustProxy: boolean,
+  ): string | null {
     const ip = this.extractClientIp(req, trustProxy);
     if (!ip) return null;
 
     const geo = geoip.lookup(ip);
-    if (!geo || geo.country !== 'US' || !geo.region) {
+    if (!geo || geo.country !== "US" || !geo.region) {
       return null;
     }
 
@@ -478,16 +602,19 @@ export class CompliancePolicyService implements OnModuleInit {
   private extractClientIp(req: Request, trustProxy: boolean): string | null {
     const socketIp =
       req.socket?.remoteAddress ||
-      (req.connection as { remoteAddress?: string } | undefined)?.remoteAddress ||
+      (req.connection as { remoteAddress?: string } | undefined)
+        ?.remoteAddress ||
       null;
 
     let candidate: string | null = null;
     if (trustProxy) {
-      const forwardedFor = this.toSingleHeaderValue(req.headers['x-forwarded-for']);
+      const forwardedFor = this.toSingleHeaderValue(
+        req.headers["x-forwarded-for"],
+      );
       candidate =
-        this.toSingleHeaderValue(req.headers['cf-connecting-ip']) ||
-        forwardedFor?.split(',')[0]?.trim() ||
-        this.toSingleHeaderValue(req.headers['x-real-ip']) ||
+        this.toSingleHeaderValue(req.headers["cf-connecting-ip"]) ||
+        forwardedFor?.split(",")[0]?.trim() ||
+        this.toSingleHeaderValue(req.headers["x-real-ip"]) ||
         req.ip ||
         socketIp ||
         null;
@@ -497,6 +624,6 @@ export class CompliancePolicyService implements OnModuleInit {
     }
 
     if (!candidate) return null;
-    return candidate.replace(/^::ffff:/, '').trim() || null;
+    return candidate.replace(/^::ffff:/, "").trim() || null;
   }
 }

--- a/src/api/src/modules/compliance/jurisdiction-disposition.mapper.spec.ts
+++ b/src/api/src/modules/compliance/jurisdiction-disposition.mapper.spec.ts
@@ -1,0 +1,218 @@
+import { JurisdictionDispositionMapper } from "./jurisdiction-disposition.mapper";
+import { JurisdictionTier } from "../../../services/geofencing";
+
+describe("JurisdictionDispositionMapper", () => {
+  beforeEach(() => {
+    JurisdictionDispositionMapper.setRefundOnlyMode(false);
+  });
+
+  describe("getDispositionMode", () => {
+    it("should return CAPTURE for TIER_1 (FULL_ACCESS)", () => {
+      expect(
+        JurisdictionDispositionMapper.getDispositionMode(
+          JurisdictionTier.TIER_1,
+        ),
+      ).toBe("CAPTURE");
+    });
+
+    it("should return REFUND for TIER_2 (REFUND_ONLY)", () => {
+      expect(
+        JurisdictionDispositionMapper.getDispositionMode(
+          JurisdictionTier.TIER_2,
+        ),
+      ).toBe("REFUND");
+    });
+
+    it("should return REFUND for TIER_3 (HARD_BLOCK)", () => {
+      expect(
+        JurisdictionDispositionMapper.getDispositionMode(
+          JurisdictionTier.TIER_3,
+        ),
+      ).toBe("REFUND");
+    });
+
+    it("should return REFUND for null tier (fail-closed)", () => {
+      expect(JurisdictionDispositionMapper.getDispositionMode(null)).toBe(
+        "REFUND",
+      );
+    });
+
+    it("should return REFUND for undefined tier (fail-closed)", () => {
+      expect(JurisdictionDispositionMapper.getDispositionMode(undefined)).toBe(
+        "REFUND",
+      );
+    });
+  });
+
+  describe("kill switch (refund-only mode)", () => {
+    it("should return REFUND for TIER_1 when kill switch is active", () => {
+      JurisdictionDispositionMapper.setRefundOnlyMode(true);
+      expect(
+        JurisdictionDispositionMapper.getDispositionMode(
+          JurisdictionTier.TIER_1,
+        ),
+      ).toBe("REFUND");
+    });
+
+    it("should return REFUND for TIER_2 when kill switch is active", () => {
+      JurisdictionDispositionMapper.setRefundOnlyMode(true);
+      expect(
+        JurisdictionDispositionMapper.getDispositionMode(
+          JurisdictionTier.TIER_2,
+        ),
+      ).toBe("REFUND");
+    });
+
+    it("should return REFUND for TIER_3 when kill switch is active", () => {
+      JurisdictionDispositionMapper.setRefundOnlyMode(true);
+      expect(
+        JurisdictionDispositionMapper.getDispositionMode(
+          JurisdictionTier.TIER_3,
+        ),
+      ).toBe("REFUND");
+    });
+
+    it("should return REFUND for null when kill switch is active", () => {
+      JurisdictionDispositionMapper.setRefundOnlyMode(true);
+      expect(JurisdictionDispositionMapper.getDispositionMode(null)).toBe(
+        "REFUND",
+      );
+    });
+
+    it("should revert to normal behavior when kill switch is deactivated", () => {
+      JurisdictionDispositionMapper.setRefundOnlyMode(true);
+      expect(
+        JurisdictionDispositionMapper.getDispositionMode(
+          JurisdictionTier.TIER_1,
+        ),
+      ).toBe("REFUND");
+
+      JurisdictionDispositionMapper.setRefundOnlyMode(false);
+      expect(
+        JurisdictionDispositionMapper.getDispositionMode(
+          JurisdictionTier.TIER_1,
+        ),
+      ).toBe("CAPTURE");
+    });
+  });
+
+  describe("isRefundOnlyMode", () => {
+    it("should return false by default", () => {
+      expect(JurisdictionDispositionMapper.isRefundOnlyMode()).toBe(false);
+    });
+
+    it("should return true when set", () => {
+      JurisdictionDispositionMapper.setRefundOnlyMode(true);
+      expect(JurisdictionDispositionMapper.isRefundOnlyMode()).toBe(true);
+    });
+
+    it("should return false when unset", () => {
+      JurisdictionDispositionMapper.setRefundOnlyMode(true);
+      JurisdictionDispositionMapper.setRefundOnlyMode(false);
+      expect(JurisdictionDispositionMapper.isRefundOnlyMode()).toBe(false);
+    });
+  });
+
+  describe("payout matrix — all configured states", () => {
+    // TIER_1 states: CAPTURE
+    const tier1States = [
+      "CA",
+      "TX",
+      "FL",
+      "IL",
+      "OH",
+      "GA",
+      "NC",
+      "MI",
+      "NJ",
+      "MA",
+      "WI",
+      "MN",
+      "CO",
+      "AL",
+      "MD",
+      "MO",
+      "OK",
+      "OR",
+      "KY",
+      "NV",
+      "KS",
+      "NE",
+      "MS",
+      "NM",
+      "WV",
+      "NH",
+      "ND",
+      "SD",
+      "DE",
+      "RI",
+      "VT",
+      "WY",
+      "AK",
+      "DC",
+    ];
+
+    // TIER_2 states: REFUND
+    const tier2States = [
+      "NY",
+      "CT",
+      "MT",
+      "AZ",
+      "IA",
+      "LA",
+      "ME",
+      "TN",
+      "VA",
+      "IN",
+      "PA",
+    ];
+
+    // TIER_3 states: REFUND
+    const tier3States = ["WA", "AR", "HI", "UT", "ID", "SC"];
+
+    it.each(tier1States)(
+      "should return CAPTURE for TIER_1 state %s",
+      (state) => {
+        expect(
+          JurisdictionDispositionMapper.getDispositionMode(
+            JurisdictionTier.TIER_1,
+          ),
+        ).toBe("CAPTURE");
+      },
+    );
+
+    it.each(tier2States)(
+      "should return REFUND for TIER_2 state %s",
+      (state) => {
+        expect(
+          JurisdictionDispositionMapper.getDispositionMode(
+            JurisdictionTier.TIER_2,
+          ),
+        ).toBe("REFUND");
+      },
+    );
+
+    it.each(tier3States)(
+      "should return REFUND for TIER_3 state %s",
+      (state) => {
+        expect(
+          JurisdictionDispositionMapper.getDispositionMode(
+            JurisdictionTier.TIER_3,
+          ),
+        ).toBe("REFUND");
+      },
+    );
+
+    it("should return REFUND for all states when kill switch is active", () => {
+      JurisdictionDispositionMapper.setRefundOnlyMode(true);
+      const allStates = [...tier1States, ...tier2States, ...tier3States];
+      for (const state of allStates) {
+        expect(
+          JurisdictionDispositionMapper.getDispositionMode(
+            JurisdictionTier.TIER_1,
+          ),
+        ).toBe("REFUND");
+      }
+    });
+  });
+});

--- a/src/api/src/modules/compliance/jurisdiction-disposition.mapper.ts
+++ b/src/api/src/modules/compliance/jurisdiction-disposition.mapper.ts
@@ -1,32 +1,54 @@
-import { JurisdictionTier } from '../../../services/geofencing';
+import { JurisdictionTier } from "../../../services/geofencing";
 
 /**
  * JurisdictionDispositionMapper
- * 
+ *
  * Determines whether a failed contract's stake should be CAPTURED (as a penalty)
  * or REFUNDED (due to jurisdictional restrictions on financial penalties/gambling).
  */
 
-export type DispositionMode = 'CAPTURE' | 'REFUND';
+export type DispositionMode = "CAPTURE" | "REFUND";
 
 export class JurisdictionDispositionMapper {
   /**
+   * Kill switch: when REFUND_ONLY_MODE is enabled, ALL settlements are forced to
+   * REFUND regardless of jurisdiction. This is an emergency override for compliance
+   * incidents or legal requirement changes.
+   */
+  private static refundOnlyMode = false;
+
+  static setRefundOnlyMode(enabled: boolean): void {
+    this.refundOnlyMode = enabled;
+  }
+
+  static isRefundOnlyMode(): boolean {
+    return this.refundOnlyMode;
+  }
+
+  /**
    * Safety-First: Any unresolved tier or unknown mode fails closed to REFUND.
    * This prevents accidental illegal capture in restrictive jurisdictions.
+   * When kill switch is active, ALL dispositions are REFUND.
    */
-  public static getDispositionMode(tier: JurisdictionTier | null | undefined): DispositionMode {
+  public static getDispositionMode(
+    tier: JurisdictionTier | null | undefined,
+  ): DispositionMode {
+    if (this.refundOnlyMode) {
+      return "REFUND";
+    }
+
     switch (tier) {
       case JurisdictionTier.TIER_1:
-        return 'CAPTURE'; // Predominance states — penalty allowed
-      
+        return "CAPTURE"; // Predominance states — penalty allowed
+
       case JurisdictionTier.TIER_2:
-        return 'REFUND';  // Material element states — refund required
-      
+        return "REFUND"; // Material element states — refund required
+
       case JurisdictionTier.TIER_3:
-        return 'REFUND';  // Hard-blocked — refund and exit
-      
+        return "REFUND"; // Hard-blocked — refund and exit
+
       default:
-        return 'REFUND';  // Fail-closed
+        return "REFUND"; // Fail-closed
     }
   }
 }

--- a/src/web/app/admin/jurisdictions/page.tsx
+++ b/src/web/app/admin/jurisdictions/page.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import React, { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  Loader2,
+  AlertTriangle,
+  MapPin,
+  Save,
+  RefreshCw,
+} from "lucide-react";
+import { api } from "../../../services/api-client";
+import { useAuth } from "../../../contexts/AuthContext";
+
+interface Jurisdiction {
+  code: string;
+  name: string;
+  tier: string;
+  disposition_mode: string;
+  updated_at: string;
+}
+
+const TIER_LABELS: Record<string, string> = {
+  FULL_ACCESS: "TIER 1 — Full Access",
+  REFUND_ONLY: "TIER 2 — Refund Only",
+  HARD_BLOCK: "TIER 3 — Hard Block",
+};
+
+const TIER_COLORS: Record<string, string> = {
+  FULL_ACCESS: "bg-green-900/50 text-green-400 border-green-800",
+  REFUND_ONLY: "bg-yellow-900/50 text-yellow-400 border-yellow-800",
+  HARD_BLOCK: "bg-red-900/50 text-red-400 border-red-800",
+};
+
+export default function JurisdictionsPage() {
+  const { user: authUser, isLoading: authLoading } = useAuth();
+  const [jurisdictions, setJurisdictions] = useState<Jurisdiction[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [filter, setFilter] = useState<string>("ALL");
+
+  const loadJurisdictions = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await api.getJurisdictions();
+      setJurisdictions(data.jurisdictions || []);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load jurisdictions",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (authLoading || !authUser) return;
+    if (authUser.role !== "ADMIN") {
+      setError("Forbidden: ADMIN role required");
+      setLoading(false);
+      return;
+    }
+    loadJurisdictions();
+  }, [authUser, authLoading, loadJurisdictions]);
+
+  const handleTierChange = async (code: string, newTier: string) => {
+    setSaving(code);
+    try {
+      await api.updateJurisdiction(code, { tier: newTier });
+      setJurisdictions((prev) =>
+        prev.map((j) => (j.code === code ? { ...j, tier: newTier } : j)),
+      );
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to update jurisdiction",
+      );
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const filtered =
+    filter === "ALL"
+      ? jurisdictions
+      : jurisdictions.filter((j) => j.tier === filter);
+
+  const tierCounts = jurisdictions.reduce(
+    (acc, j) => {
+      acc[j.tier] = (acc[j.tier] || 0) + 1;
+      return acc;
+    },
+    {} as Record<string, number>,
+  );
+
+  if (authLoading || loading) {
+    return (
+      <div className="min-h-screen bg-black text-white flex items-center justify-center">
+        <Loader2 className="animate-spin mr-3" size={24} />
+        <span className="text-neutral-400 font-bold">
+          Loading jurisdictions...
+        </span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-black text-white flex items-center justify-center">
+        <div className="text-center space-y-4">
+          <AlertTriangle className="mx-auto text-red-500" size={48} />
+          <p className="text-red-400 font-bold">{error}</p>
+          <Link
+            href="/admin"
+            className="text-neutral-400 hover:text-white underline"
+          >
+            Back to Admin
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-black text-white font-sans p-6 md:p-12 max-w-6xl mx-auto">
+      <div className="flex items-center gap-4 mb-8">
+        <Link
+          href="/admin"
+          className="text-neutral-400 hover:text-white transition-colors"
+        >
+          <ArrowLeft size={24} />
+        </Link>
+        <div className="flex items-center gap-3">
+          <MapPin className="text-blue-500" size={28} />
+          <h1 className="text-2xl font-black tracking-tight uppercase">
+            Jurisdiction Policy Registry
+          </h1>
+        </div>
+        <button
+          onClick={loadJurisdictions}
+          className="ml-auto p-2 text-neutral-400 hover:text-white transition-colors"
+          title="Refresh"
+        >
+          <RefreshCw size={20} />
+        </button>
+      </div>
+
+      {/* Tier Summary */}
+      <div className="grid grid-cols-3 gap-4 mb-8">
+        {Object.entries(TIER_LABELS).map(([tier, label]) => (
+          <button
+            key={tier}
+            onClick={() => setFilter(filter === tier ? "ALL" : tier)}
+            className={`p-4 rounded-2xl border text-center transition-colors ${
+              filter === tier
+                ? TIER_COLORS[tier]
+                : "bg-neutral-900 border-neutral-800 text-neutral-400 hover:border-neutral-600"
+            }`}
+          >
+            <p className="text-2xl font-black">{tierCounts[tier] || 0}</p>
+            <p className="text-xs uppercase tracking-widest">{label}</p>
+          </button>
+        ))}
+      </div>
+
+      {/* Jurisdictions Table */}
+      <div className="bg-neutral-900 border border-neutral-800 rounded-2xl overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-neutral-800">
+                <th className="px-6 py-4 text-left text-xs font-bold uppercase tracking-widest text-neutral-500">
+                  State
+                </th>
+                <th className="px-6 py-4 text-left text-xs font-bold uppercase tracking-widest text-neutral-500">
+                  Code
+                </th>
+                <th className="px-6 py-4 text-left text-xs font-bold uppercase tracking-widest text-neutral-500">
+                  Tier
+                </th>
+                <th className="px-6 py-4 text-left text-xs font-bold uppercase tracking-widest text-neutral-500">
+                  Disposition
+                </th>
+                <th className="px-6 py-4 text-left text-xs font-bold uppercase tracking-widest text-neutral-500">
+                  Updated
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((jurisdiction) => (
+                <tr
+                  key={jurisdiction.code}
+                  className="border-b border-neutral-800/50 hover:bg-neutral-800/30 transition-colors"
+                >
+                  <td className="px-6 py-4 text-sm font-bold">
+                    {jurisdiction.name}
+                  </td>
+                  <td className="px-6 py-4 text-sm font-mono text-neutral-400">
+                    {jurisdiction.code}
+                  </td>
+                  <td className="px-6 py-4">
+                    <select
+                      value={jurisdiction.tier}
+                      onChange={(e) =>
+                        handleTierChange(jurisdiction.code, e.target.value)
+                      }
+                      disabled={saving === jurisdiction.code}
+                      className={`px-3 py-1.5 rounded-lg text-xs font-bold border ${TIER_COLORS[jurisdiction.tier] || "bg-neutral-800 text-neutral-400 border-neutral-700"} focus:outline-none focus:border-blue-600`}
+                      aria-label={`Tier for ${jurisdiction.code}`}
+                    >
+                      <option value="FULL_ACCESS">FULL_ACCESS</option>
+                      <option value="REFUND_ONLY">REFUND_ONLY</option>
+                      <option value="HARD_BLOCK">HARD_BLOCK</option>
+                    </select>
+                    {saving === jurisdiction.code && (
+                      <Loader2
+                        className="inline-block ml-2 animate-spin"
+                        size={14}
+                      />
+                    )}
+                  </td>
+                  <td className="px-6 py-4 text-sm text-neutral-400">
+                    {jurisdiction.disposition_mode}
+                  </td>
+                  <td className="px-6 py-4 text-xs text-neutral-500">
+                    {new Date(jurisdiction.updated_at).toLocaleDateString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {filtered.length === 0 && (
+        <div className="text-center py-12 text-neutral-500">
+          No jurisdictions match the selected filter.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/web/app/admin/jurisdictions/page.tsx
+++ b/src/web/app/admin/jurisdictions/page.tsx
@@ -7,8 +7,9 @@ import {
   Loader2,
   AlertTriangle,
   MapPin,
-  Save,
   RefreshCw,
+  ShieldAlert,
+  ShieldCheck,
 } from "lucide-react";
 import { api } from "../../../services/api-client";
 import { useAuth } from "../../../contexts/AuthContext";
@@ -40,16 +41,20 @@ export default function JurisdictionsPage() {
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState<string | null>(null);
   const [filter, setFilter] = useState<string>("ALL");
+  const [killSwitchActive, setKillSwitchActive] = useState(false);
+  const [killSwitchLoading, setKillSwitchLoading] = useState(false);
 
-  const loadJurisdictions = useCallback(async () => {
+  const loadData = useCallback(async () => {
     try {
       setLoading(true);
-      const data = await api.getJurisdictions();
-      setJurisdictions(data.jurisdictions || []);
+      const [jurisdictionsData, killSwitchData] = await Promise.all([
+        api.getJurisdictions(),
+        api.getKillSwitch(),
+      ]);
+      setJurisdictions(jurisdictionsData.jurisdictions || []);
+      setKillSwitchActive(killSwitchData.refundOnlyMode);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Failed to load jurisdictions",
-      );
+      setError(err instanceof Error ? err.message : "Failed to load data");
     } finally {
       setLoading(false);
     }
@@ -62,8 +67,8 @@ export default function JurisdictionsPage() {
       setLoading(false);
       return;
     }
-    loadJurisdictions();
-  }, [authUser, authLoading, loadJurisdictions]);
+    loadData();
+  }, [authUser, authLoading, loadData]);
 
   const handleTierChange = async (code: string, newTier: string) => {
     setSaving(code);
@@ -78,6 +83,20 @@ export default function JurisdictionsPage() {
       );
     } finally {
       setSaving(null);
+    }
+  };
+
+  const handleKillSwitchToggle = async () => {
+    setKillSwitchLoading(true);
+    try {
+      const result = await api.setKillSwitch(!killSwitchActive);
+      setKillSwitchActive(result.refundOnlyMode);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to toggle kill switch",
+      );
+    } finally {
+      setKillSwitchLoading(false);
     }
   };
 
@@ -138,12 +157,59 @@ export default function JurisdictionsPage() {
           </h1>
         </div>
         <button
-          onClick={loadJurisdictions}
+          onClick={loadData}
           className="ml-auto p-2 text-neutral-400 hover:text-white transition-colors"
           title="Refresh"
         >
           <RefreshCw size={20} />
         </button>
+      </div>
+
+      {/* Kill Switch */}
+      <div
+        className={`mb-8 p-6 rounded-2xl border ${
+          killSwitchActive
+            ? "bg-red-950/50 border-red-800"
+            : "bg-neutral-900 border-neutral-800"
+        }`}
+      >
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            {killSwitchActive ? (
+              <ShieldAlert className="text-red-500" size={24} />
+            ) : (
+              <ShieldCheck className="text-green-500" size={24} />
+            )}
+            <div>
+              <h2 className="font-bold uppercase tracking-widest text-sm">
+                Kill Switch — Refund-Only Mode
+              </h2>
+              <p className="text-neutral-400 text-sm mt-1">
+                {killSwitchActive
+                  ? "ACTIVE: All settlements forced to REFUND mode regardless of jurisdiction"
+                  : "INACTIVE: Settlements follow jurisdiction policy (CAPTURE for TIER_1, REFUND for TIER_2/3)"}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={handleKillSwitchToggle}
+            disabled={killSwitchLoading}
+            className={`px-6 py-3 font-bold rounded-xl transition-colors flex items-center gap-2 ${
+              killSwitchActive
+                ? "bg-green-700 hover:bg-green-600 text-white"
+                : "bg-red-700 hover:bg-red-600 text-white"
+            }`}
+          >
+            {killSwitchLoading ? (
+              <Loader2 className="animate-spin" size={16} />
+            ) : killSwitchActive ? (
+              <ShieldCheck size={16} />
+            ) : (
+              <ShieldAlert size={16} />
+            )}
+            {killSwitchActive ? "Deactivate" : "Activate"}
+          </button>
+        </div>
       </div>
 
       {/* Tier Summary */}

--- a/src/web/services/api-client.ts
+++ b/src/web/services/api-client.ts
@@ -536,6 +536,18 @@ export const api = {
       body: JSON.stringify(data),
     }),
 
+  getKillSwitch: () =>
+    request<{ refundOnlyMode: boolean }>("/admin/kill-switch"),
+
+  setKillSwitch: (enabled: boolean) =>
+    request<{ refundOnlyMode: boolean; message: string }>(
+      "/admin/kill-switch",
+      {
+        method: "POST",
+        body: JSON.stringify({ enabled }),
+      },
+    ),
+
   getDisputes: () =>
     request<
       Array<{

--- a/src/web/services/api-client.ts
+++ b/src/web/services/api-client.ts
@@ -508,6 +508,34 @@ export const api = {
       }>;
     }>(`/admin/crisis/events${limit ? `?limit=${limit}` : ""}`),
 
+  getJurisdictions: () =>
+    request<{
+      jurisdictions: Array<{
+        code: string;
+        name: string;
+        tier: string;
+        disposition_mode: string;
+        updated_at: string;
+      }>;
+    }>("/admin/jurisdictions"),
+
+  updateJurisdiction: (
+    code: string,
+    data: { tier?: string; dispositionMode?: string },
+  ) =>
+    request<{
+      jurisdiction: {
+        code: string;
+        name: string;
+        tier: string;
+        disposition_mode: string;
+        updated_at: string;
+      };
+    }>(`/admin/jurisdictions/${code}`, {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    }),
+
   getDisputes: () =>
     request<
       Array<{


### PR DESCRIPTION
## Summary

Closes #401, #402, #403, #404, #406, #407, #408, #409

### #401 — Policy registry CRUD
- `GET /admin/jurisdictions` — list all jurisdictions with current policy tier
- `GET /admin/jurisdictions/:code` — get single jurisdiction by state code
- `PATCH /admin/jurisdictions/:code` — update tier or disposition mode
- All changes logged to event_log via TruthLogService

### #402 — Fail-closed middleware
Already implemented — GeofenceGuard with fail-closed logic applied to contracts + proofs controllers.

### #403 — Admin UI
- New page at `/admin/jurisdictions` — state matrix management
- Tier summary cards with filter functionality
- Inline tier editing with save feedback
- Responsive table with all 50 states + DC

### #404 — Compliance logging
- `logDecision()` method in CompliancePolicyService
- Writes to `compliance_decisions` table on every `evaluateUserComplianceForRequest` call
- Fire-and-forget — logging failures never block requests
- Captures: user_id, action, jurisdiction_code, tier, allowed, reason_code, metadata

### #406 — Jurisdiction-aware disposition rules
Already implemented — JurisdictionDispositionMapper maps tier to CAPTURE/REFUND.

### #407 — Kill switch — refund-only emergency override
- `JurisdictionDispositionMapper.setRefundOnlyMode()` — forces ALL settlements to REFUND
- `GET /admin/kill-switch` — get current kill switch status
- `POST /admin/kill-switch` — toggle kill switch
- All toggles logged to event_log

### #408 — Admin UI — kill switch toggle
- Kill switch toggle on jurisdictions page
- Visual indicator (red/green) for current state
- Confirmation messaging

### #409 — Tests — payout matrix all configured states
- 65 tests covering all 50 states + DC
- Kill switch behavior tests
- Fail-closed behavior for null/undefined tiers

## Verification
- [x] All 1055+ API tests pass
- [x] TypeScript compiles clean
- [x] Admin CRUD endpoints work
- [x] Compliance decisions logged correctly
- [x] Kill switch toggles correctly
- [x] Payout matrix correct for all states