### PR TITLE
feat: H1 + H3 — persist device subscriptions, add pregnancy_exclusion self-report

### DIFF
--- a/src/api/database/migrations/040_commitment_device_subscriptions.sql
+++ b/src/api/database/migrations/040_commitment_device_subscriptions.sql
@@ -1,0 +1,44 @@
+-- Migration 040: Commitment device subscriptions + pregnancy self-report audit
+-- H1 (Triadic Review): subscribeToDevice was a no-op stub. Persist real rows.
+-- H3 (Triadic Review): pregnancy_exclusion column existed but no audit trail.
+
+CREATE TABLE IF NOT EXISTS commitment_device_subscriptions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id),
+  device_id TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'ACTIVE',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  cancelled_at TIMESTAMPTZ,
+  UNIQUE(user_id, device_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_commitment_subscriptions_user
+  ON commitment_device_subscriptions(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_commitment_subscriptions_device
+  ON commitment_device_subscriptions(device_id)
+  WHERE status = 'ACTIVE';
+
+COMMENT ON TABLE commitment_device_subscriptions IS
+  'Active subscriptions from users to commitment devices (loss-aversion amplification). H1 fix: previously in-memory only.';
+
+-- Pregnancy self-report audit (H3 fix): track activation/deactivation events.
+-- The users.pregnancy_exclusion column already exists (migration 039), but
+-- there is no history of when the user toggled it. This is needed for:
+--  - Audit trail for compliance (regulators can ask when exclusion started)
+--  - Reverting a misclick (e.g. user accidentally enabled it) requires
+--    knowing how long the exclusion has been active
+--  - Mid-challenge penalty-free suspension handoff
+CREATE TABLE IF NOT EXISTS pregnancy_exclusion_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id),
+  event_type TEXT NOT NULL CHECK (event_type IN ('ACTIVATED', 'DEACTIVATED')),
+  occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  source TEXT NOT NULL DEFAULT 'SELF_REPORT'
+);
+
+CREATE INDEX IF NOT EXISTS idx_pregnancy_exclusion_events_user
+  ON pregnancy_exclusion_events(user_id, occurred_at DESC);
+
+COMMENT ON TABLE pregnancy_exclusion_events IS
+  'Audit log of pregnancy_exclusion toggles on the users row. H3 fix: provides compliance audit trail and reversion basis.';

--- a/src/api/src/modules/behavioral/behavioral-enhancements.service.ts
+++ b/src/api/src/modules/behavioral/behavioral-enhancements.service.ts
@@ -76,10 +76,37 @@ export class BehavioralEnhancementsService {
     userId: string,
     deviceId: string,
   ): Promise<{ subscribed: boolean }> {
-    this.logger.log(
-      `User ${userId} subscribed to commitment device ${deviceId}`,
+    const catalog = this.getCommitmentDeviceCatalog();
+    if (!catalog.some((d) => d.id === deviceId)) {
+      throw new BadRequestException(`Unknown commitment device: ${deviceId}`);
+    }
+
+    const { rows } = await this.pool.query(
+      `INSERT INTO commitment_device_subscriptions (user_id, device_id, status)
+       VALUES ($1, $2, 'ACTIVE')
+       ON CONFLICT (user_id, device_id) DO UPDATE
+         SET status = 'ACTIVE', cancelled_at = NULL
+       RETURNING id, status`,
+      [userId, deviceId],
     );
-    return { subscribed: true };
+
+    this.logger.log(
+      `User ${userId} subscribed to commitment device ${deviceId} (id=${rows[0].id})`,
+    );
+    return { subscribed: rows[0].status === "ACTIVE" };
+  }
+
+  async unsubscribeFromDevice(
+    userId: string,
+    deviceId: string,
+  ): Promise<{ subscribed: boolean }> {
+    const { rowCount } = await this.pool.query(
+      `UPDATE commitment_device_subscriptions
+       SET status = 'CANCELLED', cancelled_at = NOW()
+       WHERE user_id = $1 AND device_id = $2 AND status = 'ACTIVE'`,
+      [userId, deviceId],
+    );
+    return { subscribed: rowCount === 0 };
   }
 
   async calculateAmplifiedStake(

--- a/src/api/src/modules/behavioral/behavioral.controller.spec.ts
+++ b/src/api/src/modules/behavioral/behavioral.controller.spec.ts
@@ -1,0 +1,92 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { Pool } from "pg";
+import { BadRequestException } from "@nestjs/common";
+import { BehavioralController } from "./behavioral.controller";
+import { BehavioralEnhancementsService } from "./behavioral-enhancements.service";
+
+describe("BehavioralController", () => {
+  let controller: BehavioralController;
+  let service: BehavioralEnhancementsService;
+  let pool: { query: jest.Mock };
+
+  const mockQuery = jest.fn();
+  const user = { id: "user-001" };
+
+  beforeEach(async () => {
+    mockQuery.mockReset();
+    pool = { query: mockQuery };
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BehavioralController],
+      providers: [
+        BehavioralEnhancementsService,
+        { provide: Pool, useValue: pool },
+      ],
+    }).compile();
+
+    controller = module.get<BehavioralController>(BehavioralController);
+    service = module.get<BehavioralEnhancementsService>(
+      BehavioralEnhancementsService,
+    );
+  });
+
+  describe("subscribe", () => {
+    it("persists a subscription and returns subscribed=true (H1 fix)", async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: "sub-1", status: "ACTIVE" }],
+      });
+      const result = await controller.subscribe(user, "cd-001");
+      expect(result).toEqual({ subscribed: true });
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("INSERT INTO commitment_device_subscriptions"),
+        ["user-001", "cd-001"],
+      );
+    });
+
+    it("rejects an unknown device id with BadRequestException", async () => {
+      await expect(
+        controller.subscribe(user, "device-not-in-catalog"),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("unsubscribe", () => {
+    it("returns subscribed=false when no row was cancelled (still subscribed)", async () => {
+      mockQuery.mockResolvedValueOnce({ rowCount: 0 });
+      const result = await controller.unsubscribe(user, "cd-001");
+      expect(result).toEqual({ subscribed: true });
+    });
+
+    it("returns subscribed=false when the row was actually cancelled", async () => {
+      mockQuery.mockResolvedValueOnce({ rowCount: 1 });
+      const result = await controller.unsubscribe(user, "cd-001");
+      expect(result).toEqual({ subscribed: false });
+    });
+  });
+
+  describe("proposeSwap", () => {
+    it("throws NotFoundException when the source contract is missing (H2 fix)", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      await expect(
+        controller.proposeSwap(user, {
+          sourceContractId: "c-missing",
+          targetOathCategory: "BIOLOGICAL_WEIGHT",
+          carryOverPct: 50,
+        }),
+      ).rejects.toThrow(/not found/i);
+    });
+
+    it("throws BadRequestException when stake_amount is NULL (H2 fix)", async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ age_days: 30, status: "ACTIVE", stake_amount: null }],
+      });
+      await expect(
+        controller.proposeSwap(user, {
+          sourceContractId: "c-no-stake",
+          targetOathCategory: "BIOLOGICAL_WEIGHT",
+          carryOverPct: 50,
+        }),
+      ).rejects.toThrow(/stake_amount/);
+    });
+  });
+});

--- a/src/api/src/modules/behavioral/behavioral.controller.ts
+++ b/src/api/src/modules/behavioral/behavioral.controller.ts
@@ -1,0 +1,91 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Param,
+  Body,
+  UseGuards,
+} from "@nestjs/common";
+import { ApiTags, ApiOperation, ApiBearerAuth } from "@nestjs/swagger";
+import { AuthGuard } from "../../../guards/auth.guard";
+import { CurrentUser } from "../../common/decorators/current-user.decorator";
+import { BehavioralEnhancementsService } from "./behavioral-enhancements.service";
+
+@ApiTags("Behavioral")
+@Controller("behavioral")
+export class BehavioralController {
+  constructor(private readonly enhancements: BehavioralEnhancementsService) {}
+
+  @Get("commitment-devices/catalog")
+  @ApiOperation({ summary: "List the catalog of available commitment devices" })
+  getCatalog() {
+    return this.enhancements.getCommitmentDeviceCatalog();
+  }
+
+  @Post("commitment-devices/:deviceId/subscribe")
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: "Subscribe to a commitment device (persisted to DB; H1 fix)",
+  })
+  @UseGuards(AuthGuard)
+  async subscribe(
+    @CurrentUser() user: { id: string },
+    @Param("deviceId") deviceId: string,
+  ) {
+    return this.enhancements.subscribeToDevice(user.id, deviceId);
+  }
+
+  @Delete("commitment-devices/:deviceId/subscribe")
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "Cancel a commitment device subscription" })
+  @UseGuards(AuthGuard)
+  async unsubscribe(
+    @CurrentUser() user: { id: string },
+    @Param("deviceId") deviceId: string,
+  ) {
+    return this.enhancements.unsubscribeFromDevice(user.id, deviceId);
+  }
+
+  @Get("crab-bucket/risk")
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: "Classify crab-bucket (self-sabotage) risk for the current user",
+  })
+  @UseGuards(AuthGuard)
+  async risk(@CurrentUser() user: { id: string }) {
+    return this.enhancements.analyzeCrabBucketRisk(user.id);
+  }
+
+  @Get("habituation/:contractId")
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "Detect habituation signals on a contract" })
+  @UseGuards(AuthGuard)
+  async habituation(@Param("contractId") contractId: string) {
+    return this.enhancements.detectContractHabituation(contractId);
+  }
+
+  @Post("swaps")
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary:
+      "Propose a behavior swap from one contract to a different oath category",
+  })
+  @UseGuards(AuthGuard)
+  async proposeSwap(
+    @CurrentUser() user: { id: string },
+    @Body()
+    body: {
+      sourceContractId: string;
+      targetOathCategory: string;
+      carryOverPct: number;
+    },
+  ) {
+    return this.enhancements.proposeBehaviorSwap(
+      user.id,
+      body.sourceContractId,
+      body.targetOathCategory,
+      body.carryOverPct,
+    );
+  }
+}

--- a/src/api/src/modules/behavioral/behavioral.module.ts
+++ b/src/api/src/modules/behavioral/behavioral.module.ts
@@ -1,9 +1,11 @@
 import { Module, forwardRef } from "@nestjs/common";
 import { BehavioralEnhancementsService } from "./behavioral-enhancements.service";
+import { BehavioralController } from "./behavioral.controller";
 import { ContractsModule } from "../contracts/contracts.module";
 
 @Module({
   imports: [forwardRef(() => ContractsModule)],
+  controllers: [BehavioralController],
   providers: [BehavioralEnhancementsService],
   exports: [BehavioralEnhancementsService],
 })

--- a/src/api/src/modules/users/users.controller.ts
+++ b/src/api/src/modules/users/users.controller.ts
@@ -1,15 +1,30 @@
-import { Controller, Get, Patch, Delete, Param, Query, Body, UseGuards, ForbiddenException, Post } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
-import { UsersService } from './users.service';
-import { GdprService } from './gdpr.service';
-import { AuthGuard } from '../../../guards/auth.guard';
-import { CurrentUser, Public } from '../../common/decorators/current-user.decorator';
-import { IdentityVerificationService } from '../compliance/identity-verification.service';
-import { IdentityVerificationMode } from '../compliance/identity-provider.service';
+import {
+  Controller,
+  Get,
+  Patch,
+  Delete,
+  Param,
+  Query,
+  Body,
+  UseGuards,
+  ForbiddenException,
+  BadRequestException,
+  Post,
+} from "@nestjs/common";
+import { ApiTags, ApiOperation, ApiBearerAuth } from "@nestjs/swagger";
+import { Throttle } from "@nestjs/throttler";
+import { UsersService } from "./users.service";
+import { GdprService } from "./gdpr.service";
+import { AuthGuard } from "../../../guards/auth.guard";
+import {
+  CurrentUser,
+  Public,
+} from "../../common/decorators/current-user.decorator";
+import { IdentityVerificationService } from "../compliance/identity-verification.service";
+import { IdentityVerificationMode } from "../compliance/identity-provider.service";
 
-@ApiTags('Users')
-@Controller('users')
+@ApiTags("Users")
+@Controller("users")
 export class UsersController {
   constructor(
     private readonly usersService: UsersService,
@@ -17,29 +32,36 @@ export class UsersController {
     private readonly identityVerification: IdentityVerificationService,
   ) {}
 
-  @Get('me')
+  @Get("me")
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get the authenticated user profile' })
+  @ApiOperation({ summary: "Get the authenticated user profile" })
   @UseGuards(AuthGuard)
   async getMe(@CurrentUser() user: { id: string }) {
     return this.usersService.getProfile(user.id);
   }
 
-  @Get('me/compliance')
+  @Get("me/compliance")
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get compliance and identity verification status for the authenticated user' })
+  @ApiOperation({
+    summary:
+      "Get compliance and identity verification status for the authenticated user",
+  })
   @UseGuards(AuthGuard)
   async getComplianceStatus(@CurrentUser() user: { id: string }) {
     return this.identityVerification.getUserComplianceStatus(user.id);
   }
 
-  @Post('me/compliance/identity/start')
+  @Post("me/compliance/identity/start")
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Start identity verification (mock or provider-backed) for the authenticated user' })
+  @ApiOperation({
+    summary:
+      "Start identity verification (mock or provider-backed) for the authenticated user",
+  })
   @UseGuards(AuthGuard)
   async startIdentityVerification(
     @CurrentUser() user: { id: string },
-    @Body() body: {
+    @Body()
+    body: {
       mode?: IdentityVerificationMode;
       returnUrl?: string;
       refreshUrl?: string;
@@ -47,53 +69,66 @@ export class UsersController {
   ) {
     return this.identityVerification.startVerificationFlow({
       userId: user.id,
-      mode: body.mode || 'KYC_AND_AGE',
+      mode: body.mode || "KYC_AND_AGE",
       returnUrl: body.returnUrl,
       refreshUrl: body.refreshUrl,
     });
   }
 
-  @Post('me/compliance/identity/mock-complete')
+  @Post("me/compliance/identity/mock-complete")
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Complete identity verification in mock mode for local/dev testing' })
+  @ApiOperation({
+    summary:
+      "Complete identity verification in mock mode for local/dev testing",
+  })
   @UseGuards(AuthGuard)
   async completeIdentityVerificationMock(
     @CurrentUser() user: { id: string },
-    @Body() body: { mode?: IdentityVerificationMode; status?: 'VERIFIED' | 'FAILED' | 'REJECTED' },
+    @Body()
+    body: {
+      mode?: IdentityVerificationMode;
+      status?: "VERIFIED" | "FAILED" | "REJECTED";
+    },
   ) {
-    if (process.env.NODE_ENV === 'production') {
-      throw new ForbiddenException('Mock identity completion endpoint is disabled in production');
+    if (process.env.NODE_ENV === "production") {
+      throw new ForbiddenException(
+        "Mock identity completion endpoint is disabled in production",
+      );
     }
 
     return this.identityVerification.completeMockVerification({
       userId: user.id,
-      mode: body.mode || 'KYC_AND_AGE',
-      status: body.status || 'VERIFIED',
+      mode: body.mode || "KYC_AND_AGE",
+      status: body.status || "VERIFIED",
     });
   }
 
-  @Get('me/history')
+  @Get("me/history")
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get contract history for the authenticated user' })
+  @ApiOperation({ summary: "Get contract history for the authenticated user" })
   @UseGuards(AuthGuard)
   async getHistory(@CurrentUser() user: { id: string }) {
     return this.usersService.getUserHistory(user.id);
   }
 
-  @Patch('me/password')
+  @Patch("me/password")
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Change the authenticated user password' })
+  @ApiOperation({ summary: "Change the authenticated user password" })
   @UseGuards(AuthGuard)
   async changePassword(
     @CurrentUser() user: { id: string },
     @Body() body: { currentPassword: string; newPassword: string }, // allow-secret
   ) {
-    return this.usersService.changePassword(user.id, body.currentPassword, body.newPassword);
+    return this.usersService.changePassword(
+      user.id,
+      body.currentPassword,
+      body.newPassword,
+    );
   }
 
-  @Patch('me/settings')
+  @Patch("me/settings")
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Update notification preferences' })
+  @ApiOperation({ summary: "Update notification preferences" })
   @UseGuards(AuthGuard)
   async updateSettings(
     @CurrentUser() user: { id: string },
@@ -102,26 +137,28 @@ export class UsersController {
     return this.usersService.updateSettings(user.id, body);
   }
 
-  @Get('me/data-export')
+  @Get("me/data-export")
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Export all user data (GDPR Article 20)' })
+  @ApiOperation({ summary: "Export all user data (GDPR Article 20)" })
   @UseGuards(AuthGuard)
   @Throttle({ default: { ttl: 60000, limit: 3 } })
   async exportData(@CurrentUser() user: { id: string }) {
     return this.gdprService.exportUserData(user.id);
   }
 
-  @Delete('me')
+  @Delete("me")
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Request account deletion (GDPR)' })
+  @ApiOperation({ summary: "Request account deletion (GDPR)" })
   @UseGuards(AuthGuard)
   async deleteAccount(@CurrentUser() user: { id: string }) {
     return this.usersService.requestDeletion(user.id);
   }
 
-  @Post('me/self-exclusion')
+  @Post("me/self-exclusion")
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Activate self-exclusion for a specified duration (days)' })
+  @ApiOperation({
+    summary: "Activate self-exclusion for a specified duration (days)",
+  })
   @UseGuards(AuthGuard)
   async setSelfExclusion(
     @CurrentUser() user: { id: string },
@@ -130,23 +167,46 @@ export class UsersController {
     return this.usersService.setSelfExclusion(user.id, body.durationDays);
   }
 
-  @Get('leaderboard')
-  @ApiOperation({ summary: 'Get the public integrity leaderboard' })
-  @Public()
-  @Throttle({ default: { ttl: 60000, limit: 30 } })
-  async getLeaderboard(@Query('limit') limit?: string, @Query('period') period?: string) {
-    return this.usersService.getLeaderboard(limit ? parseInt(limit, 10) : 10, period);
+  @Post("me/pregnancy-exclusion")
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary:
+      "Self-report pregnancy exclusion — blocks creation of penalty-bearing contracts while active. Audited to pregnancy_exclusion_events.",
+  })
+  @UseGuards(AuthGuard)
+  async setPregnancyExclusion(
+    @CurrentUser() user: { id: string },
+    @Body() body: { active: boolean },
+  ) {
+    if (typeof body?.active !== "boolean") {
+      throw new BadRequestException("active (boolean) is required");
+    }
+    return this.usersService.setPregnancyExclusion(user.id, body.active);
   }
 
-  @Get(':id')
+  @Get("leaderboard")
+  @ApiOperation({ summary: "Get the public integrity leaderboard" })
+  @Public()
+  @Throttle({ default: { ttl: 60000, limit: 30 } })
+  async getLeaderboard(
+    @Query("limit") limit?: string,
+    @Query("period") period?: string,
+  ) {
+    return this.usersService.getLeaderboard(
+      limit ? parseInt(limit, 10) : 10,
+      period,
+    );
+  }
+
+  @Get(":id")
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Get a user profile by ID' })
+  @ApiOperation({ summary: "Get a user profile by ID" })
   // Previously @Public() with no rate limit: this allowed anonymous enumeration of
   // every user's integrity_score and signup date by walking ids. Require auth and
   // add a throttle so the endpoint can no longer be scraped anonymously.
   @UseGuards(AuthGuard)
   @Throttle({ default: { ttl: 60000, limit: 30 } })
-  async getPublicProfile(@Param('id') id: string) {
+  async getPublicProfile(@Param("id") id: string) {
     return this.usersService.getPublicProfile(id);
   }
 }

--- a/src/api/src/modules/users/users.service.spec.ts
+++ b/src/api/src/modules/users/users.service.spec.ts
@@ -1,7 +1,7 @@
-import { UsersService } from './users.service';
-import { NotFoundException, UnauthorizedException } from '@nestjs/common';
-import { Pool } from 'pg';
-import * as bcrypt from 'bcryptjs';
+import { UsersService } from "./users.service";
+import { NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { Pool } from "pg";
+import * as bcrypt from "bcryptjs";
 
 // Audit events are now written via a private appendTruthLogEvent() that
 // acquires a pooled client (pool.connect()) and runs a transaction
@@ -16,7 +16,7 @@ const mockPool = {
   connect: jest.fn().mockResolvedValue(mockClient),
 } as unknown as Pool;
 
-describe('UsersService', () => {
+describe("UsersService", () => {
   let service: UsersService;
 
   beforeEach(() => {
@@ -28,81 +28,106 @@ describe('UsersService', () => {
     (mockClient.query as jest.Mock).mockResolvedValue({ rows: [] });
   });
 
-  describe('getProfile', () => {
-    it('should return user profile for valid userId', async () => {
+  describe("getProfile", () => {
+    it("should return user profile for valid userId", async () => {
       const user = {
-        id: 'user-1',
-        email: 'demo@styx.protocol',
+        id: "user-1",
+        email: "demo@styx.protocol",
         integrity_score: 75,
-        role: 'USER',
-        status: 'ACTIVE',
-        created_at: '2025-01-01',
-        kyc_status: 'NOT_STARTED',
-        age_verification_status: 'NOT_STARTED',
+        role: "USER",
+        status: "ACTIVE",
+        created_at: "2025-01-01",
+        kyc_status: "NOT_STARTED",
+        age_verification_status: "NOT_STARTED",
         identity_provider: null,
         identity_verification_id: null,
         identity_verified_at: null,
       };
       (mockPool.query as jest.Mock)
         .mockResolvedValueOnce({ rows: [user] })
-        .mockResolvedValueOnce({ rows: [{ count: '2', total: '150.00' }] });
+        .mockResolvedValueOnce({ rows: [{ count: "2", total: "150.00" }] });
 
-      const result = await service.getProfile('user-1');
+      const result = await service.getProfile("user-1");
 
-      expect(result).toEqual(expect.objectContaining({
-        id: 'user-1',
-        email: 'demo@styx.protocol',
-        integrity_score: 75,
-        tier: 'STANDARD',
-        contract_count: 2,
-        total_staked: 150.00,
-        role: 'USER',
-        status: 'ACTIVE',
-        compliance: expect.objectContaining({
-          kyc_status: 'NOT_STARTED',
-          age_verification_status: 'NOT_STARTED',
-          is_kyc_verified: false,
-          is_age_verified: false,
+      expect(result).toEqual(
+        expect.objectContaining({
+          id: "user-1",
+          email: "demo@styx.protocol",
+          integrity_score: 75,
+          tier: "STANDARD",
+          contract_count: 2,
+          total_staked: 150.0,
+          role: "USER",
+          status: "ACTIVE",
+          compliance: expect.objectContaining({
+            kyc_status: "NOT_STARTED",
+            age_verification_status: "NOT_STARTED",
+            is_kyc_verified: false,
+            is_age_verified: false,
+          }),
         }),
-      }));
+      );
       expect(mockPool.query).toHaveBeenCalledWith(
-        expect.stringContaining('SELECT id, email'),
-        ['user-1'],
+        expect.stringContaining("SELECT id, email"),
+        ["user-1"],
       );
     });
 
-    it('should throw NotFoundException for unknown userId', async () => {
+    it("should throw NotFoundException for unknown userId", async () => {
       (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
 
-      await expect(service.getProfile('unknown-id'))
-        .rejects.toThrow(NotFoundException);
+      await expect(service.getProfile("unknown-id")).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 
-  describe('getPublicProfile', () => {
-    it('should return limited public profile fields', async () => {
-      const publicData = { id: 'user-1', integrity_score: 75, created_at: '2025-01-01' };
-      (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [publicData] });
+  describe("getPublicProfile", () => {
+    it("should return limited public profile fields", async () => {
+      const publicData = {
+        id: "user-1",
+        integrity_score: 75,
+        created_at: "2025-01-01",
+      };
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({
+        rows: [publicData],
+      });
 
-      const result = await service.getPublicProfile('user-1');
+      const result = await service.getPublicProfile("user-1");
 
       expect(result).toEqual(publicData);
     });
 
-    it('should throw NotFoundException for unknown userId', async () => {
+    it("should throw NotFoundException for unknown userId", async () => {
       (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
 
-      await expect(service.getPublicProfile('unknown'))
-        .rejects.toThrow(NotFoundException);
+      await expect(service.getPublicProfile("unknown")).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 
-  describe('getLeaderboard', () => {
-    it('should return users sorted by integrity_score descending', async () => {
+  describe("getLeaderboard", () => {
+    it("should return users sorted by integrity_score descending", async () => {
       const leaders = [
-        { id: 'u3', email: 'admin@styx.protocol', integrity_score: 200, created_at: '2025-01-01' },
-        { id: 'u2', email: 'fury@styx.protocol', integrity_score: 90, created_at: '2025-01-01' },
-        { id: 'u1', email: 'demo@styx.protocol', integrity_score: 75, created_at: '2025-01-01' },
+        {
+          id: "u3",
+          email: "admin@styx.protocol",
+          integrity_score: 200,
+          created_at: "2025-01-01",
+        },
+        {
+          id: "u2",
+          email: "fury@styx.protocol",
+          integrity_score: 90,
+          created_at: "2025-01-01",
+        },
+        {
+          id: "u1",
+          email: "demo@styx.protocol",
+          integrity_score: 75,
+          created_at: "2025-01-01",
+        },
       ];
       (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: leaders });
 
@@ -111,37 +136,31 @@ describe('UsersService', () => {
       expect(result).toHaveLength(3);
       expect(result[0].integrity_score).toBe(200);
       expect(mockPool.query).toHaveBeenCalledWith(
-        expect.stringContaining('ORDER BY integrity_score DESC'),
+        expect.stringContaining("ORDER BY integrity_score DESC"),
         [10],
       );
     });
 
-    it('should default to 10 results', async () => {
+    it("should default to 10 results", async () => {
       (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
 
       await service.getLeaderboard();
 
-      expect(mockPool.query).toHaveBeenCalledWith(
-        expect.any(String),
-        [10],
-      );
+      expect(mockPool.query).toHaveBeenCalledWith(expect.any(String), [10]);
     });
 
-    it('should cap limit at 100', async () => {
+    it("should cap limit at 100", async () => {
       (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
 
       await service.getLeaderboard(500);
 
-      expect(mockPool.query).toHaveBeenCalledWith(
-        expect.any(String),
-        [100],
-      );
+      expect(mockPool.query).toHaveBeenCalledWith(expect.any(String), [100]);
     });
 
     it('should filter by weekly activity when period is "weekly"', async () => {
       (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
 
-      await service.getLeaderboard(10, 'weekly');
+      await service.getLeaderboard(10, "weekly");
 
       expect(mockPool.query).toHaveBeenCalledWith(
         expect.stringContaining("INTERVAL '7 days'"),
@@ -152,7 +171,7 @@ describe('UsersService', () => {
     it('should filter by monthly activity when period is "monthly"', async () => {
       (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
 
-      await service.getLeaderboard(10, 'monthly');
+      await service.getLeaderboard(10, "monthly");
 
       expect(mockPool.query).toHaveBeenCalledWith(
         expect.stringContaining("INTERVAL '30 days'"),
@@ -160,97 +179,179 @@ describe('UsersService', () => {
       );
     });
 
-    it('should not add interval filter for alltime period', async () => {
+    it("should not add interval filter for alltime period", async () => {
       (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
 
-      await service.getLeaderboard(10, 'alltime');
+      await service.getLeaderboard(10, "alltime");
 
       expect(mockPool.query).toHaveBeenCalledWith(
-        expect.not.stringContaining('INTERVAL'),
+        expect.not.stringContaining("INTERVAL"),
         [10],
       );
     });
 
-    it('should not add interval filter when period is undefined', async () => {
+    it("should not add interval filter when period is undefined", async () => {
       (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
 
       await service.getLeaderboard(10);
 
       expect(mockPool.query).toHaveBeenCalledWith(
-        expect.not.stringContaining('INTERVAL'),
+        expect.not.stringContaining("INTERVAL"),
         [10],
       );
     });
   });
 
-  describe('changePassword (AU12)', () => {
-    it('updates the hash and revokes existing refresh tokens', async () => {
-      const currentHash = bcrypt.hashSync('old-password', 10); // allow-secret
+  describe("changePassword (AU12)", () => {
+    it("updates the hash and revokes existing refresh tokens", async () => {
+      const currentHash = bcrypt.hashSync("old-password", 10); // allow-secret
       (mockPool.query as jest.Mock)
-        .mockResolvedValueOnce({ rows: [{ id: 'user-1', password_hash: currentHash }] }) // SELECT
+        .mockResolvedValueOnce({
+          rows: [{ id: "user-1", password_hash: currentHash }],
+        }) // SELECT
         .mockResolvedValueOnce({ rows: [] }) // UPDATE password_hash
         .mockResolvedValueOnce({ rows: [] }); // revoke refresh tokens
 
-      const result = await service.changePassword('user-1', 'old-password', 'new-strong-password'); // allow-secret
+      const result = await service.changePassword(
+        "user-1",
+        "old-password",
+        "new-strong-password",
+      ); // allow-secret
 
-      expect(result).toEqual({ status: 'password_updated' });
+      expect(result).toEqual({ status: "password_updated" });
 
-      const sqls = (mockPool.query as jest.Mock).mock.calls.map((c) => String(c[0]));
-      expect(sqls.some((s) => s.includes('UPDATE users SET password_hash'))).toBe(true);
+      const sqls = (mockPool.query as jest.Mock).mock.calls.map((c) =>
+        String(c[0]),
+      );
+      expect(
+        sqls.some((s) => s.includes("UPDATE users SET password_hash")),
+      ).toBe(true);
       // AU12: refresh tokens must be revoked so old sessions cannot survive the change.
       const revokeCall = (mockPool.query as jest.Mock).mock.calls.find((c) =>
-        String(c[0]).includes('UPDATE refresh_tokens SET revoked = TRUE'),
+        String(c[0]).includes("UPDATE refresh_tokens SET revoked = TRUE"),
       );
       expect(revokeCall).toBeDefined();
-      expect(revokeCall![1]).toEqual(['user-1']);
+      expect(revokeCall![1]).toEqual(["user-1"]);
     });
 
-    it('rejects when the current password is incorrect and does not revoke tokens', async () => {
-      const currentHash = bcrypt.hashSync('old-password', 10); // allow-secret
-      (mockPool.query as jest.Mock)
-        .mockResolvedValueOnce({ rows: [{ id: 'user-1', password_hash: currentHash }] }); // SELECT
+    it("rejects when the current password is incorrect and does not revoke tokens", async () => {
+      const currentHash = bcrypt.hashSync("old-password", 10); // allow-secret
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({
+        rows: [{ id: "user-1", password_hash: currentHash }],
+      }); // SELECT
 
       await expect(
-        service.changePassword('user-1', 'wrong-password', 'new-strong-password'), // allow-secret
+        service.changePassword(
+          "user-1",
+          "wrong-password",
+          "new-strong-password",
+        ), // allow-secret
       ).rejects.toThrow(UnauthorizedException);
 
       const revoked = (mockPool.query as jest.Mock).mock.calls.some((c) =>
-        String(c[0]).includes('UPDATE refresh_tokens SET revoked = TRUE'),
+        String(c[0]).includes("UPDATE refresh_tokens SET revoked = TRUE"),
       );
       expect(revoked).toBe(false);
     });
   });
 
-  describe('requestDeletion', () => {
-    it('should mark user as pending deletion and stamp deletion_requested_at', async () => {
+  describe("requestDeletion", () => {
+    it("should mark user as pending deletion and stamp deletion_requested_at", async () => {
       // SELECT user + UPDATE status go through pool.query; the audit event is
       // appended via a pooled client transaction (mockClient).
       (mockPool.query as jest.Mock)
-        .mockResolvedValueOnce({ rows: [{ id: 'user-1', status: 'ACTIVE' }] }) // SELECT
+        .mockResolvedValueOnce({ rows: [{ id: "user-1", status: "ACTIVE" }] }) // SELECT
         .mockResolvedValueOnce({ rows: [] }); // UPDATE
 
-      const result = await service.requestDeletion('user-1');
+      const result = await service.requestDeletion("user-1");
 
-      expect(result).toEqual({ status: 'deletion_requested' });
+      expect(result).toEqual({ status: "deletion_requested" });
       expect((mockPool.query as jest.Mock).mock.calls[1][0]).toContain(
         "UPDATE users SET status = 'PENDING_DELETION', deletion_requested_at = NOW() WHERE id = $1",
       );
-      expect((mockPool.query as jest.Mock).mock.calls[1][1]).toEqual(['user-1']);
+      expect((mockPool.query as jest.Mock).mock.calls[1][1]).toEqual([
+        "user-1",
+      ]);
 
       // The deletion request is appended to the tamper-evident chain via a
       // pooled-client transaction.
       expect(mockPool.connect).toHaveBeenCalled();
-      const clientSql = (mockClient.query as jest.Mock).mock.calls.map((c) => String(c[0]));
-      expect(clientSql).toContain('BEGIN');
-      expect(clientSql.some((sql) => sql.includes('INSERT INTO event_log'))).toBe(true);
-      expect(clientSql).toContain('COMMIT');
+      const clientSql = (mockClient.query as jest.Mock).mock.calls.map((c) =>
+        String(c[0]),
+      );
+      expect(clientSql).toContain("BEGIN");
+      expect(
+        clientSql.some((sql) => sql.includes("INSERT INTO event_log")),
+      ).toBe(true);
+      expect(clientSql).toContain("COMMIT");
       expect(mockClient.release).toHaveBeenCalled();
     });
 
-    it('should throw NotFoundException when requesting deletion for unknown user', async () => {
+    it("should throw NotFoundException when requesting deletion for unknown user", async () => {
       (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
 
-      await expect(service.requestDeletion('missing-user')).rejects.toThrow(NotFoundException);
+      await expect(service.requestDeletion("missing-user")).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe("setPregnancyExclusion (H3 Triadic Review fix)", () => {
+    it("activates pregnancy_exclusion, stamps the column, writes audit row + truth-log event", async () => {
+      (mockPool.query as jest.Mock)
+        .mockResolvedValueOnce({
+          rows: [
+            { pregnancy_exclusion: true, pregnancy_exclusion_at: new Date() },
+          ],
+        })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const result = await service.setPregnancyExclusion("user-1", true);
+
+      expect(result.pregnancy_exclusion).toBe(true);
+
+      const sqls = (mockPool.query as jest.Mock).mock.calls.map((c) =>
+        String(c[0]),
+      );
+      expect(
+        sqls.some(
+          (s) =>
+            s.includes("UPDATE users") &&
+            s.includes("pregnancy_exclusion = $2"),
+        ),
+      ).toBe(true);
+      expect(
+        sqls.some((s) => s.includes("INSERT INTO pregnancy_exclusion_events")),
+      ).toBe(true);
+      expect(mockPool.connect).toHaveBeenCalled();
+
+      // The truth-log event_type is bound as a parameter ($2), not inlined,
+      // so check the bound argument list on the event_log INSERT.
+      const eventLogInsert = (mockClient.query as jest.Mock).mock.calls.find(
+        (c) => String(c[0]).includes("INSERT INTO event_log"),
+      );
+      expect(eventLogInsert).toBeDefined();
+      expect(eventLogInsert![1][1]).toBe("PREGNANCY_EXCLUSION_ACTIVATED");
+    });
+
+    it("deactivates and clears pregnancy_exclusion_at", async () => {
+      (mockPool.query as jest.Mock)
+        .mockResolvedValueOnce({
+          rows: [{ pregnancy_exclusion: false, pregnancy_exclusion_at: null }],
+        })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const result = await service.setPregnancyExclusion("user-1", false);
+
+      expect(result.pregnancy_exclusion).toBe(false);
+      expect(result.pregnancy_exclusion_at).toBeNull();
+    });
+
+    it("throws NotFoundException for an unknown user", async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+      await expect(
+        service.setPregnancyExclusion("missing", true),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/src/api/src/modules/users/users.service.ts
+++ b/src/api/src/modules/users/users.service.ts
@@ -1,8 +1,13 @@
-import { Injectable, NotFoundException, BadRequestException, UnauthorizedException } from '@nestjs/common';
-import { Pool, PoolClient } from 'pg';
-import * as bcrypt from 'bcryptjs';
-import { createHash } from 'crypto';
-import { getDisplayTier } from '../../../../shared/libs/integrity';
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  UnauthorizedException,
+} from "@nestjs/common";
+import { Pool, PoolClient } from "pg";
+import * as bcrypt from "bcryptjs";
+import { createHash } from "crypto";
+import { getDisplayTier } from "../../../../shared/libs/integrity";
 
 const BCRYPT_ROUNDS = 10;
 // SH12 — INVARIANT: these MUST stay byte-for-byte identical to
@@ -16,7 +21,8 @@ const BCRYPT_ROUNDS = 10;
 // (not delegated to TruthLogService) only because UsersModule does not provide
 // TruthLogService for injection and wiring it in requires editing users.module.ts
 // (out of scope here). See report note on the SH12 coupling.
-const GENESIS_HASH = '0000000000000000000000000000000000000000000000000000000000000000';
+const GENESIS_HASH =
+  "0000000000000000000000000000000000000000000000000000000000000000";
 const TRUTH_LOG_APPEND_LOCK_KEY = 0x57_54_4c_47; // 'WTLG'
 
 @Injectable()
@@ -30,22 +36,33 @@ export class UsersService {
    * advisory lock and SHA256(index|event_type|timestamp|prev|payload) preimage so
    * the chain stays consistent regardless of which writer appends.
    */
-  private async appendTruthLogEvent(eventType: string, payload: Record<string, unknown>): Promise<void> {
+  private async appendTruthLogEvent(
+    eventType: string,
+    payload: Record<string, unknown>,
+  ): Promise<void> {
     const client: PoolClient = await this.pool.connect();
     try {
-      await client.query('BEGIN');
-      await client.query('SELECT pg_advisory_xact_lock($1)', [TRUTH_LOG_APPEND_LOCK_KEY]);
+      await client.query("BEGIN");
+      await client.query("SELECT pg_advisory_xact_lock($1)", [
+        TRUTH_LOG_APPEND_LOCK_KEY,
+      ]);
 
       const latestRes = await client.query(
         `SELECT sequence_index, current_hash FROM event_log ORDER BY sequence_index DESC LIMIT 1 FOR UPDATE`,
       );
-      const previousHash = latestRes.rows.length > 0 ? latestRes.rows[0].current_hash : GENESIS_HASH;
-      const nextIndex = latestRes.rows.length > 0 ? parseInt(latestRes.rows[0].sequence_index, 10) + 1 : 1;
+      const previousHash =
+        latestRes.rows.length > 0
+          ? latestRes.rows[0].current_hash
+          : GENESIS_HASH;
+      const nextIndex =
+        latestRes.rows.length > 0
+          ? parseInt(latestRes.rows[0].sequence_index, 10) + 1
+          : 1;
       const timestamp = new Date().toISOString();
 
       const payloadString = JSON.stringify(payload);
       const hashInput = `${nextIndex}|${eventType}|${timestamp}|${previousHash}|${payloadString}`;
-      const currentHash = createHash('sha256').update(hashInput).digest('hex');
+      const currentHash = createHash("sha256").update(hashInput).digest("hex");
 
       await client.query(
         `INSERT INTO event_log (sequence_index, event_type, payload, previous_hash, current_hash, created_at)
@@ -62,9 +79,9 @@ export class UsersService {
         [nextIndex],
       );
 
-      await client.query('COMMIT');
+      await client.query("COMMIT");
     } catch (e) {
-      await client.query('ROLLBACK');
+      await client.query("ROLLBACK");
       throw e;
     } finally {
       client.release();
@@ -107,13 +124,16 @@ export class UsersService {
       status: row.status,
       created_at: row.created_at,
       compliance: {
-        kyc_status: row.kyc_status ?? 'NOT_STARTED',
-        age_verification_status: row.age_verification_status ?? 'NOT_STARTED',
+        kyc_status: row.kyc_status ?? "NOT_STARTED",
+        age_verification_status: row.age_verification_status ?? "NOT_STARTED",
         identity_provider: row.identity_provider ?? null,
         identity_verification_id: row.identity_verification_id ?? null,
         identity_verified_at: row.identity_verified_at ?? null,
-        is_kyc_verified: String(row.kyc_status || '').toUpperCase() === 'VERIFIED',
-        is_age_verified: ['VERIFIED', 'SELF_DECLARED'].includes(String(row.age_verification_status || '').toUpperCase()),
+        is_kyc_verified:
+          String(row.kyc_status || "").toUpperCase() === "VERIFIED",
+        is_age_verified: ["VERIFIED", "SELF_DECLARED"].includes(
+          String(row.age_verification_status || "").toUpperCase(),
+        ),
         terms_accepted_at: row.terms_accepted_at ?? null,
         terms_version: row.terms_version ?? null,
       },
@@ -131,16 +151,23 @@ export class UsersService {
     return result.rows;
   }
 
-  async changePassword(userId: string, currentPassword: string, newPassword: string) { // allow-secret
+  async changePassword(
+    userId: string,
+    currentPassword: string,
+    newPassword: string,
+  ) {
+    // allow-secret
     if (!currentPassword || !newPassword) {
-      throw new BadRequestException('Current and new passwords are required');
+      throw new BadRequestException("Current and new passwords are required");
     }
     if (newPassword.length < 8) {
-      throw new BadRequestException('New password must be at least 8 characters');
+      throw new BadRequestException(
+        "New password must be at least 8 characters",
+      );
     }
 
     const result = await this.pool.query(
-      'SELECT id, password_hash FROM users WHERE id = $1',
+      "SELECT id, password_hash FROM users WHERE id = $1",
       [userId],
     );
     if (result.rows.length === 0) {
@@ -150,19 +177,19 @@ export class UsersService {
     const user = result.rows[0];
 
     if (!user.password_hash) {
-      throw new BadRequestException('Account does not have a password set');
+      throw new BadRequestException("Account does not have a password set");
     }
 
     const valid = await bcrypt.compare(currentPassword, user.password_hash);
     if (!valid) {
-      throw new UnauthorizedException('Current password is incorrect');
+      throw new UnauthorizedException("Current password is incorrect");
     }
 
     const newHash = await bcrypt.hash(newPassword, BCRYPT_ROUNDS);
-    await this.pool.query(
-      'UPDATE users SET password_hash = $1 WHERE id = $2',
-      [newHash, userId],
-    );
+    await this.pool.query("UPDATE users SET password_hash = $1 WHERE id = $2", [
+      newHash,
+      userId,
+    ]);
 
     // AU12: revoke all existing refresh tokens on password change. Otherwise the
     // 7-day refresh tokens issued before the change stay valid and an attacker who
@@ -174,7 +201,7 @@ export class UsersService {
     // sync with AuthService.revokeRefreshTokensForUser.
     await this.revokeRefreshTokensForUser(userId);
 
-    return { status: 'password_updated' };
+    return { status: "password_updated" };
   }
 
   /**
@@ -194,10 +221,9 @@ export class UsersService {
   ) {
     // Store notification preferences as JSONB metadata on the user
     // For now, we use the existing table — in production this would be a separate user_settings table
-    const result = await this.pool.query(
-      'SELECT id FROM users WHERE id = $1',
-      [userId],
-    );
+    const result = await this.pool.query("SELECT id FROM users WHERE id = $1", [
+      userId,
+    ]);
     if (result.rows.length === 0) {
       throw new NotFoundException(`User ${userId} not found`);
     }
@@ -210,14 +236,14 @@ export class UsersService {
     };
 
     // Append to the tamper-evident chain so the audit trail stays linked.
-    await this.appendTruthLogEvent('SETTINGS_UPDATED', payload);
+    await this.appendTruthLogEvent("SETTINGS_UPDATED", payload);
 
-    return { status: 'settings_updated' };
+    return { status: "settings_updated" };
   }
 
   async requestDeletion(userId: string) {
     const result = await this.pool.query(
-      'SELECT id, status FROM users WHERE id = $1',
+      "SELECT id, status FROM users WHERE id = $1",
       [userId],
     );
     if (result.rows.length === 0) {
@@ -231,14 +257,14 @@ export class UsersService {
     );
 
     // Log the deletion request to the tamper-evident chain.
-    await this.appendTruthLogEvent('ACCOUNT_DELETION_REQUESTED', { userId });
+    await this.appendTruthLogEvent("ACCOUNT_DELETION_REQUESTED", { userId });
 
-    return { status: 'deletion_requested' };
+    return { status: "deletion_requested" };
   }
 
   async getPublicProfile(userId: string) {
     const result = await this.pool.query(
-      'SELECT id, integrity_score, created_at FROM users WHERE id = $1',
+      "SELECT id, integrity_score, created_at FROM users WHERE id = $1",
       [userId],
     );
     if (result.rows.length === 0) {
@@ -250,8 +276,8 @@ export class UsersService {
   async getLeaderboard(limit: number = 10, period?: string) {
     const maxLimit = Math.min(limit, 100);
 
-    let intervalFilter = '';
-    if (period === 'weekly') {
+    let intervalFilter = "";
+    if (period === "weekly") {
       intervalFilter = `AND id IN (
         SELECT DISTINCT user_id FROM contracts
         WHERE created_at >= NOW() - INTERVAL '7 days'
@@ -260,7 +286,7 @@ export class UsersService {
         JOIN contracts c ON c.id = a.contract_id
         WHERE a.attestation_date >= CURRENT_DATE - 7
       )`;
-    } else if (period === 'monthly') {
+    } else if (period === "monthly") {
       intervalFilter = `AND id IN (
         SELECT DISTINCT user_id FROM contracts
         WHERE created_at >= NOW() - INTERVAL '30 days'
@@ -283,24 +309,71 @@ export class UsersService {
 
   async setSelfExclusion(userId: string, durationDays: number) {
     if (durationDays < 1 || durationDays > 365) {
-      throw new BadRequestException('Duration must be between 1 and 365 days');
+      throw new BadRequestException("Duration must be between 1 and 365 days");
     }
 
     const expiresAt = new Date();
     expiresAt.setDate(expiresAt.getDate() + durationDays);
 
     await this.pool.query(
-      'UPDATE users SET self_exclusion_expires_at = $1 WHERE id = $2',
+      "UPDATE users SET self_exclusion_expires_at = $1 WHERE id = $2",
       [expiresAt.toISOString(), userId],
     );
 
     // Log to the tamper-evident audit chain.
-    await this.appendTruthLogEvent('SELF_EXCLUSION_ACTIVATED', {
+    await this.appendTruthLogEvent("SELF_EXCLUSION_ACTIVATED", {
       userId,
       durationDays,
       expiresAt: expiresAt.toISOString(),
     });
 
-    return { status: 'self_exclusion_activated', expiresAt };
+    return { status: "self_exclusion_activated", expiresAt };
+  }
+
+  /**
+   * H3 (Triadic Review): pregnancy_exclusion column existed in the users
+   * table (migration 039) and the createContract gate honored it, but
+   * nothing ever set it. This is the self-report endpoint that wires the
+   * user-facing toggle to the column. Activation / deactivation is
+   * recorded in pregnancy_exclusion_events (migration 040) for compliance
+   * auditability and to support a future reversion / "I clicked wrong"
+   * workflow.
+   */
+  async setPregnancyExclusion(
+    userId: string,
+    active: boolean,
+  ): Promise<{
+    pregnancy_exclusion: boolean;
+    pregnancy_exclusion_at: string | null;
+  }> {
+    const { rows } = await this.pool.query(
+      `UPDATE users
+         SET pregnancy_exclusion = $2,
+             pregnancy_exclusion_at = CASE WHEN $2 THEN NOW() ELSE NULL END
+       WHERE id = $1
+       RETURNING pregnancy_exclusion, pregnancy_exclusion_at`,
+      [userId, active],
+    );
+    if (rows.length === 0) {
+      throw new NotFoundException(`User ${userId} not found`);
+    }
+
+    await this.pool.query(
+      `INSERT INTO pregnancy_exclusion_events (user_id, event_type, source)
+       VALUES ($1, $2, 'SELF_REPORT')`,
+      [userId, active ? "ACTIVATED" : "DEACTIVATED"],
+    );
+
+    await this.appendTruthLogEvent(
+      active
+        ? "PREGNANCY_EXCLUSION_ACTIVATED"
+        : "PREGNANCY_EXCLUSION_DEACTIVATED",
+      { userId },
+    );
+
+    return {
+      pregnancy_exclusion: rows[0].pregnancy_exclusion,
+      pregnancy_exclusion_at: rows[0].pregnancy_exclusion_at,
+    };
   }
 }


### PR DESCRIPTION
H1: subscribeToDevice now writes a real row to commitment_device_subscriptions (migration 040) and validates device_id against the catalog. unsubscribeFromDevice counterpart. New BehavioralController exposes the service over HTTP (the module previously had no controller).

H3: POST /users/me/pregnancy-exclusion {active: bool} sets users.pregnancy_exclusion, stamps pregnancy_exclusion_at, writes an audit row to pregnancy_exclusion_events (migration 040), and appends PREGNANCY_EXCLUSION_ACTIVATED|DEACTIVATED to the tamper-evident truth log. The column existed and the createContract gate honored it, but no API path ever set it.

1188 API tests pass.