### PR TITLE
chore: e2e suite optimization — workers, scope, timeout

### DIFF
--- a/.config/playwright/playwright.config.ts
+++ b/.config/playwright/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 2 : undefined,
   reporter: process.env.CI ? 'html' : 'list',
   use: {
     baseURL: process.env.E2E_BASE_URL || 'http://localhost:3001',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
       - id: check
         run: |
           BASE="${{ github.event.pull_request.base.sha || 'HEAD~1' }}"
-          if git diff --name-only "$BASE" | grep -q "^src/web/"; then
+          if git diff --name-only "$BASE" | grep -qE "^(src/web/|e2e/|src/shared/|\.config/playwright/)"; then
             echo "web=true" >> $GITHUB_OUTPUT
           else
             echo "web=false" >> $GITHUB_OUTPUT
@@ -215,6 +215,7 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [build_and_test_matrix, beta_readiness, changed-files]
     if: needs.changed-files.outputs.web == 'true'
     continue-on-error: true


### PR DESCRIPTION
## Summary
Three low-risk optimizations based on analysis of the E2E CI pipeline.

## Changes
- **workers: 1 → 2** in CI — 7 spec files currently run serially. 2 workers lets Playwright's `fullyParallel: true` actually work.
- **changed-files scope** — expanded from `src/web/` only to also check `e2e/` + `src/shared/` + `.config/playwright/`. E2E tests should re-run when E2E tests themselves change, or shared libs change.
- **timeout-minutes: 10** — safety net. No explicit timeout meant potential 6-hour hang on GitHub default.

## Analysis
- E2E takes ~2 min when triggered, but only triggers on `src/web/` changes (rare — 30+ runs skipped).
- `continue-on-error: true` means E2E failures don't block merges.
- `fullyParallel: true` paired with `workers: 1` is a contradiction — parallelism was disabled.