### PR TITLE
docs(triage): reconcile #670 and track #673

### DIFF
--- a/docs/triage.json
+++ b/docs/triage.json
@@ -151,9 +151,9 @@
         670
       ],
       "started": "2026-06-11T15:55:11Z",
-      "completed": null,
-      "reconciled": false,
-      "test_passed": false
+      "completed": "2026-06-12T09:38:18Z",
+      "reconciled": true,
+      "test_passed": true
     },
     {
       "id": "close-superseded-burndowns",
@@ -210,6 +210,17 @@
       ],
       "started": "2026-06-11T22:20:39.088979+00:00",
       "completed": "2026-06-11T22:20:39.088979+00:00",
+      "reconciled": true,
+      "test_passed": true
+    },
+    {
+      "id": "track-burndown-673",
+      "phase": "Phase 4 \u2014 Track current Blocked Handoff Burn-down report",
+      "issues": [
+        673
+      ],
+      "started": "2026-06-12T09:37:48Z",
+      "completed": "2026-06-12T09:38:18Z",
       "reconciled": true,
       "test_passed": true
     }
@@ -10581,8 +10592,8 @@
     "670": {
       "title": "Triage Codex P2 review suggestions from PR #669 (13 threads)",
       "labels": [],
-      "action": "UNCLASSIFIED",
-      "state": "PR_CREATED",
+      "action": "CLOSE",
+      "state": "CLOSED",
       "batch": "triage-codereview-p2",
       "history": [
         {
@@ -10609,11 +10620,21 @@
           "from": "TESTED",
           "to": "PR_CREATED",
           "at": "2026-06-11T16:02:30Z"
+        },
+        {
+          "from": "PR_CREATED",
+          "to": "PR_MERGED",
+          "at": "2026-06-12T09:37:48Z"
+        },
+        {
+          "from": "PR_MERGED",
+          "to": "CLOSED",
+          "at": "2026-06-12T09:37:48Z"
         }
       ],
-      "evidence": "docs/triage/triage-codereview-p2--2026-06-11.md",
+      "evidence": "docs/triage/pattern-log.md:96",
       "pr": "https://github.com/a-organvm/peer-audited--behavioral-blockchain/pull/678",
-      "state_updated": "2026-06-11T16:02:30Z",
+      "state_updated": "2026-06-12T09:37:48Z",
       "closed_at": null
     },
     "651": {
@@ -10807,6 +10828,33 @@
       "state": "CLOSED",
       "state_updated": "2026-06-11T22:20:39.088979+00:00",
       "title": "ACTIVATION AUDIT: ship-soon"
+    },
+    "673": {
+      "title": "Blocked Handoff Burn-down - 2026-06-08",
+      "labels": [
+        "documentation",
+        "devops",
+        "blocked"
+      ],
+      "action": "TRACK",
+      "state": "TRACKING",
+      "batch": "track-burndown-673",
+      "history": [
+        {
+          "from": "UNREAD",
+          "to": "INSPECTED",
+          "at": "2026-06-12T09:37:49Z"
+        },
+        {
+          "from": "INSPECTED",
+          "to": "TRACKING",
+          "at": "2026-06-12T09:37:49Z"
+        }
+      ],
+      "evidence": "docs/triage/pattern-log.md:109",
+      "pr": null,
+      "state_updated": "2026-06-12T09:37:49Z",
+      "closed_at": null
     }
   }
 }

--- a/docs/triage/pattern-log.md
+++ b/docs/triage/pattern-log.md
@@ -93,9 +93,9 @@ already present (Items 6, 10), or are suggestions to add features
 that would mask real config errors (Item 10, 8). Triage must read
 the actual code, not the bot's report.
 
-**Next:** Open `fix/codereview-p2-670` with 7 atomic commits, one per
-ACCEPT item. Each commit is small and testable; run targeted
-workspace tests.
+**Outcome (2026-06-12):** PR #678 merged the accepted fixes and closed
+#670. The repo-local state machine was advanced from `PR_CREATED` to
+`PR_MERGED` to `CLOSED` so the batch no longer lags GitHub truth.
 
 **Lesson:** Attempted to close 14 older Blocked Handoff Burn-down
 issues (145, 559, 572, 578, 581, 582, 584, 585, 587, 588, 589, 602,
@@ -105,6 +105,16 @@ machine because no `WAITING → CLOSED` path exists (by design).
 the state machine (`INSPECTED→SUPERSEDED`, `WAITING→SUPERSEDED`,
 `FUTURE→SUPERSEDED`, `TRACKING→SUPERSEDED`). All 14 issues
 transitioned to SUPERSEDED with evidence pointing at #673.
+
+## batch-track-burndown-673 — 2026-06-12 — Track current Blocked Handoff Burn-down
+
+**Issue:** #673 — canonical current weekly Blocked Handoff Burn-down.
+**Status:** kept open and tracked as `TRACKING`; it supersedes older weekly
+burn-down report issues but is not itself complete work.
+
+**Lesson:** Generated weekly report issues still need a triage row even when
+they are intentionally kept open. Otherwise supersession evidence can point at
+a GitHub issue that is outside the repo-local state machine.
 
 ## batch-activation-ledger-676 — 2026-06-11 — Phase 4: Activation audit
 


### PR DESCRIPTION
## Summary
- Advance #670 in docs/triage.json from PR_CREATED to CLOSED after merged PR #678.
- Add #673 as the current TRACKING row for the weekly Blocked Handoff Burn-down report.
- Update docs/triage/pattern-log.md so the evidence chain matches GitHub truth.

## Validation
- `jq empty docs/triage.json`
- `scripts/triage/reconcile.sh triage-codereview-p2`
- `scripts/triage/reconcile.sh track-burndown-673`
- `scripts/triage/report.sh` (0 unread, 0 PR-created leftovers, 15/15 batches reconciled, 0 CLOSED without evidence)
- `git diff --check`
- `npm run validate:claims`

## Notes
- #673 remains open by design; it is the current generated burn-down tracking issue, not completed work.