### PR TITLE
test(e2e): scope auth cookie by env-derived origin via seedAuthCookie helper

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { setupUnauthenticatedMocks, MOCK_USER, MOCK_CSRF_TOKEN } from './fixtures/api-mocks';
+import { seedAuthCookie } from './fixtures/auth-cookie';
 
 test.describe('Authentication', () => {
   test.beforeEach(async ({ page }) => {
@@ -116,9 +117,7 @@ test.describe('Authentication', () => {
     // Pre-seed the auth cookie so the post-register redirect lands on /dashboard
     // (proxy.ts gates protected routes on the styx_auth_token cookie) instead of
     // bouncing back to /login — this asserts the true register-success path.
-    await page.context().addCookies([
-      { name: 'styx_auth_token', value: 'jwt-e2e-token', domain: 'localhost', path: '/' },
-    ]);
+    await seedAuthCookie(page, 'jwt-e2e-token');
 
     await page.goto('/register');
     await page.fill('input[type="email"], input[name="email"]', 'new@styx.test');

--- a/e2e/fixtures/auth-cookie.ts
+++ b/e2e/fixtures/auth-cookie.ts
@@ -1,0 +1,21 @@
+import { Page } from '@playwright/test';
+
+function resolveE2EBaseUrl(): string {
+  const rawUrl =
+    process.env.E2E_BASE_URL ||
+    process.env.STYX_WEB_PUBLIC_URL ||
+    process.env.NEXT_PUBLIC_WEB_URL ||
+    'http://localhost:3001';
+
+  return new URL(rawUrl).origin;
+}
+
+export async function seedAuthCookie(page: Page, token = 'jwt-e2e-test-token') {
+  await page.context().addCookies([
+    {
+      name: 'styx_auth_token',
+      value: token,
+      url: resolveE2EBaseUrl(),
+    },
+  ]);
+}

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,5 +1,6 @@
 import { test as base, Page } from '@playwright/test';
-import { setupAuthenticatedMocks, MOCK_USER, MOCK_CSRF_TOKEN } from './api-mocks';
+import { setupAuthenticatedMocks, MOCK_USER } from './api-mocks';
+import { seedAuthCookie } from './auth-cookie';
 
 /**
  * Extended test fixture providing an authenticated page.
@@ -39,14 +40,7 @@ export const test = base.extend<{ authenticatedPage: Page }>({
     // (server-side, so it cannot see localStorage or client-side route mocks).
     // The previous `localStorage.styx_token` injection was inert — the app
     // reads no such key — which is why authenticated specs landed on /login.
-    await page.context().addCookies([
-      {
-        name: 'styx_auth_token',
-        value: 'jwt-e2e-test-token',
-        domain: 'localhost',
-        path: '/',
-      },
-    ]);
+    await seedAuthCookie(page);
 
     await use(page);
   },


### PR DESCRIPTION
## Summary
- The e2e auth fixtures hardcoded `domain: 'localhost', path: '/'` when seeding the `styx_auth_token` cookie, but the dev server origin is env-derived (`run-web.mjs` derives the port from `E2E_BASE_URL`/`STYX_WEB_PUBLIC_URL`), so the cookie landed on the wrong origin and authenticated specs bounced to `/login` instead of `/dashboard`.
- Extracts `seedAuthCookie(page, token?)` into `e2e/fixtures/auth-cookie.ts`: resolves `E2E_BASE_URL` > `STYX_WEB_PUBLIC_URL` > `NEXT_PUBLIC_WEB_URL` (fallback `http://localhost:3001`) and uses Playwright's `url:` cookie scoping so the cookie lands on the actual server origin.
- `e2e/auth.spec.ts` and `e2e/fixtures/auth.ts` now call the shared helper instead of duplicating the cookie literal.

## Provenance
Recovered from an interrupted Codex session (`019ead60-5689-7f83-82d5-99ad24cb5d02`, branch was local-only/uncommitted). Part of the every-surface session finishline walk (`session-meta/codex/session-lifecycle/2026-06-09-codex-desktop-root-to-leaf/`).

## Test plan
- [x] `npx playwright test e2e/auth.spec.ts --config .config/playwright/playwright.config.ts --list` — 28 tests collected across 5 projects, new fixture import resolves
- [ ] Full server+browser e2e run in CI (host machine is RAM-constrained; deferring the heavy run to CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)