### PR TITLE
fix: restore two services wrongly deleted in PR #660 as duplicates

### DIFF
--- a/src/api/services/fury-router/honeypot-engine-wrapper.service.ts
+++ b/src/api/services/fury-router/honeypot-engine-wrapper.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from "@nestjs/common";
+import {
+  HoneypotEngine as SharedEngine,
+  HoneypotArtifact,
+} from "../../../shared/fury-logic/index.ts";
+
+/**
+ * HoneypotEngineWrapper
+ *
+ * Distinct from the canonical HoneypotService in services/intelligence/,
+ * which is a cron-based synthetic-proof injector. This class is a thin
+ * Nest-injectable subclass of the shared HoneypotEngine, suitable for
+ * dependency injection into the fury-router pipeline when the router wants
+ * a class-typed engine rather than the singleton functions exported by
+ * shared/fury-logic.
+ *
+ * Restored from the deletion in PR #660. The deletion was based on a
+ * "no callers" grep, but the value of the file is providing a class
+ * handle to the shared engine for DI consumers; callers can be added when
+ * the fury-router is refactored to use DI rather than function imports.
+ */
+@Injectable()
+export class HoneypotEngineWrapper extends SharedEngine {}
+export { HoneypotArtifact };

--- a/src/api/src/modules/behavioral/behavioral.module.ts
+++ b/src/api/src/modules/behavioral/behavioral.module.ts
@@ -1,12 +1,13 @@
 import { Module, forwardRef } from "@nestjs/common";
 import { BehavioralEnhancementsService } from "./behavioral-enhancements.service";
 import { BehavioralController } from "./behavioral.controller";
+import { RecoveryStatusCalculator } from "./recovery-status.calculator";
 import { ContractsModule } from "../contracts/contracts.module";
 
 @Module({
   imports: [forwardRef(() => ContractsModule)],
   controllers: [BehavioralController],
-  providers: [BehavioralEnhancementsService],
-  exports: [BehavioralEnhancementsService],
+  providers: [BehavioralEnhancementsService, RecoveryStatusCalculator],
+  exports: [BehavioralEnhancementsService, RecoveryStatusCalculator],
 })
 export class BehavioralModule {}

--- a/src/api/src/modules/behavioral/recovery-status.calculator.spec.ts
+++ b/src/api/src/modules/behavioral/recovery-status.calculator.spec.ts
@@ -1,0 +1,54 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { RecoveryStatusCalculator } from "./recovery-status.calculator";
+
+describe("RecoveryStatusCalculator", () => {
+  let calculator: RecoveryStatusCalculator;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RecoveryStatusCalculator],
+    }).compile();
+    calculator = module.get<RecoveryStatusCalculator>(RecoveryStatusCalculator);
+  });
+
+  it("computes days remaining and a non-zero loss velocity for a mid-life contract", () => {
+    const start = new Date(Date.now() - 5 * 86_400_000);
+    const result = calculator.getStatus({
+      id: "c-1",
+      startDate: start,
+      durationDays: 30,
+      baseVolatility: 0.5,
+    });
+    expect(result.contractId).toBe("c-1");
+    expect(result.daysRemaining).toBeGreaterThan(20);
+    expect(result.daysRemaining).toBeLessThanOrEqual(25);
+    expect(result.lossVelocity).toBeGreaterThan(0);
+    expect(result.riskLevel).toMatch(/^(LOW|MEDIUM|HIGH)$/);
+  });
+
+  it("clamps daysRemaining to 0 for an expired contract", () => {
+    const result = calculator.getStatus({
+      id: "c-2",
+      startDate: new Date(Date.now() - 60 * 86_400_000),
+      durationDays: 30,
+      baseVolatility: 0.5,
+    });
+    expect(result.daysRemaining).toBe(0);
+  });
+
+  it("scales the penalty multiplier with baseVolatility", () => {
+    const low = calculator.getStatus({
+      id: "c-3",
+      startDate: new Date(),
+      durationDays: 30,
+      baseVolatility: 0.1,
+    });
+    const high = calculator.getStatus({
+      id: "c-4",
+      startDate: new Date(),
+      durationDays: 30,
+      baseVolatility: 5.0,
+    });
+    expect(high.currentMultiplier).toBeGreaterThan(low.currentMultiplier);
+  });
+});

--- a/src/api/src/modules/behavioral/recovery-status.calculator.ts
+++ b/src/api/src/modules/behavioral/recovery-status.calculator.ts
@@ -1,0 +1,67 @@
+import { Injectable } from "@nestjs/common";
+import { LossAversionEngine } from "../../../../shared/behavioral-physics/loss-aversion.engine";
+import { VolatilityEngine } from "../../../../shared/behavioral-physics/volatility.engine";
+
+/**
+ * RecoveryStatusCalculator
+ *
+ * Distinct from the canonical RecoveryProtocolService in services/health/,
+ * which enforces isolation-risk guardrails on recovery contracts. This class
+ * calculates real-time behavioral-status metrics — loss velocity, current
+ * multiplier, and risk level — for the dashboard / attestation UI.
+ *
+ * Restored from the deletion in PR #660. That PR incorrectly classified this
+ * file as a "duplicate" of services/health/recovery-protocol.service.ts
+ * because of the class-name collision; in fact the two services do
+ * different work (guardrail enforcement vs. metric calculation) and this
+ * one had no callers only because it was never wired into a module.
+ */
+
+export interface RecoveryStatus {
+  contractId: string;
+  daysRemaining: number;
+  currentMultiplier: number;
+  lossVelocity: number;
+  riskLevel: "LOW" | "MEDIUM" | "HIGH";
+}
+
+@Injectable()
+export class RecoveryStatusCalculator {
+  private lossEngine = new LossAversionEngine();
+  private volatilityEngine = new VolatilityEngine();
+
+  public getStatus(contract: {
+    id: string;
+    startDate: Date;
+    durationDays: number;
+    baseVolatility: number;
+  }): RecoveryStatus {
+    const now = new Date();
+    const elapsedMs = now.getTime() - contract.startDate.getTime();
+    const elapsedDays = elapsedMs / (1000 * 60 * 60 * 24);
+    const daysRemaining = Math.max(0, contract.durationDays - elapsedDays);
+
+    const temporalMultiplier = this.volatilityEngine.getTemporalMultiplier(now);
+    const lossVelocity = this.lossEngine.calculateLossVelocity(
+      daysRemaining,
+      contract.durationDays,
+    );
+
+    const currentVolatility = contract.baseVolatility * temporalMultiplier;
+    const currentMultiplier =
+      this.lossEngine.calculatePenaltyMultiplier(currentVolatility);
+
+    let riskLevel: "LOW" | "MEDIUM" | "HIGH" = "LOW";
+    if (temporalMultiplier > 1.25 || lossVelocity > 0.7) riskLevel = "HIGH";
+    else if (temporalMultiplier > 1.0 || lossVelocity > 0.4)
+      riskLevel = "MEDIUM";
+
+    return {
+      contractId: contract.id,
+      daysRemaining: Math.round(daysRemaining * 10) / 10,
+      currentMultiplier: Math.round(currentMultiplier * 1000) / 1000,
+      lossVelocity: Math.round(lossVelocity * 100) / 100,
+      riskLevel,
+    };
+  }
+}


### PR DESCRIPTION
PR #660 deleted two files based on a class-name grep that conflated 'same name' with 'duplicate implementation'. Both files had unique logic that was lost.

**1. `src/api/src/modules/behavioral/recovery-protocol.service.ts` → `recovery-status.calculator.ts`**
- Class renamed `RecoveryProtocolService` → `RecoveryStatusCalculator` to avoid the name collision with the canonical one in `services/health/`.
- The canonical `services/health/recovery-protocol.service.ts` enforces isolation-risk guardrails on recovery contracts (no-contact identifiers, anti-isolation limits, ethical acknowledgments).
- This one calculates behavioral-physics metrics: loss velocity, current multiplier, and risk level using `LossAversionEngine` + `VolatilityEngine`.
- Different responsibility, different module, different fate. Both should coexist.

**2. `src/api/services/fury-router/honeypot.service.ts` → `honeypot-engine-wrapper.service.ts`**
- Class renamed `HoneypotService` → `HoneypotEngineWrapper` to avoid the name collision with the canonical one in `services/intelligence/`.
- The canonical `services/intelligence/honeypot.service.ts` is a cron-based synthetic-proof injector with varied descriptions, integrity scoring, and Fury accuracy grading.
- This one is a Nest-injectable subclass of the shared `HoneypotEngine`, providing a class-typed handle for DI consumers. No callers today, but the value is its DI surface — useful when the fury-router is refactored to use DI rather than function imports from `shared/fury-logic`.

**Module wiring:** `BehavioralModule` now also provides + exports `RecoveryStatusCalculator` so the class is reachable. The 'no callers' grep in #660 was a symptom of missing DI wiring, not evidence of dead code.

**Tests:** 3 new cases in `recovery-status.calculator.spec.ts` (mid-life contract, expired contract, multiplier-scaling-with-volatility). 1191 API tests pass (up from 1188).

**Why this is a recovery, not a new feature:** The original files existed prior to #660 and were deleted by it. This PR restores the unique code that was wrongly classified as duplicate.