### PR TITLE
feat(styx-cli): operational wrapper for the Audience Growth Engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6777,6 +6777,10 @@
       "resolved": "src/shared",
       "link": true
     },
+    "node_modules/@styx/styx-cli": {
+      "resolved": "packages/styx-cli",
+      "link": true
+    },
     "node_modules/@styx/test-harness": {
       "resolved": "src/test-harness",
       "link": true
@@ -22469,6 +22473,25 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "packages/styx-cli": {
+      "name": "@styx/styx-cli",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@styx/audience-engine": "0.1.0"
+      },
+      "bin": {
+        "styx": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.5.0",
+        "vitest": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "src/api": {

--- a/packages/audience-engine/src/index.ts
+++ b/packages/audience-engine/src/index.ts
@@ -7,7 +7,7 @@
  */
 
 export { loadConfig } from "./loaders/config.js";
-export { generatePlan } from "./generators/plan.js";
+export { generatePlan, parseDateNoTimezoneDrift } from "./generators/plan.js";
 export { renderMarkdown } from "./generators/markdown.js";
 export type {
   InstanceConfig,

--- a/packages/styx-cli/package.json
+++ b/packages/styx-cli/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@styx/styx-cli",
+  "version": "0.1.0",
+  "description": "Operational wrapper for the Audience Growth Engine, tuned for Styx/Jessica. Runs the engine with Styx defaults and logs weekly metrics.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "styx": "dist/cli.js"
+  },
+  "files": [
+    "dist",
+    "templates"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "lint": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@styx/audience-engine": "0.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.5.0",
+    "vitest": "^4.1.0"
+  },
+  "keywords": [
+    "styx",
+    "audience-engine",
+    "cli",
+    "no-contact",
+    "jessica"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/packages/styx-cli/src/cli.ts
+++ b/packages/styx-cli/src/cli.ts
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * @styx/styx-cli — Operational wrapper for the Audience Growth Engine.
+ *
+ * Two commands:
+ *   styx plan-week [--start <iso>] [--output <md>]
+ *       Run the engine with Styx defaults (templates/styx-instance.yaml),
+ *       write the 30-day plan to <md> (default: outbox/styx/<week>.md).
+ *
+ *   styx log-week --week <YYYY-WNN> --followers <N> --email <N> [--opens <%>] [--waitlist <N>]
+ *       Append a row to the weekly metrics log.
+ *
+ * The CLI is the friendly face of the engine. Jessica (or any operator)
+ * can run it without reading the playbook.
+ */
+
+import { writeFile, mkdir, readFile, appendFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import {
+  loadConfig,
+  generatePlan,
+  renderMarkdown,
+  parseDateNoTimezoneDrift,
+} from "@styx/audience-engine";
+
+function printUsage(): void {
+  console.log(`@styx/styx-cli — Operational wrapper for the Audience Growth Engine
+
+Usage:
+  styx plan-week [--start <iso>] [--output <md>]
+  styx log-week --week <YYYY-WNN> --followers <N> --email <N> [--opens <%>] [--waitlist <N>]
+
+Commands:
+  plan-week   Generate the 30-day content plan for Styx/Jessica
+  log-week    Append a row to the weekly metrics log
+
+Options:
+  --start     Start date in ISO format (default: next Monday)
+  --output    Output path (default: outbox/styx/<week>.md)
+  --week      ISO week (e.g. 2026-W24) for log-week
+  --followers Follower count (net) for log-week
+  --email     Email subscriber count (net) for log-week
+  --opens     Brief open rate (%), optional
+  --waitlist  Qualified waitlist count, optional
+  --help      Show this help
+`);
+}
+
+function findDefaultConfig(): string {
+  // The default Styx config is in the audience-engine package's templates.
+  // We look for it relative to the current working directory first, then
+  // in the package's node_modules.
+  const candidates = [
+    resolve("packages/audience-engine/templates/styx-instance.yaml"),
+    resolve("node_modules/@styx/audience-engine/templates/styx-instance.yaml"),
+    resolve("../audience-engine/templates/styx-instance.yaml"),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    "Could not find templates/styx-instance.yaml. Run from the repo root, or pass --config <path>.",
+  );
+}
+
+interface PlanWeekArgs {
+  start?: string;
+  output?: string;
+  config?: string;
+}
+
+async function cmdPlanWeek(args: PlanWeekArgs): Promise<number> {
+  const configPath = args.config ?? findDefaultConfig();
+  let config;
+  try {
+    config = await loadConfig(configPath);
+  } catch (err) {
+    console.error(
+      `✗ Config invalid: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return 1;
+  }
+  const startDate = args.start
+    ? parseDateNoTimezoneDrift(args.start)
+    : undefined;
+  const plan = generatePlan(config, startDate);
+  const markdown = renderMarkdown(plan);
+  const week = isoWeekString(plan.startDate);
+  const outPath = resolve(args.output ?? `outbox/styx/${week}.md`);
+  await mkdir(dirname(outPath), { recursive: true });
+  await writeFile(outPath, markdown, "utf-8");
+  const placed = plan.weeks.reduce((n, w) => n + w.days.length, 0);
+  console.error(
+    `✓ Wrote 30-day Styx plan to ${outPath} (${plan.weeks.length} buckets, ${placed} placed slots)`,
+  );
+  console.error(`  Window: ${plan.startDate} → ${plan.endDate}`);
+  return 0;
+}
+
+interface LogWeekArgs {
+  week: string;
+  followers: number;
+  email: number;
+  opens?: number;
+  waitlist?: number;
+  metricsFile?: string;
+}
+
+async function cmdLogWeek(args: LogWeekArgs): Promise<number> {
+  const file = resolve(
+    args.metricsFile ??
+      process.env.STYX_METRICS_FILE ??
+      "outbox/styx/metrics.csv",
+  );
+  await mkdir(dirname(file), { recursive: true });
+  const row = [
+    args.week,
+    String(args.followers),
+    String(args.email),
+    args.opens !== undefined ? String(args.opens) : "",
+    args.waitlist !== undefined ? String(args.waitlist) : "",
+  ].join(",");
+  const exists = existsSync(file);
+  if (!exists) {
+    const header = "week,followers_net,email_net,opens_pct,waitlist\n";
+    await writeFile(file, header + row + "\n", "utf-8");
+  } else {
+    await appendFile(file, row + "\n", "utf-8");
+  }
+  console.error(`✓ Appended ${args.week} to ${file}`);
+  return 0;
+}
+
+function isoWeekString(isoDate: string): string {
+  // Convert "YYYY-MM-DD" to "YYYY-WNN" using ISO week numbering.
+  const d = new Date(isoDate);
+  const target = new Date(d.valueOf());
+  const dayNr = (d.getDay() + 6) % 7;
+  target.setDate(target.getDate() - dayNr + 3);
+  const firstThursday = target.valueOf();
+  target.setMonth(0, 1);
+  if (target.getDay() !== 4) {
+    target.setMonth(0, 1 + ((4 - target.getDay() + 7) % 7));
+  }
+  const weekNumber =
+    1 + Math.ceil((firstThursday - target.valueOf()) / 604800000);
+  return `${d.getFullYear()}-W${String(weekNumber).padStart(2, "0")}`;
+}
+
+function parseArgs(argv: string[]): {
+  command: string;
+  args: Record<string, string>;
+} {
+  const [, , command, ...rest] = argv;
+  const args: Record<string, string> = {};
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i];
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+      const value = rest[i + 1];
+      if (value && !value.startsWith("--")) {
+        args[key] = value;
+        i++;
+      } else {
+        args[key] = "true";
+      }
+    }
+  }
+  return { command: command ?? "help", args };
+}
+
+async function main(): Promise<number> {
+  const { command, args } = parseArgs(process.argv);
+  if (command === "help" || args.help === "true") {
+    printUsage();
+    return 0;
+  }
+  if (command === "plan-week") {
+    return cmdPlanWeek(args as unknown as PlanWeekArgs);
+  }
+  if (command === "log-week") {
+    if (!args.week || !args.followers || !args.email) {
+      console.error("Error: log-week requires --week, --followers, --email");
+      printUsage();
+      return 2;
+    }
+    return cmdLogWeek({
+      week: args.week,
+      followers: Number(args.followers),
+      email: Number(args.email),
+      opens: args.opens !== undefined ? Number(args.opens) : undefined,
+      waitlist: args.waitlist !== undefined ? Number(args.waitlist) : undefined,
+      metricsFile: args["metrics-file"],
+    });
+  }
+  console.error(`Unknown command: ${command}`);
+  printUsage();
+  return 2;
+}
+
+main().then((code) => process.exit(code));

--- a/packages/styx-cli/src/cli.ts
+++ b/packages/styx-cli/src/cli.ts
@@ -17,12 +17,14 @@
 import { writeFile, mkdir, readFile, appendFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { createRequire } from "node:module";
 import {
   loadConfig,
   generatePlan,
   renderMarkdown,
   parseDateNoTimezoneDrift,
 } from "@styx/audience-engine";
+import { isoWeekString } from "./iso-week.js";
 
 function printUsage(): void {
   console.log(`@styx/styx-cli — Operational wrapper for the Audience Growth Engine
@@ -48,22 +50,16 @@ Options:
 }
 
 function findDefaultConfig(): string {
-  // The default Styx config is in the audience-engine package's templates.
-  // We look for it relative to the current working directory first, then
-  // in the package's node_modules.
-  const candidates = [
-    resolve("packages/audience-engine/templates/styx-instance.yaml"),
-    resolve("node_modules/@styx/audience-engine/templates/styx-instance.yaml"),
-    resolve("../audience-engine/templates/styx-instance.yaml"),
-  ];
-  for (const candidate of candidates) {
-    if (existsSync(candidate)) {
-      return candidate;
-    }
-  }
-  throw new Error(
-    "Could not find templates/styx-instance.yaml. Run from the repo root, or pass --config <path>.",
+  const pkgRequire = createRequire(
+    require.resolve("@styx/audience-engine/package.json"),
   );
+  try {
+    return pkgRequire.resolve("@styx/audience-engine/templates/styx-instance.yaml");
+  } catch {
+    throw new Error(
+      "Could not find templates/styx-instance.yaml in @styx/audience-engine. Pass --config <path>.",
+    );
+  }
 }
 
 interface PlanWeekArgs {
@@ -86,6 +82,10 @@ async function cmdPlanWeek(args: PlanWeekArgs): Promise<number> {
   const startDate = args.start
     ? parseDateNoTimezoneDrift(args.start)
     : undefined;
+  if (startDate && Number.isNaN(startDate.getTime())) {
+    console.error(`✗ Invalid start date: ${args.start}`);
+    return 1;
+  }
   const plan = generatePlan(config, startDate);
   const markdown = renderMarkdown(plan);
   const week = isoWeekString(plan.startDate);
@@ -134,22 +134,6 @@ async function cmdLogWeek(args: LogWeekArgs): Promise<number> {
   return 0;
 }
 
-function isoWeekString(isoDate: string): string {
-  // Convert "YYYY-MM-DD" to "YYYY-WNN" using ISO week numbering.
-  const d = new Date(isoDate);
-  const target = new Date(d.valueOf());
-  const dayNr = (d.getDay() + 6) % 7;
-  target.setDate(target.getDate() - dayNr + 3);
-  const firstThursday = target.valueOf();
-  target.setMonth(0, 1);
-  if (target.getDay() !== 4) {
-    target.setMonth(0, 1 + ((4 - target.getDay() + 7) % 7));
-  }
-  const weekNumber =
-    1 + Math.ceil((firstThursday - target.valueOf()) / 604800000);
-  return `${d.getFullYear()}-W${String(weekNumber).padStart(2, "0")}`;
-}
-
 function parseArgs(argv: string[]): {
   command: string;
   args: Record<string, string>;
@@ -187,12 +171,28 @@ async function main(): Promise<number> {
       printUsage();
       return 2;
     }
+    const followers = Number(args.followers);
+    const email = Number(args.email);
+    const opens = args.opens !== undefined ? Number(args.opens) : undefined;
+    const waitlist = args.waitlist !== undefined ? Number(args.waitlist) : undefined;
+    if (!Number.isFinite(followers) || !Number.isFinite(email)) {
+      console.error(`✗ Invalid metric value: --followers and --email must be numbers`);
+      return 2;
+    }
+    if (opens !== undefined && !Number.isFinite(opens)) {
+      console.error(`✗ Invalid --opens value: must be a number`);
+      return 2;
+    }
+    if (waitlist !== undefined && !Number.isFinite(waitlist)) {
+      console.error(`✗ Invalid --waitlist value: must be a number`);
+      return 2;
+    }
     return cmdLogWeek({
       week: args.week,
-      followers: Number(args.followers),
-      email: Number(args.email),
-      opens: args.opens !== undefined ? Number(args.opens) : undefined,
-      waitlist: args.waitlist !== undefined ? Number(args.waitlist) : undefined,
+      followers,
+      email,
+      opens,
+      waitlist,
       metricsFile: args["metrics-file"],
     });
   }

--- a/packages/styx-cli/src/index.ts
+++ b/packages/styx-cli/src/index.ts
@@ -1,0 +1,5 @@
+/**
+ * @styx/styx-cli — public API.
+ */
+
+export { isoWeekString } from "./iso-week.js";

--- a/packages/styx-cli/src/iso-week.test.ts
+++ b/packages/styx-cli/src/iso-week.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { isoWeekString } from "./iso-week.js";
+
+describe("isoWeekString", () => {
+  it("converts a Monday to its ISO week", () => {
+    // 2026-06-15 is a Monday → ISO week 2026-W25
+    expect(isoWeekString("2026-06-15")).toBe("2026-W25");
+  });
+
+  it("handles the first week of the year (containing Jan 4)", () => {
+    // 2026-01-05 is a Monday → ISO week 2026-W02
+    expect(isoWeekString("2026-01-05")).toBe("2026-W02");
+  });
+
+  it("handles week 1 of a year where Jan 1 is a Thursday", () => {
+    // 2026-01-01 is a Thursday → ISO week 2026-W01
+    expect(isoWeekString("2026-01-01")).toBe("2026-W01");
+  });
+
+  it("pads single-digit weeks", () => {
+    expect(isoWeekString("2026-01-08")).toBe("2026-W02");
+  });
+});

--- a/packages/styx-cli/src/iso-week.ts
+++ b/packages/styx-cli/src/iso-week.ts
@@ -1,0 +1,33 @@
+/**
+ * ISO week-numbering utility. Extracted from the CLI for testability.
+ *
+ * Given a date string "YYYY-MM-DD", returns the ISO week as "YYYY-WNN".
+ * Uses the ISO 8601 definition: weeks start Monday; the first week of
+ * a year is the one containing the first Thursday. The "ISO year" of a
+ * date near the start of January or end of December can differ from the
+ * Gregorian year (e.g. 2026-01-01 is in ISO year 2026, and 2025-12-29
+ * is also in ISO year 2026).
+ *
+ * Implementation: shift the date to the Thursday of its ISO week, then
+ * compute the week number from Jan 1 of the Thursday's year (the ISO
+ * year). All math is in UTC to avoid timezone drift — `new Date(s)` for
+ * a date-only string parses as UTC, so we use the UTC accessors.
+ */
+export function isoWeekString(isoDate: string): string {
+  const d = new Date(isoDate);
+  // Work in UTC. The input is parsed as UTC midnight for date-only
+  // strings; getUTCDate returns the same date regardless of timezone.
+  // Day of week, with Monday=1, Sunday=7.
+  const day = d.getUTCDay() || 7;
+  // Shift to the Thursday of this ISO week.
+  const utc = new Date(d.getTime());
+  utc.setUTCDate(utc.getUTCDate() + 4 - day);
+  const isoYear = utc.getUTCFullYear();
+  // Jan 1 of the ISO year.
+  const yearStart = new Date(Date.UTC(isoYear, 0, 1));
+  // Week 1 is the week containing the first Thursday.
+  const weekNumber = Math.ceil(
+    ((utc.getTime() - yearStart.getTime()) / 86400000 + 1) / 7,
+  );
+  return `${isoYear}-W${String(weekNumber).padStart(2, "0")}`;
+}

--- a/packages/styx-cli/tsconfig.json
+++ b/packages/styx-cli/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/styx-cli/vitest.config.ts
+++ b/packages/styx-cli/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+  server: {
+    deps: {
+      inline: [],
+    },
+  },
+});

--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,15 @@
     "@styx/web#lint": {
       "dependsOn": ["build"]
     },
+    "@styx/styx-cli#lint": {
+      "dependsOn": ["^build"]
+    },
+    "@styx/audience-engine#test": {
+      "dependsOn": ["^build"]
+    },
+    "@styx/styx-cli#test": {
+      "dependsOn": ["^build"]
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
Adds packages/styx-cli, the friendly face of the engine. Wraps @styx/audience-engine for Styx/Jessica defaults, plus a metric logger for the weekly review.

Two commands:
- `styx plan-week [--start <iso>] [--output <md>]`: runs the engine with the bundled Styx config and writes the 30-day plan
- `styx log-week --week <YYYY-WNN> --followers <N> --email <N> [--opens <%>] [--waitlist <N>]`: appends to metrics.csv for the weekly review

4 vitest tests pass. CLI smoke-tested. isoWeekString uses UTC math to avoid timezone drift.