### PR TITLE
chore: enable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
       - "/src/mobile"
       - "/src/pitch"
       - "/src/shared"
+      - "/src/web"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
@@ -46,4 +47,12 @@ updates:
     open-pull-requests-limit: 3
     groups:
       cargo-deps:
+        patterns: ["*"]
+  - package-ecosystem: "terraform"
+    directory: "/infra/terraform"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      terraform-providers:
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/packages/audience-engine"
+      - "/packages/audit-engine"
+      - "/packages/styx-cli"
+      - "/src/api"
+      - "/src/ask-styx"
+      - "/src/desktop"
+      - "/src/mobile"
+      - "/src/pitch"
+      - "/src/shared"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      npm-deps:
+        patterns: ["*"]
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      github-actions-deps:
+        patterns: ["*"]
+  - package-ecosystem: "docker"
+    directories:
+      - "/.config/docker"
+      - "/src/api"
+      - "/src/web"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      docker-deps:
+        patterns: ["*"]
+  - package-ecosystem: "cargo"
+    directories:
+      - "/src/desktop/src-tauri"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      cargo-deps:
+        patterns: ["*"]


### PR DESCRIPTION
Fleet-wide freshness rollout: weekly grouped version updates for all detected ecosystems (npm gha docker cargo), capped at 3 open PRs per ecosystem. Vulnerability alerts and automated security fixes enabled alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)