### PR TITLE
docs(triage): reopen not-planned closures as live work

### DIFF
--- a/docs/triage.json
+++ b/docs/triage.json
@@ -2,7 +2,7 @@
   "batches": [
     {
       "id": "close-already-impl",
-      "phase": "Phase 1 \u2014 Close already implemented",
+      "phase": "Phase 1 — Close already implemented",
       "issues": [
         29,
         30,
@@ -29,7 +29,7 @@
     },
     {
       "id": "build-tier1-quick",
-      "phase": "Tier 1 \u2014 Quick code features (tests, small fixes)",
+      "phase": "Tier 1 — Quick code features (tests, small fixes)",
       "issues": [
         207,
         44,
@@ -46,7 +46,7 @@
     },
     {
       "id": "build-tier2-services",
-      "phase": "Tier 2 \u2014 Mobile tests + oracle circuit breaker",
+      "phase": "Tier 2 — Mobile tests + oracle circuit breaker",
       "issues": [
         45,
         66
@@ -146,7 +146,7 @@
     },
     {
       "id": "triage-codereview-p2",
-      "phase": "Phase 4 \u2014 Triage Codex P2 review threads",
+      "phase": "Phase 4 — Triage Codex P2 review threads",
       "issues": [
         670
       ],
@@ -157,7 +157,7 @@
     },
     {
       "id": "close-superseded-burndowns",
-      "phase": "Phase 4 \u2014 Close superseded weekly Blocked Handoff Burn-downs (keep #673)",
+      "phase": "Phase 4 — Close superseded weekly Blocked Handoff Burn-downs (keep #673)",
       "issues": [
         145,
         559,
@@ -181,7 +181,7 @@
     },
     {
       "id": "triage-activation-676",
-      "phase": "Phase 4 \u2014 Activation audit (Issue #676)",
+      "phase": "Phase 4 — Activation audit (Issue #676)",
       "issues": [
         676
       ],
@@ -204,7 +204,7 @@
     },
     {
       "id": "triage-activation-675",
-      "phase": "Phase 4 \u2014 Activation audit (Issue #675)",
+      "phase": "Phase 4 — Activation audit (Issue #675)",
       "issues": [
         675
       ],
@@ -215,12 +215,34 @@
     },
     {
       "id": "track-burndown-673",
-      "phase": "Phase 4 \u2014 Track current Blocked Handoff Burn-down report",
+      "phase": "Phase 4 — Track current Blocked Handoff Burn-down report",
       "issues": [
         673
       ],
       "started": "2026-06-12T09:37:48Z",
       "completed": "2026-06-12T09:38:18Z",
+      "reconciled": true,
+      "test_passed": true
+    },
+    {
+      "id": "audit-not-planned-closures",
+      "phase": "Phase 4 — Repair NOT_PLANNED closure drift",
+      "issues": [
+        569,
+        561,
+        560,
+        314,
+        313,
+        312,
+        311,
+        309,
+        292,
+        289,
+        287,
+        282
+      ],
+      "started": "2026-06-12T11:46:15Z",
+      "completed": "2026-06-12T11:48:08Z",
       "reconciled": true,
       "test_passed": true
     }
@@ -245,7 +267,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:40Z",
-      "title": "feat: Resistance pattern detection engine \u2014 displacement, self-dramatization, victimhood, healing trap"
+      "title": "feat: Resistance pattern detection engine — displacement, self-dramatization, victimhood, healing trap"
     },
     "101": {
       "action": "FUTURE",
@@ -267,7 +289,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:40Z",
-      "title": "feat: AI rationalization classifier \u2014 Pressfield-informed excuse analysis via Gemini"
+      "title": "feat: AI rationalization classifier — Pressfield-informed excuse analysis via Gemini"
     },
     "102": {
       "action": "FUTURE",
@@ -289,7 +311,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:40Z",
-      "title": "feat: BBO (Bigger Better Offer) substitution engine \u2014 active craving replacement library"
+      "title": "feat: BBO (Bigger Better Offer) substitution engine — active craving replacement library"
     },
     "103": {
       "action": "FUTURE",
@@ -310,7 +332,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:40Z",
-      "title": "feat: Styx Academy \u2014 structured psychoeducation module (reward-based learning curriculum)"
+      "title": "feat: Styx Academy — structured psychoeducation module (reward-based learning curriculum)"
     },
     "104": {
       "action": "FUTURE",
@@ -331,7 +353,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:40Z",
-      "title": "feat: Zero-gap contract rollover \u2014 'Start the Next One Today' momentum bridge"
+      "title": "feat: Zero-gap contract rollover — 'Start the Next One Today' momentum bridge"
     },
     "105": {
       "action": "FUTURE",
@@ -352,7 +374,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:40Z",
-      "title": "feat: Generosity loop / Pay It Forward \u2014 prosocial reward mechanism for successful completers"
+      "title": "feat: Generosity loop / Pay It Forward — prosocial reward mechanism for successful completers"
     },
     "106": {
       "action": "FUTURE",
@@ -373,7 +395,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:40Z",
-      "title": "feat: Fury auditor wellness system \u2014 empathy fatigue prevention, bias detection, distraction flagging"
+      "title": "feat: Fury auditor wellness system — empathy fatigue prevention, bias detection, distraction flagging"
     },
     "107": {
       "action": "FUTURE",
@@ -416,7 +438,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:40Z",
-      "title": "feat: Passive proof API integrations \u2014 Strava, Duolingo, GitHub, Calm, Kindle beyond health wearables"
+      "title": "feat: Passive proof API integrations — Strava, Duolingo, GitHub, Calm, Kindle beyond health wearables"
     },
     "109": {
       "action": "FUTURE",
@@ -438,7 +460,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:40Z",
-      "title": "feat: Disenchantment score \u2014 reward devaluation tracking over contract lifecycle"
+      "title": "feat: Disenchantment score — reward devaluation tracking over contract lifecycle"
     },
     "110": {
       "action": "FUTURE",
@@ -459,7 +481,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:40Z",
-      "title": "feat: Habit discontinuity window detector \u2014 life transitions as acquisition/re-engagement triggers"
+      "title": "feat: Habit discontinuity window detector — life transitions as acquisition/re-engagement triggers"
     },
     "111": {
       "action": "FUTURE",
@@ -480,7 +502,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:40Z",
-      "title": "feat: Implementation intention contract syntax \u2014 time + location binding beyond habit stacking"
+      "title": "feat: Implementation intention contract syntax — time + location binding beyond habit stacking"
     },
     "112": {
       "action": "FUTURE",
@@ -501,7 +523,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:40Z",
-      "title": "feat: Goldilocks difficulty calibration \u2014 bidirectional adaptive challenge + overambitious timetable guard"
+      "title": "feat: Goldilocks difficulty calibration — bidirectional adaptive challenge + overambitious timetable guard"
     },
     "113": {
       "action": "BUILD",
@@ -1502,7 +1524,7 @@
       "pr": null,
       "state": "CLOSED",
       "state_updated": "2026-06-01T15:40:51Z",
-      "title": "fix: integrity score has no ceiling \u2014 fraud penalties become negligible at high scores"
+      "title": "fix: integrity score has no ceiling — fraud penalties become negligible at high scores"
     },
     "164": {
       "action": "FUTURE",
@@ -1525,7 +1547,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:41Z",
-      "title": "fix: Redis single point of failure \u2014 no HA configuration"
+      "title": "fix: Redis single point of failure — no HA configuration"
     },
     "165": {
       "action": "FUTURE",
@@ -1703,7 +1725,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:41Z",
-      "title": "docs: doctoral dissertation \u2014 epic tracker"
+      "title": "docs: doctoral dissertation — epic tracker"
     },
     "187": {
       "action": "CLOSE",
@@ -1729,7 +1751,7 @@
       "pr": null,
       "state": "CLOSED",
       "state_updated": "2026-06-01T15:40:51Z",
-      "title": "feat: Ask Styx standalone SPA \u2014 epic tracker"
+      "title": "feat: Ask Styx standalone SPA — epic tracker"
     },
     "188": {
       "action": "FUTURE",
@@ -1750,7 +1772,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:41Z",
-      "title": "audit: business/ops gap analysis \u2014 epic tracker"
+      "title": "audit: business/ops gap analysis — epic tracker"
     },
     "189": {
       "action": "FUTURE",
@@ -1771,7 +1793,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:41Z",
-      "title": "audit: stub/placeholder inventory \u2014 epic tracker"
+      "title": "audit: stub/placeholder inventory — epic tracker"
     },
     "190": {
       "action": "FUTURE",
@@ -1792,7 +1814,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:41Z",
-      "title": "audit: architecture completeness matrix \u2014 epic tracker"
+      "title": "audit: architecture completeness matrix — epic tracker"
     },
     "191": {
       "action": "FUTURE",
@@ -1813,7 +1835,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:41Z",
-      "title": "audit: cross-tool comprehensive summary \u2014 epic tracker"
+      "title": "audit: cross-tool comprehensive summary — epic tracker"
     },
     "192": {
       "action": "FUTURE",
@@ -1834,7 +1856,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:41Z",
-      "title": "governance: registry + tier promotion \u2014 epic tracker"
+      "title": "governance: registry + tier promotion — epic tracker"
     },
     "193": {
       "action": "TRACK",
@@ -1961,7 +1983,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:42Z",
-      "title": "docs: draft Chapter 1 \u2014 Introduction and Problem Statement"
+      "title": "docs: draft Chapter 1 — Introduction and Problem Statement"
     },
     "199": {
       "action": "TRACK",
@@ -2276,7 +2298,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:42Z",
-      "title": "audit: Phase 1 \u2014 read core strategic docs (implementation-status, E2G, roadmap)"
+      "title": "audit: Phase 1 — read core strategic docs (implementation-status, E2G, roadmap)"
     },
     "211": {
       "action": "TRACK",
@@ -2298,7 +2320,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:42Z",
-      "title": "audit: Phase 2 \u2014 read market & research foundation (market-analysis, competitor, behavioral-econ)"
+      "title": "audit: Phase 2 — read market & research foundation (market-analysis, competitor, behavioral-econ)"
     },
     "212": {
       "action": "TRACK",
@@ -2325,7 +2347,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:26Z",
-      "title": "audit: Phase 3 \u2014 read infrastructure & ops (render.yaml, .env.example, docker-compose, terraform)"
+      "title": "audit: Phase 3 — read infrastructure & ops (render.yaml, .env.example, docker-compose, terraform)"
     },
     "213": {
       "action": "TRACK",
@@ -2346,7 +2368,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:42Z",
-      "title": "audit: Phase 4 \u2014 search operational detail docs (ops, monitoring, support, hiring)"
+      "title": "audit: Phase 4 — search operational detail docs (ops, monitoring, support, hiring)"
     },
     "214": {
       "action": "TRACK",
@@ -2368,7 +2390,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:42Z",
-      "title": "audit: Phase 5 \u2014 search marketing & content (pitch, positioning, brand)"
+      "title": "audit: Phase 5 — search marketing & content (pitch, positioning, brand)"
     },
     "215": {
       "action": "TRACK",
@@ -2394,7 +2416,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:27Z",
-      "title": "audit: Phase 6 \u2014 search growth & retention (feedback, iteration, testing)"
+      "title": "audit: Phase 6 — search growth & retention (feedback, iteration, testing)"
     },
     "216": {
       "action": "TRACK",
@@ -2421,7 +2443,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:27Z",
-      "title": "audit: Phase 7 \u2014 read business model & metrics (b2b metrics service, revenue docs)"
+      "title": "audit: Phase 7 — read business model & metrics (b2b metrics service, revenue docs)"
     },
     "217": {
       "action": "TRACK",
@@ -2465,7 +2487,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:42Z",
-      "title": "audit: Phase 1 \u2014 grep comment markers (TODO, FIXME, HACK, STUB, WIP)"
+      "title": "audit: Phase 1 — grep comment markers (TODO, FIXME, HACK, STUB, WIP)"
     },
     "219": {
       "action": "TRACK",
@@ -2487,7 +2509,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:42Z",
-      "title": "audit: Phase 2 \u2014 grep function/method stubs (throw not implemented, bare returns)"
+      "title": "audit: Phase 2 — grep function/method stubs (throw not implemented, bare returns)"
     },
     "220": {
       "action": "TRACK",
@@ -2509,7 +2531,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:42Z",
-      "title": "audit: Phase 3 \u2014 grep component/UI placeholders (Coming soon, placeholder text)"
+      "title": "audit: Phase 3 — grep component/UI placeholders (Coming soon, placeholder text)"
     },
     "221": {
       "action": "TRACK",
@@ -2531,7 +2553,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:42Z",
-      "title": "audit: Phase 4 \u2014 grep hardcoded mock data (const mockData, MOCK:, STUB:)"
+      "title": "audit: Phase 4 — grep hardcoded mock data (const mockData, MOCK:, STUB:)"
     },
     "222": {
       "action": "TRACK",
@@ -2553,7 +2575,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:42Z",
-      "title": "audit: Phase 5 \u2014 filename-based detection (stub, placeholder, mock, dummy in name)"
+      "title": "audit: Phase 5 — filename-based detection (stub, placeholder, mock, dummy in name)"
     },
     "223": {
       "action": "TRACK",
@@ -2575,7 +2597,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:42Z",
-      "title": "audit: Phase 6 \u2014 targeted directory scans (services/, modules/, screens/, panels/)"
+      "title": "audit: Phase 6 — targeted directory scans (services/, modules/, screens/, panels/)"
     },
     "224": {
       "action": "TRACK",
@@ -2624,7 +2646,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:27Z",
-      "title": "audit: Phase 1 \u2014 service layer deep dive (40+ files in src/api/services/)"
+      "title": "audit: Phase 1 — service layer deep dive (40+ files in src/api/services/)"
     },
     "226": {
       "action": "TRACK",
@@ -2651,7 +2673,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:27Z",
-      "title": "audit: Phase 2 \u2014 NestJS module layer deep dive (100+ files in src/api/src/modules/)"
+      "title": "audit: Phase 2 — NestJS module layer deep dive (100+ files in src/api/src/modules/)"
     },
     "227": {
       "action": "TRACK",
@@ -2672,7 +2694,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:42Z",
-      "title": "audit: Phase 3 \u2014 shared libraries inventory (src/shared/libs/)"
+      "title": "audit: Phase 3 — shared libraries inventory (src/shared/libs/)"
     },
     "228": {
       "action": "TRACK",
@@ -2693,7 +2715,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:42Z",
-      "title": "audit: Phase 4 \u2014 frontend inventory (src/web/app/, utils/, stores/, components/)"
+      "title": "audit: Phase 4 — frontend inventory (src/web/app/, utils/, stores/, components/)"
     },
     "229": {
       "action": "TRACK",
@@ -2720,7 +2742,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:27Z",
-      "title": "audit: Phase 5 \u2014 mobile inventory (src/mobile/screens/, services/)"
+      "title": "audit: Phase 5 — mobile inventory (src/mobile/screens/, services/)"
     },
     "230": {
       "action": "TRACK",
@@ -2747,7 +2769,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:27Z",
-      "title": "audit: Phase 6 \u2014 desktop inventory (src/desktop/src/panels/)"
+      "title": "audit: Phase 6 — desktop inventory (src/desktop/src/panels/)"
     },
     "231": {
       "action": "TRACK",
@@ -2769,7 +2791,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:42Z",
-      "title": "audit: Phase 7 \u2014 database schema + seed data (schema.sql, seed.sql)"
+      "title": "audit: Phase 7 — database schema + seed data (schema.sql, seed.sql)"
     },
     "232": {
       "action": "TRACK",
@@ -2790,7 +2812,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:42Z",
-      "title": "audit: Phase 8 \u2014 synthesize completeness matrix (19 feature areas, % scoring)"
+      "title": "audit: Phase 8 — synthesize completeness matrix (19 feature areas, % scoring)"
     },
     "233": {
       "action": "TRACK",
@@ -3650,7 +3672,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:43Z",
-      "title": "feat: activate domain-expert agent contexts \u2014 epic tracker"
+      "title": "feat: activate domain-expert agent contexts — epic tracker"
     },
     "268": {
       "action": "TRACK",
@@ -3791,7 +3813,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:43Z",
-      "title": "audit: UX flow audit \u2014 5 critical flows (friction, safety, a11y, copy)"
+      "title": "audit: UX flow audit — 5 critical flows (friction, safety, a11y, copy)"
     },
     "274": {
       "action": "TRACK",
@@ -3812,7 +3834,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:43Z",
-      "title": "docs: draft FAQ v1 \u2014 10 help articles with linguistic cloaker vocabulary"
+      "title": "docs: draft FAQ v1 — 10 help articles with linguistic cloaker vocabulary"
     },
     "275": {
       "action": "TRACK",
@@ -3893,7 +3915,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:43Z",
-      "title": "Legal & Compliance Department \u2014 Task Tracker"
+      "title": "Legal & Compliance Department — Task Tracker"
     },
     "285": {
       "action": "TRACK",
@@ -3914,7 +3936,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:43Z",
-      "title": "Product & Design Department \u2014 Task Tracker"
+      "title": "Product & Design Department — Task Tracker"
     },
     "286": {
       "action": "TRACK",
@@ -3935,7 +3957,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:43Z",
-      "title": "Operations & Infrastructure Department \u2014 Task Tracker"
+      "title": "Operations & Infrastructure Department — Task Tracker"
     },
     "288": {
       "action": "TRACK",
@@ -3956,7 +3978,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:43Z",
-      "title": "Growth & Marketing Department \u2014 Task Tracker"
+      "title": "Growth & Marketing Department — Task Tracker"
     },
     "29": {
       "action": "CLOSE",
@@ -4003,7 +4025,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:43Z",
-      "title": "Finance & Revenue Department \u2014 Task Tracker"
+      "title": "Finance & Revenue Department — Task Tracker"
     },
     "291": {
       "action": "TRACK",
@@ -4024,7 +4046,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:43Z",
-      "title": "Customer Success Department \u2014 Task Tracker"
+      "title": "Customer Success Department — Task Tracker"
     },
     "293": {
       "action": "TRACK",
@@ -4050,7 +4072,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:27Z",
-      "title": "Enterprise Sales / B2B Department \u2014 Task Tracker"
+      "title": "Enterprise Sales / B2B Department — Task Tracker"
     },
     "294": {
       "action": "TRACK",
@@ -4475,7 +4497,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "Cross-jurisdictional consent matrix \u2014 data consent by state"
+      "title": "Cross-jurisdictional consent matrix — data consent by state"
     },
     "321": {
       "action": "TRACK",
@@ -4559,7 +4581,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "Enterprise DPA template \u2014 Data Processing Agreement"
+      "title": "Enterprise DPA template — Data Processing Agreement"
     },
     "325": {
       "action": "TRACK",
@@ -4601,7 +4623,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "Define beta success metrics \u2014 concrete targets"
+      "title": "Define beta success metrics — concrete targets"
     },
     "327": {
       "action": "BUILD",
@@ -4641,7 +4663,7 @@
       "pr": null,
       "state": "CLOSED",
       "state_updated": "2026-06-01T19:54:34Z",
-      "title": "No-Contact recovery UX audit \u2014 5 critical flows"
+      "title": "No-Contact recovery UX audit — 5 critical flows"
     },
     "328": {
       "action": "TRACK",
@@ -4661,7 +4683,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "User interview protocol \u2014 structured guide for 10 beta users"
+      "title": "User interview protocol — structured guide for 10 beta users"
     },
     "329": {
       "action": "TRACK",
@@ -4727,7 +4749,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "Feature prioritization from analytics \u2014 data-driven backlog"
+      "title": "Feature prioritization from analytics — data-driven backlog"
     },
     "331": {
       "action": "TRACK",
@@ -4747,7 +4769,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "Enterprise UX audit \u2014 HR + coach dashboard usability"
+      "title": "Enterprise UX audit — HR + coach dashboard usability"
     },
     "332": {
       "action": "TRACK",
@@ -4772,7 +4794,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:56Z",
-      "title": "Uptime monitoring setup \u2014 UptimeRobot/BetterUptime"
+      "title": "Uptime monitoring setup — UptimeRobot/BetterUptime"
     },
     "333": {
       "action": "TRACK",
@@ -4793,7 +4815,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "Render starter \u2192 production plan upgrade evaluation"
+      "title": "Render starter → production plan upgrade evaluation"
     },
     "334": {
       "action": "TRACK",
@@ -4839,7 +4861,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:56Z",
-      "title": "Incident response runbook v1 \u2014 severity, escalation, rollback"
+      "title": "Incident response runbook v1 — severity, escalation, rollback"
     },
     "336": {
       "action": "TRACK",
@@ -4864,7 +4886,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:56Z",
-      "title": "Load testing \u2014 500 concurrent users simulation"
+      "title": "Load testing — 500 concurrent users simulation"
     },
     "337": {
       "action": "TRACK",
@@ -4910,7 +4932,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "APNs/FCM credential management \u2014 secure push notification keys"
+      "title": "APNs/FCM credential management — secure push notification keys"
     },
     "339": {
       "action": "TRACK",
@@ -4935,7 +4957,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:56Z",
-      "title": "Load testing \u2014 5,000 concurrent users at scale"
+      "title": "Load testing — 5,000 concurrent users at scale"
     },
     "340": {
       "action": "TRACK",
@@ -4977,7 +4999,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "Referral loop \u2014 waitlist and cohort invite mechanic"
+      "title": "Referral loop — waitlist and cohort invite mechanic"
     },
     "346": {
       "action": "TRACK",
@@ -4998,7 +5020,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "PR strategy for App Store launch \u2014 press kit + target list + narrative"
+      "title": "PR strategy for App Store launch — press kit + target list + narrative"
     },
     "348": {
       "action": "TRACK",
@@ -5018,7 +5040,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "Unit economics model v1 \u2014 $39 contract profitability"
+      "title": "Unit economics model v1 — $39 contract profitability"
     },
     "349": {
       "action": "TRACK",
@@ -5038,7 +5060,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "Stripe production account setup \u2014 real-money switch"
+      "title": "Stripe production account setup — real-money switch"
     },
     "350": {
       "action": "TRACK",
@@ -5058,7 +5080,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "Financial reconciliation process \u2014 Stripe vs internal records"
+      "title": "Financial reconciliation process — Stripe vs internal records"
     },
     "351": {
       "action": "TRACK",
@@ -5098,7 +5120,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "B2B pricing model \u2014 $49/$149/$349/$999+ tiers"
+      "title": "B2B pricing model — $49/$149/$349/$999+ tiers"
     },
     "353": {
       "action": "TRACK",
@@ -5118,7 +5140,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "Revenue reporting \u2014 MRR, churn, ARPU monthly report"
+      "title": "Revenue reporting — MRR, churn, ARPU monthly report"
     },
     "354": {
       "action": "TRACK",
@@ -5138,7 +5160,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "Support channel setup \u2014 email + Discord for beta"
+      "title": "Support channel setup — email + Discord for beta"
     },
     "355": {
       "action": "TRACK",
@@ -5158,7 +5180,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "FAQ / Help Center v1 \u2014 10 help articles"
+      "title": "FAQ / Help Center v1 — 10 help articles"
     },
     "356": {
       "action": "TRACK",
@@ -5178,7 +5200,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "Onboarding email sequence \u2014 7-day drip campaign"
+      "title": "Onboarding email sequence — 7-day drip campaign"
     },
     "357": {
       "action": "TRACK",
@@ -5198,7 +5220,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "Churn signal detection \u2014 predictive patterns"
+      "title": "Churn signal detection — predictive patterns"
     },
     "358": {
       "action": "TRACK",
@@ -5244,7 +5266,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:56Z",
-      "title": "Identify 50 target therapists/coaches \u2014 ICP definition"
+      "title": "Identify 50 target therapists/coaches — ICP definition"
     },
     "360": {
       "action": "TRACK",
@@ -5266,7 +5288,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "Outreach sequence \u2014 5-email cold outreach + LinkedIn"
+      "title": "Outreach sequence — 5-email cold outreach + LinkedIn"
     },
     "361": {
       "action": "TRACK",
@@ -5292,7 +5314,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:56Z",
-      "title": "Enterprise demo environment \u2014 sandboxed Render instance"
+      "title": "Enterprise demo environment — sandboxed Render instance"
     },
     "362": {
       "action": "TRACK",
@@ -5314,7 +5336,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:44Z",
-      "title": "Security questionnaire template \u2014 pre-filled answers"
+      "title": "Security questionnaire template — pre-filled answers"
     },
     "363": {
       "action": "TRACK",
@@ -5336,7 +5358,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:45Z",
-      "title": "First pilot onboarding \u2014 1-3 practitioners"
+      "title": "First pilot onboarding — 1-3 practitioners"
     },
     "364": {
       "action": "TRACK",
@@ -5362,7 +5384,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:56Z",
-      "title": "Enterprise pricing live \u2014 published tiers + billing"
+      "title": "Enterprise pricing live — published tiers + billing"
     },
     "365": {
       "action": "TRACK",
@@ -5474,7 +5496,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:56Z",
-      "title": "Internal dogfood beta \u2014 founders + 5-10 trusted people"
+      "title": "Internal dogfood beta — founders + 5-10 trusted people"
     },
     "370": {
       "action": "TRACK",
@@ -5499,7 +5521,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:56Z",
-      "title": "Monitoring + alerting setup \u2014 Sentry + uptime"
+      "title": "Monitoring + alerting setup — Sentry + uptime"
     },
     "371": {
       "action": "TRACK",
@@ -5519,7 +5541,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:45Z",
-      "title": "Support channel setup \u2014 email + Discord"
+      "title": "Support channel setup — email + Discord"
     },
     "372": {
       "action": "TRACK",
@@ -5540,7 +5562,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:45Z",
-      "title": "TestFlight external beta \u2014 50-100 users"
+      "title": "TestFlight external beta — 50-100 users"
     },
     "374": {
       "action": "TRACK",
@@ -5581,7 +5603,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:45Z",
-      "title": "Real-money pilot \u2014 10-25 users"
+      "title": "Real-money pilot — 10-25 users"
     },
     "376": {
       "action": "TRACK",
@@ -5601,7 +5623,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:45Z",
-      "title": "Open beta expansion \u2014 500+ users"
+      "title": "Open beta expansion — 500+ users"
     },
     "377": {
       "action": "TRACK",
@@ -5642,7 +5664,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:45Z",
-      "title": "App Store launch (public) \u2014 general availability"
+      "title": "App Store launch (public) — general availability"
     },
     "379": {
       "action": "TRACK",
@@ -5662,7 +5684,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:45Z",
-      "title": "Mobile Native Engineer (Swift) \u2014 contract sourcing"
+      "title": "Mobile Native Engineer (Swift) — contract sourcing"
     },
     "380": {
       "action": "TRACK",
@@ -5682,7 +5704,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:45Z",
-      "title": "Legal Counsel \u2014 retainer engagement"
+      "title": "Legal Counsel — retainer engagement"
     },
     "381": {
       "action": "TRACK",
@@ -5702,7 +5724,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:45Z",
-      "title": "Kotlin contractor \u2014 Android health data bridge"
+      "title": "Kotlin contractor — Android health data bridge"
     },
     "382": {
       "action": "TRACK",
@@ -5727,7 +5749,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:56Z",
-      "title": "QA / Beta Coordinator \u2014 part-time hire"
+      "title": "QA / Beta Coordinator — part-time hire"
     },
     "383": {
       "action": "TRACK",
@@ -5747,7 +5769,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:45Z",
-      "title": "Growth / Community Manager \u2014 hiring"
+      "title": "Growth / Community Manager — hiring"
     },
     "384": {
       "action": "TRACK",
@@ -5768,7 +5790,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:45Z",
-      "title": "Enterprise Sales / BD \u2014 hiring (if fundraise)"
+      "title": "Enterprise Sales / BD — hiring (if fundraise)"
     },
     "385": {
       "action": "TRACK",
@@ -5793,7 +5815,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:56Z",
-      "title": "DevOps / SRE \u2014 part-time (if fundraise)"
+      "title": "DevOps / SRE — part-time (if fundraise)"
     },
     "39": {
       "action": "TRACK",
@@ -6059,7 +6081,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:56Z",
-      "title": "Ask Styx: Integration tests \u2014 E2E question\u2192answer flow"
+      "title": "Ask Styx: Integration tests — E2E question→answer flow"
     },
     "423": {
       "action": "TRACK",
@@ -6262,7 +6284,7 @@
       "pr": null,
       "state": "CLOSED",
       "state_updated": "2026-06-01T19:54:34Z",
-      "title": "DisputeTimeline: Interaction \u2014 zoom, filter, detail panels"
+      "title": "DisputeTimeline: Interaction — zoom, filter, detail panels"
     },
     "430": {
       "action": "BUILD",
@@ -6303,7 +6325,7 @@
       "pr": null,
       "state": "CLOSED",
       "state_updated": "2026-06-01T19:54:34Z",
-      "title": "DisputeTimeline: Tests \u2014 rendering, state transitions, edge cases"
+      "title": "DisputeTimeline: Tests — rendering, state transitions, edge cases"
     },
     "431": {
       "action": "TRACK",
@@ -6428,7 +6450,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:56Z",
-      "title": "Agents: Integration tests \u2014 multi-agent routing"
+      "title": "Agents: Integration tests — multi-agent routing"
     },
     "436": {
       "action": "TRACK",
@@ -6508,7 +6530,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "Audit: Map all modules \u2192 feature coverage matrix"
+      "title": "Audit: Map all modules → feature coverage matrix"
     },
     "44": {
       "action": "WAITING",
@@ -6726,7 +6748,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-005: Schema + API \u2014 lockdown rules + timelock enforcement"
+      "title": "TKT-P1-005: Schema + API — lockdown rules + timelock enforcement"
     },
     "449": {
       "action": "TRACK",
@@ -6744,7 +6766,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-005: UI \u2014 danger zone indicator + timelock countdown"
+      "title": "TKT-P1-005: UI — danger zone indicator + timelock countdown"
     },
     "45": {
       "action": "BUILD",
@@ -6787,7 +6809,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-005: Tests \u2014 lockdown triggers + timelock expiry"
+      "title": "TKT-P1-005: Tests — lockdown triggers + timelock expiry"
     },
     "451": {
       "action": "TRACK",
@@ -6805,7 +6827,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-012: Schema + API \u2014 risk multiplier rules + schedule config"
+      "title": "TKT-P1-012: Schema + API — risk multiplier rules + schedule config"
     },
     "452": {
       "action": "TRACK",
@@ -6823,7 +6845,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-012: UI \u2014 multiplier indicator + schedule display"
+      "title": "TKT-P1-012: UI — multiplier indicator + schedule display"
     },
     "453": {
       "action": "TRACK",
@@ -6841,7 +6863,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-012: Tests \u2014 multiplier calculation + edge cases"
+      "title": "TKT-P1-012: Tests — multiplier calculation + edge cases"
     },
     "454": {
       "action": "TRACK",
@@ -6859,7 +6881,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-017: Schema + API \u2014 partner linking + notification triggers"
+      "title": "TKT-P1-017: Schema + API — partner linking + notification triggers"
     },
     "455": {
       "action": "TRACK",
@@ -6877,7 +6899,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-017: UI \u2014 partner invitation + status dashboard"
+      "title": "TKT-P1-017: UI — partner invitation + status dashboard"
     },
     "456": {
       "action": "TRACK",
@@ -6895,7 +6917,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-017: Tests \u2014 protocol flow + notification delivery"
+      "title": "TKT-P1-017: Tests — protocol flow + notification delivery"
     },
     "457": {
       "action": "TRACK",
@@ -6913,7 +6935,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-010: Schema + API \u2014 progress tracking + downscale logic"
+      "title": "TKT-P1-010: Schema + API — progress tracking + downscale logic"
     },
     "458": {
       "action": "TRACK",
@@ -6931,7 +6953,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-010: UI \u2014 progress visualization + downscale flow"
+      "title": "TKT-P1-010: UI — progress visualization + downscale flow"
     },
     "459": {
       "action": "TRACK",
@@ -6949,7 +6971,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-010: Tests \u2014 progress calculation + UX state transitions"
+      "title": "TKT-P1-010: Tests — progress calculation + UX state transitions"
     },
     "46": {
       "action": "BUILD",
@@ -7011,7 +7033,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-016: Schema + API \u2014 oath storage + identity binding"
+      "title": "TKT-P1-016: Schema + API — oath storage + identity binding"
     },
     "461": {
       "action": "TRACK",
@@ -7029,7 +7051,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-016: UI \u2014 oath creation flow + identity confirmation"
+      "title": "TKT-P1-016: UI — oath creation flow + identity confirmation"
     },
     "462": {
       "action": "TRACK",
@@ -7047,7 +7069,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-016: Tests \u2014 onboarding flow + oath persistence"
+      "title": "TKT-P1-016: Tests — onboarding flow + oath persistence"
     },
     "463": {
       "action": "TRACK",
@@ -7065,7 +7087,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-018: Schema + API \u2014 gradient calculation + leaderboard data"
+      "title": "TKT-P1-018: Schema + API — gradient calculation + leaderboard data"
     },
     "464": {
       "action": "TRACK",
@@ -7083,7 +7105,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-018: UI \u2014 dashboard visualization + real-time leaderboard"
+      "title": "TKT-P1-018: UI — dashboard visualization + real-time leaderboard"
     },
     "465": {
       "action": "TRACK",
@@ -7101,7 +7123,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-018: Tests \u2014 gradient math + leaderboard ranking"
+      "title": "TKT-P1-018: Tests — gradient math + leaderboard ranking"
     },
     "466": {
       "action": "TRACK",
@@ -7119,7 +7141,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-006: API \u2014 push notification dispatch + device registration"
+      "title": "TKT-P1-006: API — push notification dispatch + device registration"
     },
     "467": {
       "action": "TRACK",
@@ -7139,7 +7161,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-006: Native \u2014 APNs (iOS) + FCM (Android) integration"
+      "title": "TKT-P1-006: Native — APNs (iOS) + FCM (Android) integration"
     },
     "468": {
       "action": "TRACK",
@@ -7157,7 +7179,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-006: Tests \u2014 delivery confirmation + fallback scenarios"
+      "title": "TKT-P1-006: Tests — delivery confirmation + fallback scenarios"
     },
     "469": {
       "action": "TRACK",
@@ -7177,7 +7199,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-019: Whitepaper draft \u2014 skill-vs-chance legal argument"
+      "title": "TKT-P1-019: Whitepaper draft — skill-vs-chance legal argument"
     },
     "47": {
       "action": "BUILD",
@@ -7241,7 +7263,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-019: Legal review \u2014 counsel sign-off on classification"
+      "title": "TKT-P1-019: Legal review — counsel sign-off on classification"
     },
     "471": {
       "action": "TRACK",
@@ -7259,7 +7281,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-019: Release gate \u2014 automated check before contest features"
+      "title": "TKT-P1-019: Release gate — automated check before contest features"
     },
     "472": {
       "action": "TRACK",
@@ -7277,7 +7299,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-009: Schema + API \u2014 exclusion registry + cooling-off periods"
+      "title": "TKT-P1-009: Schema + API — exclusion registry + cooling-off periods"
     },
     "473": {
       "action": "TRACK",
@@ -7295,7 +7317,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-009: UI \u2014 self-exclusion flow + responsible-use settings"
+      "title": "TKT-P1-009: UI — self-exclusion flow + responsible-use settings"
     },
     "474": {
       "action": "TRACK",
@@ -7313,7 +7335,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-009: Tests \u2014 exclusion enforcement + re-entry validation"
+      "title": "TKT-P1-009: Tests — exclusion enforcement + re-entry validation"
     },
     "475": {
       "action": "TRACK",
@@ -7333,7 +7355,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-007: Native \u2014 HealthKit/Google Health Connect integration"
+      "title": "TKT-P1-007: Native — HealthKit/Google Health Connect integration"
     },
     "476": {
       "action": "TRACK",
@@ -7351,7 +7373,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:46Z",
-      "title": "TKT-P1-007: UI \u2014 health data display + consent management"
+      "title": "TKT-P1-007: UI — health data display + consent management"
     },
     "477": {
       "action": "TRACK",
@@ -7369,7 +7391,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "TKT-P1-007: Tests \u2014 data sync accuracy + privacy compliance"
+      "title": "TKT-P1-007: Tests — data sync accuracy + privacy compliance"
     },
     "478": {
       "action": "TRACK",
@@ -7387,7 +7409,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "TKT-P1-013: API \u2014 video upload + processing pipeline"
+      "title": "TKT-P1-013: API — video upload + processing pipeline"
     },
     "479": {
       "action": "TRACK",
@@ -7405,7 +7427,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "TKT-P1-013: UI \u2014 upload progress + processing state display"
+      "title": "TKT-P1-013: UI — upload progress + processing state display"
     },
     "48": {
       "action": "FUTURE",
@@ -7429,7 +7451,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "feat: B2B cohort orchestration \u2014 orgs create/manage cohorts for their clients"
+      "title": "feat: B2B cohort orchestration — orgs create/manage cohorts for their clients"
     },
     "480": {
       "action": "TRACK",
@@ -7447,7 +7469,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "TKT-P1-013: Tests \u2014 upload flow + processing state machine"
+      "title": "TKT-P1-013: Tests — upload flow + processing state machine"
     },
     "481": {
       "action": "TRACK",
@@ -7465,7 +7487,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "TKT-P1-014: Schema \u2014 mask configuration + audit trail"
+      "title": "TKT-P1-014: Schema — mask configuration + audit trail"
     },
     "482": {
       "action": "TRACK",
@@ -7483,7 +7505,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "TKT-P1-014: UI \u2014 masked display toggle + audit workbench"
+      "title": "TKT-P1-014: UI — masked display toggle + audit workbench"
     },
     "483": {
       "action": "TRACK",
@@ -7501,7 +7523,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "TKT-P1-014: Tests \u2014 masking rules + display fidelity"
+      "title": "TKT-P1-014: Tests — masking rules + display fidelity"
     },
     "484": {
       "action": "TRACK",
@@ -7519,7 +7541,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "TKT-P1-008: Schema + API \u2014 routing algorithm + cluster detection"
+      "title": "TKT-P1-008: Schema + API — routing algorithm + cluster detection"
     },
     "485": {
       "action": "TRACK",
@@ -7537,7 +7559,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "TKT-P1-008: Admin UI \u2014 cluster visualization + override controls"
+      "title": "TKT-P1-008: Admin UI — cluster visualization + override controls"
     },
     "486": {
       "action": "TRACK",
@@ -7555,7 +7577,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "TKT-P1-008: Tests \u2014 routing fairness + collusion detection accuracy"
+      "title": "TKT-P1-008: Tests — routing fairness + collusion detection accuracy"
     },
     "487": {
       "action": "TRACK",
@@ -7573,7 +7595,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "TKT-P1-015: Schema + API \u2014 slashing rules + honey-trap triggers"
+      "title": "TKT-P1-015: Schema + API — slashing rules + honey-trap triggers"
     },
     "488": {
       "action": "TRACK",
@@ -7591,7 +7613,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "TKT-P1-015: Admin UI \u2014 enforcement dashboard + evidence review"
+      "title": "TKT-P1-015: Admin UI — enforcement dashboard + evidence review"
     },
     "489": {
       "action": "TRACK",
@@ -7609,7 +7631,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "TKT-P1-015: Tests \u2014 slashing calculation + false positive safeguards"
+      "title": "TKT-P1-015: Tests — slashing calculation + false positive safeguards"
     },
     "49": {
       "action": "TRACK",
@@ -7636,7 +7658,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:57Z",
-      "title": "decision: Weekly live sessions \u2014 in-app scheduling vs external operational cadence"
+      "title": "decision: Weekly live sessions — in-app scheduling vs external operational cadence"
     },
     "490": {
       "action": "TRACK",
@@ -7654,7 +7676,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "Service scaffolding \u2014 NestJS module + 19 contract checks"
+      "title": "Service scaffolding — NestJS module + 19 contract checks"
     },
     "491": {
       "action": "TRACK",
@@ -7679,7 +7701,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:57Z",
-      "title": "CI integration \u2014 pre-deploy gate + status reporting"
+      "title": "CI integration — pre-deploy gate + status reporting"
     },
     "492": {
       "action": "TRACK",
@@ -7697,7 +7719,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "Tests \u2014 all 19 readiness criteria pass/fail"
+      "title": "Tests — all 19 readiness criteria pass/fail"
     },
     "493": {
       "action": "TRACK",
@@ -7715,7 +7737,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "Schema + API \u2014 survey definitions + response storage"
+      "title": "Schema + API — survey definitions + response storage"
     },
     "494": {
       "action": "TRACK",
@@ -7733,7 +7755,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "UI \u2014 survey presentation + completion tracking"
+      "title": "UI — survey presentation + completion tracking"
     },
     "495": {
       "action": "TRACK",
@@ -7751,7 +7773,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "Tests \u2014 survey flow + statistical analysis pipeline"
+      "title": "Tests — survey flow + statistical analysis pipeline"
     },
     "496": {
       "action": "TRACK",
@@ -7769,7 +7791,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "Schema \u2014 emotional tracking fields (urge, trigger, outcome)"
+      "title": "Schema — emotional tracking fields (urge, trigger, outcome)"
     },
     "497": {
       "action": "TRACK",
@@ -7787,7 +7809,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "UI \u2014 daily attestation emotional input components"
+      "title": "UI — daily attestation emotional input components"
     },
     "498": {
       "action": "TRACK",
@@ -7805,7 +7827,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "Tests \u2014 attestation flow + data integrity"
+      "title": "Tests — attestation flow + data integrity"
     },
     "499": {
       "action": "TRACK",
@@ -7823,7 +7845,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "Schema + API \u2014 queue management + cohort threshold logic"
+      "title": "Schema + API — queue management + cohort threshold logic"
     },
     "50": {
       "action": "FUTURE",
@@ -7864,7 +7886,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "UI \u2014 waitlist position display + notification opt-in"
+      "title": "UI — waitlist position display + notification opt-in"
     },
     "501": {
       "action": "TRACK",
@@ -7882,7 +7904,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "Tests \u2014 queue ordering + cohort fill triggers"
+      "title": "Tests — queue ordering + cohort fill triggers"
     },
     "502": {
       "action": "TRACK",
@@ -7900,7 +7922,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "Schema + API \u2014 referral tracking + reward distribution"
+      "title": "Schema + API — referral tracking + reward distribution"
     },
     "503": {
       "action": "TRACK",
@@ -7918,7 +7940,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "UI \u2014 referral link generation + reward status"
+      "title": "UI — referral link generation + reward status"
     },
     "504": {
       "action": "TRACK",
@@ -7936,7 +7958,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "Tests \u2014 referral attribution + double-spend prevention"
+      "title": "Tests — referral attribution + double-spend prevention"
     },
     "507": {
       "action": "TRACK",
@@ -7954,7 +7976,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "Tests \u2014 conversion tracking + email delivery"
+      "title": "Tests — conversion tracking + email delivery"
     },
     "508": {
       "action": "TRACK",
@@ -7972,7 +7994,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "Schema \u2014 violation code definitions + rejection reasons"
+      "title": "Schema — violation code definitions + rejection reasons"
     },
     "509": {
       "action": "TRACK",
@@ -7990,7 +8012,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "API \u2014 violation code CRUD + audit trail"
+      "title": "API — violation code CRUD + audit trail"
     },
     "51": {
       "action": "FUTURE",
@@ -8031,7 +8053,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "Tests \u2014 taxonomy completeness + audit logging"
+      "title": "Tests — taxonomy completeness + audit logging"
     },
     "511": {
       "action": "TRACK",
@@ -8049,7 +8071,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "Schema + API \u2014 exclusion criteria + suspension logic"
+      "title": "Schema + API — exclusion criteria + suspension logic"
     },
     "512": {
       "action": "TRACK",
@@ -8067,7 +8089,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "UI \u2014 exclusion request flow + suspension status"
+      "title": "UI — exclusion request flow + suspension status"
     },
     "513": {
       "action": "TRACK",
@@ -8085,7 +8107,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "Tests \u2014 exclusion triggers + re-entry validation"
+      "title": "Tests — exclusion triggers + re-entry validation"
     },
     "514": {
       "action": "TRACK",
@@ -8103,7 +8125,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "Schema + API \u2014 tier definitions + escalation rules"
+      "title": "Schema + API — tier definitions + escalation rules"
     },
     "515": {
       "action": "TRACK",
@@ -8121,7 +8143,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "UI \u2014 verification requirement display per tier"
+      "title": "UI — verification requirement display per tier"
     },
     "516": {
       "action": "TRACK",
@@ -8139,7 +8161,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "Tests \u2014 tier transitions + escalation triggers"
+      "title": "Tests — tier transitions + escalation triggers"
     },
     "517": {
       "action": "TRACK",
@@ -8157,7 +8179,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:47Z",
-      "title": "API \u2014 content moderation queue + automated filtering"
+      "title": "API — content moderation queue + automated filtering"
     },
     "518": {
       "action": "TRACK",
@@ -8175,7 +8197,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "Admin UI \u2014 moderation dashboard + appeal flow"
+      "title": "Admin UI — moderation dashboard + appeal flow"
     },
     "519": {
       "action": "TRACK",
@@ -8193,7 +8215,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "Tests \u2014 filter accuracy + moderation latency"
+      "title": "Tests — filter accuracy + moderation latency"
     },
     "52": {
       "action": "BUILD",
@@ -8236,7 +8258,7 @@
       "pr": null,
       "state": "CLOSED",
       "state_updated": "2026-06-01T19:43:45Z",
-      "title": "feat: Waitlist / cohort fill queue \u2014 hold users until cohort reaches minimum"
+      "title": "feat: Waitlist / cohort fill queue — hold users until cohort reaches minimum"
     },
     "520": {
       "action": "TRACK",
@@ -8254,7 +8276,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "Schema + API \u2014 circuit breaker state machine + pause logic"
+      "title": "Schema + API — circuit breaker state machine + pause logic"
     },
     "521": {
       "action": "TRACK",
@@ -8272,7 +8294,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "UI \u2014 countdown display + pause/resume controls"
+      "title": "UI — countdown display + pause/resume controls"
     },
     "522": {
       "action": "TRACK",
@@ -8290,7 +8312,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "Tests \u2014 state transitions + timer accuracy"
+      "title": "Tests — state transitions + timer accuracy"
     },
     "523": {
       "action": "TRACK",
@@ -8315,7 +8337,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:57Z",
-      "title": "Infrastructure \u2014 k6/artillery setup + test scenarios"
+      "title": "Infrastructure — k6/artillery setup + test scenarios"
     },
     "524": {
       "action": "TRACK",
@@ -8365,7 +8387,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:57Z",
-      "title": "Tests \u2014 baseline establishment + regression thresholds"
+      "title": "Tests — baseline establishment + regression thresholds"
     },
     "526": {
       "action": "TRACK",
@@ -8383,7 +8405,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "Copy \u2014 linguistically safe notification templates"
+      "title": "Copy — linguistically safe notification templates"
     },
     "527": {
       "action": "TRACK",
@@ -8401,7 +8423,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "UI \u2014 notification display + acknowledgment flow"
+      "title": "UI — notification display + acknowledgment flow"
     },
     "528": {
       "action": "TRACK",
@@ -8419,7 +8441,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "Tests \u2014 copy validation + delivery confirmation"
+      "title": "Tests — copy validation + delivery confirmation"
     },
     "529": {
       "action": "TRACK",
@@ -8437,7 +8459,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "Checklist automation \u2014 readiness criteria check script"
+      "title": "Checklist automation — readiness criteria check script"
     },
     "53": {
       "action": "FUTURE",
@@ -8485,7 +8507,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:57Z",
-      "title": "Gate enforcement \u2014 CI integration + blocking status"
+      "title": "Gate enforcement — CI integration + blocking status"
     },
     "531": {
       "action": "TRACK",
@@ -8503,7 +8525,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "Checklist automation \u2014 financial readiness criteria"
+      "title": "Checklist automation — financial readiness criteria"
     },
     "532": {
       "action": "TRACK",
@@ -8523,7 +8545,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "Gate enforcement \u2014 settlement + compliance verification"
+      "title": "Gate enforcement — settlement + compliance verification"
     },
     "533": {
       "action": "TRACK",
@@ -8541,7 +8563,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "Checklist automation \u2014 App Store guidelines compliance"
+      "title": "Checklist automation — App Store guidelines compliance"
     },
     "534": {
       "action": "TRACK",
@@ -8559,7 +8581,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "Gate enforcement \u2014 legal + UX + performance criteria"
+      "title": "Gate enforcement — legal + UX + performance criteria"
     },
     "535": {
       "action": "TRACK",
@@ -8582,7 +8604,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:57Z",
-      "title": "Checklist automation \u2014 enterprise infrastructure criteria"
+      "title": "Checklist automation — enterprise infrastructure criteria"
     },
     "536": {
       "action": "TRACK",
@@ -8605,7 +8627,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:57Z",
-      "title": "Gate enforcement \u2014 security + DPA + demo readiness"
+      "title": "Gate enforcement — security + DPA + demo readiness"
     },
     "537": {
       "action": "TRACK",
@@ -8623,7 +8645,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "Schema + API \u2014 spike calculation + stake doubling logic"
+      "title": "Schema + API — spike calculation + stake doubling logic"
     },
     "538": {
       "action": "TRACK",
@@ -8641,7 +8663,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "UI \u2014 spike indicator + incentive display"
+      "title": "UI — spike indicator + incentive display"
     },
     "539": {
       "action": "TRACK",
@@ -8659,7 +8681,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "Tests \u2014 calculation accuracy + edge cases"
+      "title": "Tests — calculation accuracy + edge cases"
     },
     "54": {
       "action": "FUTURE",
@@ -8683,7 +8705,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "feat: Motivation profiling at intake \u2014 tailor experience to user archetype"
+      "title": "feat: Motivation profiling at intake — tailor experience to user archetype"
     },
     "540": {
       "action": "TRACK",
@@ -8701,7 +8723,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "Schema \u2014 per-state compliance flags + feature toggles"
+      "title": "Schema — per-state compliance flags + feature toggles"
     },
     "541": {
       "action": "TRACK",
@@ -8719,7 +8741,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "Admin UI \u2014 state toggle management + audit trail"
+      "title": "Admin UI — state toggle management + audit trail"
     },
     "542": {
       "action": "TRACK",
@@ -8737,7 +8759,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "Tests \u2014 toggle enforcement + state combinations"
+      "title": "Tests — toggle enforcement + state combinations"
     },
     "543": {
       "action": "TRACK",
@@ -8755,7 +8777,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "UI \u2014 stake amount selector + bounds enforcement"
+      "title": "UI — stake amount selector + bounds enforcement"
     },
     "544": {
       "action": "TRACK",
@@ -8773,7 +8795,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "API \u2014 validation + jurisdictional bounds lookup"
+      "title": "API — validation + jurisdictional bounds lookup"
     },
     "545": {
       "action": "TRACK",
@@ -8791,7 +8813,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "Tests \u2014 bounds enforcement + UX state management"
+      "title": "Tests — bounds enforcement + UX state management"
     },
     "546": {
       "action": "BUILD",
@@ -8816,7 +8838,7 @@
       "pr": null,
       "state": "CLOSED",
       "state_updated": "2026-06-01T19:35:10Z",
-      "title": "Schema + API \u2014 RBAC model + org authorization"
+      "title": "Schema + API — RBAC model + org authorization"
     },
     "547": {
       "action": "BUILD",
@@ -8856,7 +8878,7 @@
       "pr": null,
       "state": "CLOSED",
       "state_updated": "2026-06-01T19:56:38Z",
-      "title": "UI \u2014 dashboard layout + role-specific views"
+      "title": "UI — dashboard layout + role-specific views"
     },
     "548": {
       "action": "BUILD",
@@ -8881,7 +8903,7 @@
       "pr": null,
       "state": "CLOSED",
       "state_updated": "2026-06-01T19:35:13Z",
-      "title": "Tests \u2014 access control + org isolation"
+      "title": "Tests — access control + org isolation"
     },
     "549": {
       "action": "BUILD",
@@ -8906,7 +8928,7 @@
       "pr": null,
       "state": "CLOSED",
       "state_updated": "2026-06-01T19:35:15Z",
-      "title": "Desktop \u2014 hash collider algorithm integration"
+      "title": "Desktop — hash collider algorithm integration"
     },
     "55": {
       "action": "FUTURE",
@@ -8954,7 +8976,7 @@
       "pr": null,
       "state": "CLOSED",
       "state_updated": "2026-06-01T19:35:18Z",
-      "title": "UI \u2014 visualization + parameter controls"
+      "title": "UI — visualization + parameter controls"
     },
     "551": {
       "action": "BUILD",
@@ -8979,7 +9001,7 @@
       "pr": null,
       "state": "CLOSED",
       "state_updated": "2026-06-01T19:35:20Z",
-      "title": "Tests \u2014 collision detection accuracy + performance"
+      "title": "Tests — collision detection accuracy + performance"
     },
     "552": {
       "action": "BUILD",
@@ -9020,7 +9042,7 @@
       "pr": null,
       "state": "CLOSED",
       "state_updated": "2026-06-01T19:56:38Z",
-      "title": "Schema + API \u2014 org billing model + scope management"
+      "title": "Schema + API — org billing model + scope management"
     },
     "553": {
       "action": "BUILD",
@@ -9061,7 +9083,7 @@
       "pr": null,
       "state": "CLOSED",
       "state_updated": "2026-06-01T19:56:38Z",
-      "title": "UI \u2014 billing dashboard + scope controls"
+      "title": "UI — billing dashboard + scope controls"
     },
     "554": {
       "action": "BUILD",
@@ -9102,7 +9124,7 @@
       "pr": null,
       "state": "CLOSED",
       "state_updated": "2026-06-01T19:56:38Z",
-      "title": "Tests \u2014 billing flow + scope enforcement"
+      "title": "Tests — billing flow + scope enforcement"
     },
     "555": {
       "action": "FUTURE",
@@ -9122,7 +9144,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:48Z",
-      "title": "\ud83c\udfdb Phase Beta \u2014 Market-safe money enablement (Alpha\u2192Beta gate)"
+      "title": "🏛 Phase Beta — Market-safe money enablement (Alpha→Beta gate)"
     },
     "556": {
       "action": "FUTURE",
@@ -9142,7 +9164,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:49Z",
-      "title": "\ud83c\udfdb Phase Gamma \u2014 Proof integrity at scale (Beta\u2192Gamma gate)"
+      "title": "🏛 Phase Gamma — Proof integrity at scale (Beta→Gamma gate)"
     },
     "557": {
       "action": "FUTURE",
@@ -9162,7 +9184,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:49Z",
-      "title": "\ud83c\udfdb Phase Delta \u2014 Retention + network effects (Gamma\u2192Delta gate)"
+      "title": "🏛 Phase Delta — Retention + network effects (Gamma→Delta gate)"
     },
     "558": {
       "action": "FUTURE",
@@ -9182,7 +9204,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:49Z",
-      "title": "\ud83c\udfdb Phase Omega \u2014 Enterprise expansion (Delta\u2192Omega gate)"
+      "title": "🏛 Phase Omega — Enterprise expansion (Delta→Omega gate)"
     },
     "559": {
       "action": "WAITING",
@@ -9280,7 +9302,7 @@
       "pr": null,
       "state": "TRACKING",
       "state_updated": "2026-06-01T15:53:57Z",
-      "title": "decision: Community features / local meetups \u2014 in-app or operational?"
+      "title": "decision: Community features / local meetups — in-app or operational?"
     },
     "572": {
       "action": "WAITING",
@@ -9600,7 +9622,7 @@
       "pr": null,
       "state": "TRACK",
       "state_updated": "2026-06-01T15:50:49Z",
-      "title": "expansive inquiry: Styx revenue gap \u2014 why no money"
+      "title": "expansive inquiry: Styx revenue gap — why no money"
     },
     "598": {
       "action": "TRACK",
@@ -9672,7 +9694,7 @@
       "action": "BUG",
       "batch": "bug-603-npm-audit",
       "closed_at": "2026-06-01T19:30:00Z",
-      "evidence": "src/ask-styx/package.json:vitest upgraded 3.2.4\u21924.1.7 fixing GHSA-5xrq-8626-4rwp; src/test-harness/package.json:same; remaining 25 vulns are expo transitive deps requiring expo 54\u219256 major bump",
+      "evidence": "src/ask-styx/package.json:vitest upgraded 3.2.4→4.1.7 fixing GHSA-5xrq-8626-4rwp; src/test-harness/package.json:same; remaining 25 vulns are expo transitive deps requiring expo 54→56 major bump",
       "history": [
         {
           "from": "UNREAD",
@@ -9788,7 +9810,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:49Z",
-      "title": "feat: Post-contract exit interviews \u2014 structured feedback collection"
+      "title": "feat: Post-contract exit interviews — structured feedback collection"
     },
     "66": {
       "action": "BUILD",
@@ -9830,7 +9852,7 @@
       "pr": null,
       "state": "CLOSED",
       "state_updated": "2026-06-01T16:00:40Z",
-      "title": "feat: Oracle circuit breaker & pausable countdown \u2014 safety mechanism for verification failures"
+      "title": "feat: Oracle circuit breaker & pausable countdown — safety mechanism for verification failures"
     },
     "67": {
       "action": "FUTURE",
@@ -9852,7 +9874,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:49Z",
-      "title": "feat: Cross-jurisdictional verification consent matrix \u2014 privacy compliance per state/country"
+      "title": "feat: Cross-jurisdictional verification consent matrix — privacy compliance per state/country"
     },
     "68": {
       "action": "FUTURE",
@@ -9874,7 +9896,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:49Z",
-      "title": "feat: 'Invite Your Coach' B2B self-onboarding \u2014 practitioner-led acquisition channel"
+      "title": "feat: 'Invite Your Coach' B2B self-onboarding — practitioner-led acquisition channel"
     },
     "69": {
       "action": "FUTURE",
@@ -9896,7 +9918,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:49Z",
-      "title": "feat: Practitioner risk intelligence \u2014 composite relapse risk score & NLP journal alerts"
+      "title": "feat: Practitioner risk intelligence — composite relapse risk score & NLP journal alerts"
     },
     "70": {
       "action": "FUTURE",
@@ -9918,7 +9940,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:49Z",
-      "title": "feat: Day 21 micro-reward \u2014 dopamine danger zone intervention"
+      "title": "feat: Day 21 micro-reward — dopamine danger zone intervention"
     },
     "71": {
       "action": "FUTURE",
@@ -9939,7 +9961,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:49Z",
-      "title": "feat: Milestone-triggered shareable resilience reports \u2014 social proof for recovery"
+      "title": "feat: Milestone-triggered shareable resilience reports — social proof for recovery"
     },
     "72": {
       "action": "FUTURE",
@@ -9960,7 +9982,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:49Z",
-      "title": "feat: Sequential-to-simultaneous habit unlocking engine \u2014 multi-behavior progression"
+      "title": "feat: Sequential-to-simultaneous habit unlocking engine — multi-behavior progression"
     },
     "73": {
       "action": "FUTURE",
@@ -9981,7 +10003,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:49Z",
-      "title": "feat: Ecological momentary assessment (EMA) \u2014 stress pulse micro-surveys"
+      "title": "feat: Ecological momentary assessment (EMA) — stress pulse micro-surveys"
     },
     "74": {
       "action": "FUTURE",
@@ -10002,7 +10024,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:49Z",
-      "title": "feat: Stake tapering & incentive fading \u2014 gradual transition from extrinsic to intrinsic motivation"
+      "title": "feat: Stake tapering & incentive fading — gradual transition from extrinsic to intrinsic motivation"
     },
     "75": {
       "action": "FUTURE",
@@ -10023,7 +10045,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:49Z",
-      "title": "feat: Goodharting detection bounties \u2014 anti-gaming verification for metric manipulation"
+      "title": "feat: Goodharting detection bounties — anti-gaming verification for metric manipulation"
     },
     "76": {
       "action": "FUTURE",
@@ -10044,7 +10066,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:49Z",
-      "title": "feat: Multi-judge adjudication panel \u2014 escalated dispute resolution for high-stakes contracts"
+      "title": "feat: Multi-judge adjudication panel — escalated dispute resolution for high-stakes contracts"
     },
     "77": {
       "action": "FUTURE",
@@ -10065,7 +10087,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:49Z",
-      "title": "feat: High-stakes tournament mode \u2014 competitive bracket format for group challenges"
+      "title": "feat: High-stakes tournament mode — competitive bracket format for group challenges"
     },
     "78": {
       "action": "FUTURE",
@@ -10086,7 +10108,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:49Z",
-      "title": "feat: Consumer premium membership tier \u2014 subscription model for power users"
+      "title": "feat: Consumer premium membership tier — subscription model for power users"
     },
     "79": {
       "action": "FUTURE",
@@ -10108,7 +10130,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:49Z",
-      "title": "feat: 'Digital Detox' as primary GTM vertical \u2014 Screen Time API integration"
+      "title": "feat: 'Digital Detox' as primary GTM vertical — Screen Time API integration"
     },
     "80": {
       "action": "FUTURE",
@@ -10129,7 +10151,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:50Z",
-      "title": "feat: Video call spot-checks \u2014 live verification for high-stakes contracts"
+      "title": "feat: Video call spot-checks — live verification for high-stakes contracts"
     },
     "81": {
       "action": "FUTURE",
@@ -10150,7 +10172,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:50Z",
-      "title": "feat: Counter-claim & harassment filing \u2014 Fury auditor accountability mechanism"
+      "title": "feat: Counter-claim & harassment filing — Fury auditor accountability mechanism"
     },
     "82": {
       "action": "FUTURE",
@@ -10172,7 +10194,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:50Z",
-      "title": "feat: Proof-of-Personhood / anti-Sybil layer \u2014 multi-account abuse prevention"
+      "title": "feat: Proof-of-Personhood / anti-Sybil layer — multi-account abuse prevention"
     },
     "83": {
       "action": "FUTURE",
@@ -10193,7 +10215,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:50Z",
-      "title": "feat: Decentralized dispute resolution (Schelling-point / Kleros-style) \u2014 trustless adjudication"
+      "title": "feat: Decentralized dispute resolution (Schelling-point / Kleros-style) — trustless adjudication"
     },
     "84": {
       "action": "FUTURE",
@@ -10214,7 +10236,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:50Z",
-      "title": "feat: 'Inquisitor' RPG mode \u2014 gamified progression system for Fury auditors"
+      "title": "feat: 'Inquisitor' RPG mode — gamified progression system for Fury auditors"
     },
     "85": {
       "action": "FUTURE",
@@ -10236,7 +10258,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:50Z",
-      "title": "feat: Geographic payment routing engine \u2014 jurisdiction-aware processor selection"
+      "title": "feat: Geographic payment routing engine — jurisdiction-aware processor selection"
     },
     "86": {
       "action": "FUTURE",
@@ -10258,7 +10280,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:50Z",
-      "title": "feat: Recovery Ambassador Program \u2014 peer referral network for recovery niche"
+      "title": "feat: Recovery Ambassador Program — peer referral network for recovery niche"
     },
     "87": {
       "action": "FUTURE",
@@ -10279,7 +10301,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:50Z",
-      "title": "feat: Contingency management reward escalation \u2014 graduated positive reinforcement schedule"
+      "title": "feat: Contingency management reward escalation — graduated positive reinforcement schedule"
     },
     "88": {
       "action": "FUTURE",
@@ -10300,7 +10322,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:50Z",
-      "title": "feat: Asymmetric whistleblower system \u2014 enhanced anonymous reporting with graduated bounties"
+      "title": "feat: Asymmetric whistleblower system — enhanced anonymous reporting with graduated bounties"
     },
     "89": {
       "action": "FUTURE",
@@ -10321,7 +10343,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:50Z",
-      "title": "feat: Data revenue sharing with users \u2014 behavioral data ownership & compensation"
+      "title": "feat: Data revenue sharing with users — behavioral data ownership & compensation"
     },
     "90": {
       "action": "FUTURE",
@@ -10342,7 +10364,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:50Z",
-      "title": "feat: Stablecoin-denominated stakes \u2014 crypto payment rail for regulatory flexibility"
+      "title": "feat: Stablecoin-denominated stakes — crypto payment rail for regulatory flexibility"
     },
     "91": {
       "action": "FUTURE",
@@ -10364,7 +10386,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:50Z",
-      "title": "feat: Oracle failure fallback \u2014 staked arbiter network for verification system outages"
+      "title": "feat: Oracle failure fallback — staked arbiter network for verification system outages"
     },
     "92": {
       "action": "FUTURE",
@@ -10386,7 +10408,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:50Z",
-      "title": "feat: DECO privacy-preserving oracle \u2014 TLS-based verification without data exposure"
+      "title": "feat: DECO privacy-preserving oracle — TLS-based verification without data exposure"
     },
     "93": {
       "action": "FUTURE",
@@ -10449,7 +10471,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:50Z",
-      "title": "feat: Neurologically-timed instant reward system \u2014 per-proof micro-rewards & variable bonuses"
+      "title": "feat: Neurologically-timed instant reward system — per-proof micro-rewards & variable bonuses"
     },
     "96": {
       "action": "FUTURE",
@@ -10491,7 +10513,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:50Z",
-      "title": "feat: Temptation bundling engine \u2014 Premack's Principle reward gating"
+      "title": "feat: Temptation bundling engine — Premack's Principle reward gating"
     },
     "98": {
       "action": "FUTURE",
@@ -10533,7 +10555,7 @@
       "pr": null,
       "state": "FUTURE",
       "state_updated": "2026-06-01T15:50:50Z",
-      "title": "feat: Gateway Oath tier \u2014 Two-Minute Rule with progressive habit shaping ladder"
+      "title": "feat: Gateway Oath tier — Two-Minute Rule with progressive habit shaping ladder"
     },
     "606 602 598 597 596 589 588 587 585 584 582 581 578 572 568 559 444 443 442 441 440 439 438 437 436 426 425 424 423 418 417 416 415 277 276 275 274 271 261 260 259 255 254 253 252 240 239 236 233 224 217 210 206 200 199 198 197 196 195 194 193 186 184 183 180 179 145 ": {
       "title": "Unknown",
@@ -10854,6 +10876,321 @@
       "evidence": "docs/triage/pattern-log.md:109",
       "pr": null,
       "state_updated": "2026-06-12T09:37:49Z",
+      "closed_at": null
+    },
+    "569": {
+      "title": "Priority tomorrow: full project-board review + cleanup",
+      "labels": [
+        "business",
+        "ops",
+        "docs",
+        "follow-up",
+        "stale"
+      ],
+      "action": "TRACK",
+      "state": "TRACKING",
+      "batch": "audit-not-planned-closures",
+      "history": [
+        {
+          "from": "UNREAD",
+          "to": "INSPECTED",
+          "at": "2026-06-12T11:47:17Z"
+        },
+        {
+          "from": "INSPECTED",
+          "to": "TRACKING",
+          "at": "2026-06-12T11:47:17Z"
+        }
+      ],
+      "evidence": "https://github.com/a-organvm/peer-audited--behavioral-blockchain/issues/569",
+      "pr": null,
+      "state_updated": "2026-06-12T11:47:17Z",
+      "closed_at": null
+    },
+    "561": {
+      "title": "Authority layer — founder essay + beta safety/trust summary",
+      "labels": [
+        "P1-beta-enhancer",
+        "marketing",
+        "follow-up",
+        "stale"
+      ],
+      "action": "TRACK",
+      "state": "TRACKING",
+      "batch": "audit-not-planned-closures",
+      "history": [
+        {
+          "from": "UNREAD",
+          "to": "INSPECTED",
+          "at": "2026-06-12T11:47:17Z"
+        },
+        {
+          "from": "INSPECTED",
+          "to": "TRACKING",
+          "at": "2026-06-12T11:47:17Z"
+        }
+      ],
+      "evidence": "https://github.com/a-organvm/peer-audited--behavioral-blockchain/issues/561",
+      "pr": null,
+      "state_updated": "2026-06-12T11:47:17Z",
+      "closed_at": null
+    },
+    "560": {
+      "title": "Emergency acquisition asset — \"Do Not Text Your Ex Tonight\" page/tool",
+      "labels": [
+        "P1-beta-enhancer",
+        "marketing",
+        "follow-up",
+        "stale"
+      ],
+      "action": "BUILD",
+      "state": "TRACKING",
+      "batch": "audit-not-planned-closures",
+      "history": [
+        {
+          "from": "UNREAD",
+          "to": "INSPECTED",
+          "at": "2026-06-12T11:47:17Z"
+        },
+        {
+          "from": "INSPECTED",
+          "to": "TRACKING",
+          "at": "2026-06-12T11:47:17Z"
+        }
+      ],
+      "evidence": "https://github.com/a-organvm/peer-audited--behavioral-blockchain/issues/560",
+      "pr": null,
+      "state_updated": "2026-06-12T11:47:17Z",
+      "closed_at": null
+    },
+    "314": {
+      "title": "feat: B2B orchestration panel — billing & scope management (F-DESKTOP-05)",
+      "labels": [
+        "desktop",
+        "P1-beta-enhancer",
+        "b2b"
+      ],
+      "action": "BUILD",
+      "state": "TRACKING",
+      "batch": "audit-not-planned-closures",
+      "history": [
+        {
+          "from": "UNREAD",
+          "to": "INSPECTED",
+          "at": "2026-06-12T11:47:17Z"
+        },
+        {
+          "from": "INSPECTED",
+          "to": "TRACKING",
+          "at": "2026-06-12T11:47:17Z"
+        }
+      ],
+      "evidence": "https://github.com/a-organvm/peer-audited--behavioral-blockchain/issues/314",
+      "pr": null,
+      "state_updated": "2026-06-12T11:47:17Z",
+      "closed_at": null
+    },
+    "313": {
+      "title": "feat: Hash collider desktop tool wiring (F-DESKTOP-04)",
+      "labels": [
+        "desktop",
+        "P1-beta-enhancer"
+      ],
+      "action": "BUILD",
+      "state": "TRACKING",
+      "batch": "audit-not-planned-closures",
+      "history": [
+        {
+          "from": "UNREAD",
+          "to": "INSPECTED",
+          "at": "2026-06-12T11:47:17Z"
+        },
+        {
+          "from": "INSPECTED",
+          "to": "TRACKING",
+          "at": "2026-06-12T11:47:17Z"
+        }
+      ],
+      "evidence": "https://github.com/a-organvm/peer-audited--behavioral-blockchain/issues/313",
+      "pr": null,
+      "state_updated": "2026-06-12T11:47:17Z",
+      "closed_at": null
+    },
+    "312": {
+      "title": "feat: HR dashboard — role-based access & org authorization (F-WEB-03)",
+      "labels": [
+        "P1-beta-enhancer",
+        "b2b"
+      ],
+      "action": "BUILD",
+      "state": "TRACKING",
+      "batch": "audit-not-planned-closures",
+      "history": [
+        {
+          "from": "UNREAD",
+          "to": "INSPECTED",
+          "at": "2026-06-12T11:47:17Z"
+        },
+        {
+          "from": "INSPECTED",
+          "to": "TRACKING",
+          "at": "2026-06-12T11:47:17Z"
+        }
+      ],
+      "evidence": "https://github.com/a-organvm/peer-audited--behavioral-blockchain/issues/312",
+      "pr": null,
+      "state_updated": "2026-06-12T11:47:17Z",
+      "closed_at": null
+    },
+    "311": {
+      "title": "feat: Bounded stake selection UI (F-UX-06)",
+      "labels": [
+        "P1-beta-enhancer"
+      ],
+      "action": "BUILD",
+      "state": "TRACKING",
+      "batch": "audit-not-planned-closures",
+      "history": [
+        {
+          "from": "UNREAD",
+          "to": "INSPECTED",
+          "at": "2026-06-12T11:47:17Z"
+        },
+        {
+          "from": "INSPECTED",
+          "to": "TRACKING",
+          "at": "2026-06-12T11:47:17Z"
+        }
+      ],
+      "evidence": "https://github.com/a-organvm/peer-audited--behavioral-blockchain/issues/311",
+      "pr": null,
+      "state_updated": "2026-06-12T11:47:17Z",
+      "closed_at": null
+    },
+    "309": {
+      "title": "feat: Finish line spike — double-stake incentive (F-CORE-09)",
+      "labels": [
+        "P1-beta-enhancer"
+      ],
+      "action": "BUILD",
+      "state": "TRACKING",
+      "batch": "audit-not-planned-closures",
+      "history": [
+        {
+          "from": "UNREAD",
+          "to": "INSPECTED",
+          "at": "2026-06-12T11:47:17Z"
+        },
+        {
+          "from": "INSPECTED",
+          "to": "TRACKING",
+          "at": "2026-06-12T11:47:18Z"
+        }
+      ],
+      "evidence": "https://github.com/a-organvm/peer-audited--behavioral-blockchain/issues/309",
+      "pr": null,
+      "state_updated": "2026-06-12T11:47:18Z",
+      "closed_at": null
+    },
+    "292": {
+      "title": "feat: Skill-contest whitepaper release gate (TKT-P1-019)",
+      "labels": [
+        "P1-beta-enhancer",
+        "blocked"
+      ],
+      "action": "TRACK",
+      "state": "TRACKING",
+      "batch": "audit-not-planned-closures",
+      "history": [
+        {
+          "from": "UNREAD",
+          "to": "INSPECTED",
+          "at": "2026-06-12T11:47:18Z"
+        },
+        {
+          "from": "INSPECTED",
+          "to": "TRACKING",
+          "at": "2026-06-12T11:47:18Z"
+        }
+      ],
+      "evidence": "https://github.com/a-organvm/peer-audited--behavioral-blockchain/issues/292",
+      "pr": null,
+      "state_updated": "2026-06-12T11:47:18Z",
+      "closed_at": null
+    },
+    "289": {
+      "title": "feat: Collusion slashing & honey-trap enforcement (TKT-P1-015)",
+      "labels": [
+        "P1-beta-enhancer"
+      ],
+      "action": "BUILD",
+      "state": "TRACKING",
+      "batch": "audit-not-planned-closures",
+      "history": [
+        {
+          "from": "UNREAD",
+          "to": "INSPECTED",
+          "at": "2026-06-12T11:47:18Z"
+        },
+        {
+          "from": "INSPECTED",
+          "to": "TRACKING",
+          "at": "2026-06-12T11:47:18Z"
+        }
+      ],
+      "evidence": "https://github.com/a-organvm/peer-audited--behavioral-blockchain/issues/289",
+      "pr": null,
+      "state_updated": "2026-06-12T11:47:18Z",
+      "closed_at": null
+    },
+    "287": {
+      "title": "feat: Anti-collusion routing — admin cluster screen (TKT-P1-008)",
+      "labels": [
+        "P1-beta-enhancer"
+      ],
+      "action": "BUILD",
+      "state": "TRACKING",
+      "batch": "audit-not-planned-closures",
+      "history": [
+        {
+          "from": "UNREAD",
+          "to": "INSPECTED",
+          "at": "2026-06-12T11:47:18Z"
+        },
+        {
+          "from": "INSPECTED",
+          "to": "TRACKING",
+          "at": "2026-06-12T11:47:18Z"
+        }
+      ],
+      "evidence": "https://github.com/a-organvm/peer-audited--behavioral-blockchain/issues/287",
+      "pr": null,
+      "state_updated": "2026-06-12T11:47:18Z",
+      "closed_at": null
+    },
+    "282": {
+      "title": "feat: Video proof pipeline — processing state UI (TKT-P1-013)",
+      "labels": [
+        "P1-beta-enhancer"
+      ],
+      "action": "BUILD",
+      "state": "TRACKING",
+      "batch": "audit-not-planned-closures",
+      "history": [
+        {
+          "from": "UNREAD",
+          "to": "INSPECTED",
+          "at": "2026-06-12T11:47:18Z"
+        },
+        {
+          "from": "INSPECTED",
+          "to": "TRACKING",
+          "at": "2026-06-12T11:47:18Z"
+        }
+      ],
+      "evidence": "https://github.com/a-organvm/peer-audited--behavioral-blockchain/issues/282",
+      "pr": null,
+      "state_updated": "2026-06-12T11:47:18Z",
       "closed_at": null
     }
   }

--- a/docs/triage/pattern-log.md
+++ b/docs/triage/pattern-log.md
@@ -187,3 +187,22 @@ instantiations cover the named type-space. The third (Styx) was the proof-of-run
 the fourth and fifth (public-record-data-scrapper, sovereign-ecosystem) are the
 proof-of-type-coverage. The cross-instance verdict table is the smallest
 artifact that exposes the parameter shape to future readers.
+
+## batch-audit-not-planned-closures — 2026-06-12 — Repair NOT_PLANNED closure drift
+
+**Issues:** #569, #561, #560, #314, #313, #312, #311, #309, #292, #289, #287,
+#282.
+
+**Status:** all 12 were reopened on GitHub and added to `docs/triage.json` as
+live work. They are not complete, not canceled, and not eligible for closure
+until implemented or explicitly represented by a durable plan that keeps the
+work visible.
+
+**Build obligations:** #560, #314, #313, #312, #311, #309, #289, #287, #282.
+
+**Tracking/planning obligations:** #569, #561, #292.
+
+**Lesson:** `NOT_PLANNED` is not a valid queue-cleanup state for this repo. If
+work is post-beta, blocked, duplicate, stale, or too large for the current
+session, keep it open and record the live obligation. Closing is reserved for
+implemented work with evidence.


### PR DESCRIPTION
## Summary
- reopen and ledger 12 issues that had been closed as `NOT_PLANNED`
- mark the 9 buildable items as `BUILD` obligations and the 3 planning/governance items as `TRACK`
- document that stale/future/too-large work stays open unless implemented with evidence

## Why
The live GitHub issue queue had 12 closed issues with `stateReason=NOT_PLANNED` and no corresponding rows in `docs/triage.json`. That made the repo-local dashboard look clean while live work had been removed from the queue.

## Validation
- `jq empty docs/triage.json`
- `npm run validate:claims`
- `scripts/triage/reconcile.sh audit-not-planned-closures`
- `scripts/triage/report.sh`
- `git diff --check`

Live GitHub verification after reopening:
- open issues: 432
- closed `NOT_PLANNED` issues: 0
- open PRs before this PR: 0
