### PR TITLE
feat(web): build bounded stake selector

### DIFF
--- a/docs/triage.json
+++ b/docs/triage.json
@@ -242,7 +242,7 @@
         282
       ],
       "started": "2026-06-12T11:46:15Z",
-      "completed": "2026-06-12T11:48:08Z",
+      "completed": "2026-06-12T12:03:33Z",
       "reconciled": true,
       "test_passed": true
     }
@@ -11048,7 +11048,7 @@
         "P1-beta-enhancer"
       ],
       "action": "BUILD",
-      "state": "TRACKING",
+      "state": "TESTED",
       "batch": "audit-not-planned-closures",
       "history": [
         {
@@ -11060,11 +11060,26 @@
           "from": "INSPECTED",
           "to": "TRACKING",
           "at": "2026-06-12T11:47:17Z"
+        },
+        {
+          "from": "TRACKING",
+          "to": "BUILD_STARTED",
+          "at": "2026-06-12T11:59:13Z"
+        },
+        {
+          "from": "BUILD_STARTED",
+          "to": "BUILD_DONE",
+          "at": "2026-06-12T11:59:13Z"
+        },
+        {
+          "from": "BUILD_DONE",
+          "to": "TESTED",
+          "at": "2026-06-12T11:59:13Z"
         }
       ],
-      "evidence": "https://github.com/a-organvm/peer-audited--behavioral-blockchain/issues/311",
+      "evidence": "src/web/app/contracts/new/page.test.tsx:84",
       "pr": null,
-      "state_updated": "2026-06-12T11:47:17Z",
+      "state_updated": "2026-06-12T11:59:13Z",
       "closed_at": null
     },
     "309": {

--- a/docs/triage.json
+++ b/docs/triage.json
@@ -242,7 +242,7 @@
         282
       ],
       "started": "2026-06-12T11:46:15Z",
-      "completed": "2026-06-12T12:03:33Z",
+      "completed": "2026-06-12T12:06:29Z",
       "reconciled": true,
       "test_passed": true
     }
@@ -11048,7 +11048,7 @@
         "P1-beta-enhancer"
       ],
       "action": "BUILD",
-      "state": "TESTED",
+      "state": "PR_CREATED",
       "batch": "audit-not-planned-closures",
       "history": [
         {
@@ -11075,11 +11075,16 @@
           "from": "BUILD_DONE",
           "to": "TESTED",
           "at": "2026-06-12T11:59:13Z"
+        },
+        {
+          "from": "TESTED",
+          "to": "PR_CREATED",
+          "at": "2026-06-12T12:06:29Z"
         }
       ],
       "evidence": "src/web/app/contracts/new/page.test.tsx:84",
-      "pr": null,
-      "state_updated": "2026-06-12T11:59:13Z",
+      "pr": "https://github.com/a-organvm/peer-audited--behavioral-blockchain/pull/692",
+      "state_updated": "2026-06-12T12:06:29Z",
       "closed_at": null
     },
     "309": {

--- a/docs/triage.json
+++ b/docs/triage.json
@@ -242,7 +242,7 @@
         282
       ],
       "started": "2026-06-12T11:46:15Z",
-      "completed": "2026-06-12T12:06:29Z",
+      "completed": "2026-06-12T12:15:10Z",
       "reconciled": true,
       "test_passed": true
     }

--- a/docs/triage/pattern-log.md
+++ b/docs/triage/pattern-log.md
@@ -206,3 +206,19 @@ work visible.
 work is post-beta, blocked, duplicate, stale, or too large for the current
 session, keep it open and record the live obligation. Closing is reserved for
 implemented work with evidence.
+
+## batch-build-bounded-stake-311 — 2026-06-12 — Build bounded stake selector
+
+**Issue:** #311 — bounded stake selection UI.
+
+**Status:** implemented and tested locally. The contract creation page now
+derives stake bounds from the user's integrity tier, applies the Aegis safety
+ceiling, renders a bounded slider plus numeric amount control, shows loss-framed
+copy, and displays the live `$30 + $9 = $39` fee breakdown.
+
+**Evidence:** `src/web/app/contracts/new/page.tsx`, plus static render coverage
+in `src/web/app/contracts/new/page.test.tsx`.
+
+**Lesson:** Tracked live work must be able to move into implementation. The
+triage transition script now permits `TRACKING`, `FUTURE`, and `WAITING` issues
+to enter `BUILD_STARTED` when a deferred obligation is actually picked up.

--- a/scripts/triage/state-transition.sh
+++ b/scripts/triage/state-transition.sh
@@ -47,6 +47,9 @@ valid_transition() {
   "INSPECTED→WAITING") return 0 ;;
   "INSPECTED→FUTURE") return 0 ;;
   "INSPECTED→BUG") return 0 ;;
+  "TRACKING→BUILD_STARTED") return 0 ;;
+  "FUTURE→BUILD_STARTED") return 0 ;;
+  "WAITING→BUILD_STARTED") return 0 ;;
   "WAITING→SUPERSEDED") return 0 ;;
   "FUTURE→SUPERSEDED") return 0 ;;
   "TRACKING→SUPERSEDED") return 0 ;;

--- a/src/web/app/contracts/new/page.test.tsx
+++ b/src/web/app/contracts/new/page.test.tsx
@@ -21,17 +21,21 @@ jest.mock('next/link', () => {
 jest.mock('../../../services/api-client', () => ({
   api: {
     createContract: jest.fn().mockResolvedValue({ id: 'new-id' }),
+    getUserContracts: jest.fn().mockResolvedValue([]),
   },
 }));
 
+let mockAuthUser = {
+  id: '1',
+  email: 'test@styx.io',
+  integrity_score: 125,
+  role: 'USER',
+  failed_contracts: 0,
+};
+
 jest.mock('../../../contexts/AuthContext', () => ({
   useAuth: () => ({
-    user: {
-      id: '1',
-      email: 'test@styx.io',
-      integrity_score: 125,
-      role: 'USER',
-    },
+    user: mockAuthUser,
     token: 'mock-token',
     login: jest.fn(),
     register: jest.fn(),
@@ -43,6 +47,16 @@ jest.mock('../../../contexts/AuthContext', () => ({
 import NewContractPage from './page';
 
 describe('New Contract Page', () => {
+  beforeEach(() => {
+    mockAuthUser = {
+      id: '1',
+      email: 'test@styx.io',
+      integrity_score: 125,
+      role: 'USER',
+      failed_contracts: 0,
+    };
+  });
+
   it('renders the page heading', () => {
     const html = renderToStaticMarkup(<NewContractPage />);
 
@@ -103,6 +117,35 @@ describe('New Contract Page', () => {
     expect(html).toContain('Aegis safety ceiling');
     expect(html).toContain('KYC required at this amount');
     expect(html).toContain('choose only an amount you can afford to lose');
+  });
+
+  it('keeps exact $20 micro stakes outside KYC and MVP fees', () => {
+    mockAuthUser = {
+      id: '1',
+      email: 'micro@styx.io',
+      integrity_score: 35,
+      role: 'USER',
+      failed_contracts: 0,
+    };
+    const html = renderToStaticMarkup(<NewContractPage />);
+
+    expect(html).toContain('MICRO tier cap');
+    expect(html).toContain('$20.00');
+    expect(html).toContain('No KYC required');
+    expect(html).toContain('Only applies to the $30 MVP plan');
+  });
+
+  it('renders failure-history cap copy when failed contracts are known', () => {
+    mockAuthUser = {
+      id: '1',
+      email: 'risk@styx.io',
+      integrity_score: 125,
+      role: 'USER',
+      failed_contracts: 3,
+    };
+    const html = renderToStaticMarkup(<NewContractPage />);
+
+    expect(html).toContain('Failure-history cap: $50.00 after 3 failed contracts.');
   });
 
   it('renders duration buttons', () => {

--- a/src/web/app/contracts/new/page.test.tsx
+++ b/src/web/app/contracts/new/page.test.tsx
@@ -24,6 +24,22 @@ jest.mock('../../../services/api-client', () => ({
   },
 }));
 
+jest.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: {
+      id: '1',
+      email: 'test@styx.io',
+      integrity_score: 125,
+      role: 'USER',
+    },
+    token: 'mock-token',
+    login: jest.fn(),
+    register: jest.fn(),
+    logout: jest.fn(),
+    isLoading: false,
+  }),
+}));
+
 import NewContractPage from './page';
 
 describe('New Contract Page', () => {
@@ -66,6 +82,27 @@ describe('New Contract Page', () => {
 
     expect(html).toContain('Stake Amount (USD)');
     expect(html).toContain('FBO hold');
+  });
+
+  it('renders bounded stake controls with live fee breakdown', () => {
+    const html = renderToStaticMarkup(<NewContractPage />);
+
+    expect(html).toContain('Bounded stake amount');
+    expect(html).toContain('You could lose');
+    expect(html).toContain('Refundable stake');
+    expect(html).toContain('Platform fee');
+    expect(html).toContain('$9.00');
+    expect(html).toContain('Entry total');
+    expect(html).toContain('$39.00');
+  });
+
+  it('renders tier and Aegis safety copy for the selected amount', () => {
+    const html = renderToStaticMarkup(<NewContractPage />);
+
+    expect(html).toContain('HIGH ROLLER tier cap');
+    expect(html).toContain('Aegis safety ceiling');
+    expect(html).toContain('KYC required at this amount');
+    expect(html).toContain('choose only an amount you can afford to lose');
   });
 
   it('renders duration buttons', () => {

--- a/src/web/app/contracts/new/page.tsx
+++ b/src/web/app/contracts/new/page.tsx
@@ -1,10 +1,13 @@
 'use client';
 
-import React, { Suspense, useState } from 'react';
+import React, { Suspense, useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Flame, ArrowLeft, Loader2 } from 'lucide-react';
+import { Flame, ArrowLeft, Loader2, ShieldCheck, TriangleAlert } from 'lucide-react';
 import Link from 'next/link';
 import { api } from '../../../services/api-client';
+import { useAuth } from '../../../contexts/AuthContext';
+import { getAllowedTiers, getDisplayTier, getTierMaxStake } from '../../../../shared/libs/integrity';
+import { isKycRequired } from '../../../../shared/config/stake-tiers';
 import { getRealmBySlug } from '../../../../shared/libs/realm-registry';
 
 const OATH_CATEGORIES = [
@@ -57,14 +60,30 @@ const DURATION_OPTIONS = [
   { value: 90, label: '90 days' },
 ];
 
+const DEFAULT_STAKE_USD = 30;
+const PLATFORM_FEE_USD = 9;
+const AEGIS_MAX_STAKE_USD = 500;
+const LOW_INTEGRITY_AEGIS_MAX_USD = 100;
+const MIN_STAKE_USD = 1;
+
+function clampStakeAmount(value: number, maxStakeUsd: number): number {
+  if (maxStakeUsd < MIN_STAKE_USD) return 0;
+  return Math.min(Math.max(value, MIN_STAKE_USD), maxStakeUsd);
+}
+
+function formatMoney(value: number): string {
+  return `$${value.toFixed(2)}`;
+}
+
 function NewContractPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { user } = useAuth();
   const realmSlug = searchParams.get('realm');
   const realmFilter = realmSlug ? getRealmBySlug(realmSlug) : null;
   const [oathCategory, setOathCategory] = useState('');
   const [verificationMethod, setVerificationMethod] = useState('');
-  const [stakeAmount, setStakeAmount] = useState('');
+  const [stakeAmount, setStakeAmount] = useState(String(DEFAULT_STAKE_USD));
   const [durationDays, setDurationDays] = useState(30);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -79,6 +98,29 @@ function NewContractPageContent() {
 
   const isRecovery = oathCategory.startsWith('RECOVERY_');
   const isNoContact = oathCategory === 'RECOVERY_NOCONTACT';
+  const integrityScore = user?.integrity_score ?? 50;
+  const allowedTiers = useMemo(() => getAllowedTiers(integrityScore), [integrityScore]);
+  const tierMaxStakeCents = useMemo(() => getTierMaxStake(allowedTiers), [allowedTiers]);
+  const tierMaxStakeUsd = Number.isFinite(tierMaxStakeCents)
+    ? tierMaxStakeCents / 100
+    : AEGIS_MAX_STAKE_USD;
+  const aegisMaxStakeUsd = integrityScore < 40
+    ? Math.min(AEGIS_MAX_STAKE_USD, LOW_INTEGRITY_AEGIS_MAX_USD)
+    : AEGIS_MAX_STAKE_USD;
+  const maxStakeUsd = Math.floor(Math.max(0, Math.min(tierMaxStakeUsd, aegisMaxStakeUsd)));
+  const selectedStakeUsd = clampStakeAmount(Number.parseFloat(stakeAmount) || 0, maxStakeUsd);
+  const platformFeeUsd = selectedStakeUsd > 0 ? PLATFORM_FEE_USD : 0;
+  const totalEntryUsd = selectedStakeUsd + platformFeeUsd;
+  const requiresKyc = selectedStakeUsd > 0 && isKycRequired(Math.round(selectedStakeUsd * 100));
+  const canStake = maxStakeUsd >= MIN_STAKE_USD;
+  const displayTier = getDisplayTier(integrityScore).replace(/_/g, ' ');
+
+  useEffect(() => {
+    const nextStake = clampStakeAmount(Number.parseFloat(stakeAmount) || DEFAULT_STAKE_USD, maxStakeUsd);
+    if (String(nextStake) !== stakeAmount) {
+      setStakeAmount(String(nextStake));
+    }
+  }, [maxStakeUsd, stakeAmount]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -90,8 +132,12 @@ function NewContractPageContent() {
     }
 
     const amount = parseFloat(stakeAmount);
-    if (isNaN(amount) || amount <= 0 || amount > 20) {
-      setError('Stake amount must be between $1 and $20 for the current beta phase.');
+    if (!canStake) {
+      setError('Integrity score is too low to open a financial commitment right now.');
+      return;
+    }
+    if (isNaN(amount) || amount < MIN_STAKE_USD || amount > maxStakeUsd) {
+      setError(`Stake amount must be between ${formatMoney(MIN_STAKE_USD)} and ${formatMoney(maxStakeUsd)} for your current tier.`);
       return;
     }
 
@@ -113,6 +159,7 @@ function NewContractPageContent() {
         verificationMethod,
         stakeAmount: amount,
         durationDays: effectiveDuration,
+        ...(amount === DEFAULT_STAKE_USD ? { pricing: { plan: 'MVP_39' } } : {}),
         ...(realmFilter ? { realmId: realmFilter.id } : {}),
       };
 
@@ -216,20 +263,71 @@ function NewContractPageContent() {
           <label className="block text-sm font-bold text-neutral-400 uppercase tracking-widest mb-3">
             Stake Amount (USD)
           </label>
-          <div className="relative">
-            <span className="absolute left-4 top-1/2 -translate-y-1/2 text-red-500 font-black text-xl">$</span>
+          <div className="space-y-5 rounded-xl border border-neutral-800 bg-neutral-900 p-5">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <p className="text-xs font-bold uppercase tracking-widest text-neutral-500">You could lose</p>
+                <p className="mt-1 text-4xl font-black text-red-500">{formatMoney(selectedStakeUsd)}</p>
+                <p className="mt-2 text-sm text-neutral-500">
+                  {displayTier} tier cap: {formatMoney(maxStakeUsd)}. Aegis safety ceiling: {formatMoney(aegisMaxStakeUsd)}.
+                </p>
+              </div>
+              <div className="rounded-lg border border-neutral-800 bg-black px-4 py-3 text-right">
+                <p className="text-xs font-bold uppercase tracking-widest text-neutral-500">Entry total</p>
+                <p className="text-2xl font-black text-white">{formatMoney(totalEntryUsd)}</p>
+              </div>
+            </div>
+
             <input
-              type="number"
-              min="1"
-              max="20"
-              step="0.01"
-              value={stakeAmount}
+              aria-label="Bounded stake amount"
+              type="range"
+              min={canStake ? MIN_STAKE_USD : 0}
+              max={Math.max(maxStakeUsd, MIN_STAKE_USD)}
+              step="1"
+              value={selectedStakeUsd}
+              disabled={!canStake}
               onChange={(e) => setStakeAmount(e.target.value)}
-              placeholder="0.00"
-              className="w-full p-4 pl-10 bg-neutral-900 border border-neutral-800 rounded-xl text-white font-black text-2xl placeholder:text-neutral-700 focus:border-red-600 focus:outline-none"
+              className="w-full accent-red-600 disabled:opacity-40"
             />
+
+            <div className="grid gap-3 sm:grid-cols-[1fr_1fr_1fr]">
+              <div className="rounded-lg border border-neutral-800 bg-black p-3">
+                <p className="text-xs font-bold uppercase tracking-widest text-neutral-500">Refundable stake</p>
+                <p className="mt-1 text-lg font-black text-white">{formatMoney(selectedStakeUsd)}</p>
+              </div>
+              <div className="rounded-lg border border-neutral-800 bg-black p-3">
+                <p className="text-xs font-bold uppercase tracking-widest text-neutral-500">Platform fee</p>
+                <p className="mt-1 text-lg font-black text-white">{formatMoney(platformFeeUsd)}</p>
+              </div>
+              <label className="rounded-lg border border-neutral-800 bg-black p-3">
+                <span className="text-xs font-bold uppercase tracking-widest text-neutral-500">Amount</span>
+                <span className="mt-1 flex items-center gap-2">
+                  <span className="text-red-500 font-black">$</span>
+                  <input
+                    type="number"
+                    min={canStake ? MIN_STAKE_USD : 0}
+                    max={maxStakeUsd}
+                    step="1"
+                    value={selectedStakeUsd}
+                    disabled={!canStake}
+                    onChange={(e) => setStakeAmount(e.target.value)}
+                    className="w-full bg-transparent text-lg font-black text-white focus:outline-none disabled:opacity-40"
+                  />
+                </span>
+              </label>
+            </div>
+
+            <div className="flex flex-col gap-3 border-t border-neutral-800 pt-4 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-xs text-neutral-500">
+                Loss framing is intentional: choose only an amount you can afford to lose.
+              </p>
+              <p className={`inline-flex items-center gap-2 text-xs font-bold uppercase tracking-widest ${requiresKyc ? 'text-amber-400' : 'text-emerald-400'}`}>
+                {requiresKyc ? <TriangleAlert size={14} /> : <ShieldCheck size={14} />}
+                {requiresKyc ? 'KYC required at this amount' : 'No KYC required'}
+              </p>
+            </div>
           </div>
-          <p className="text-xs text-neutral-600 mt-2">Test-money only ($20 cap). Failure means simulated forfeiture.</p>
+          <p className="text-xs text-neutral-600 mt-2">Test-money only. Backend Aegis checks still enforce final safety limits.</p>
         </div>
 
         {/* Duration */}

--- a/src/web/app/contracts/new/page.tsx
+++ b/src/web/app/contracts/new/page.tsx
@@ -7,7 +7,6 @@ import Link from 'next/link';
 import { api } from '../../../services/api-client';
 import { useAuth } from '../../../contexts/AuthContext';
 import { getAllowedTiers, getDisplayTier, getTierMaxStake } from '../../../../shared/libs/integrity';
-import { isKycRequired } from '../../../../shared/config/stake-tiers';
 import { getRealmBySlug } from '../../../../shared/libs/realm-registry';
 
 const OATH_CATEGORIES = [
@@ -64,6 +63,9 @@ const DEFAULT_STAKE_USD = 30;
 const PLATFORM_FEE_USD = 9;
 const AEGIS_MAX_STAKE_USD = 500;
 const LOW_INTEGRITY_AEGIS_MAX_USD = 100;
+const FAILURE_AEGIS_MAX_USD = 50;
+const FAILURE_DOWNSCALE_STRIKE_THRESHOLD = 3;
+const KYC_EXEMPT_MAX_USD = 20;
 const MIN_STAKE_USD = 1;
 
 function clampStakeAmount(value: number, maxStakeUsd: number): number {
@@ -73,6 +75,32 @@ function clampStakeAmount(value: number, maxStakeUsd: number): number {
 
 function formatMoney(value: number): string {
   return `$${value.toFixed(2)}`;
+}
+
+function getProfileFailureCount(
+  user: { failed_contracts?: number; failedContracts?: number } | null | undefined,
+): number | null {
+  const rawCount = user?.failed_contracts ?? user?.failedContracts;
+  return typeof rawCount === 'number' && Number.isFinite(rawCount)
+    ? Math.max(0, rawCount)
+    : null;
+}
+
+function getFailureAdjustedTierMaxStakeUsd(tierMaxStakeUsd: number, failureCount: number | null): number {
+  if (failureCount == null || failureCount < FAILURE_DOWNSCALE_STRIKE_THRESHOLD) {
+    return tierMaxStakeUsd;
+  }
+
+  const downscaleFactor = Math.pow(
+    0.5,
+    Math.floor(failureCount / FAILURE_DOWNSCALE_STRIKE_THRESHOLD),
+  );
+
+  return Math.min(tierMaxStakeUsd * downscaleFactor, FAILURE_AEGIS_MAX_USD);
+}
+
+function requiresCreateContractKyc(stakeUsd: number): boolean {
+  return stakeUsd > KYC_EXEMPT_MAX_USD;
 }
 
 function NewContractPageContent() {
@@ -87,6 +115,7 @@ function NewContractPageContent() {
   const [durationDays, setDurationDays] = useState(30);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [failureCount, setFailureCount] = useState<number | null>(null);
 
   // Recovery stream fields
   const [apEmail, setApEmail] = useState('');
@@ -99,6 +128,8 @@ function NewContractPageContent() {
   const isRecovery = oathCategory.startsWith('RECOVERY_');
   const isNoContact = oathCategory === 'RECOVERY_NOCONTACT';
   const integrityScore = user?.integrity_score ?? 50;
+  const profileFailureCount = getProfileFailureCount(user);
+  const effectiveFailureCount = failureCount ?? profileFailureCount;
   const allowedTiers = useMemo(() => getAllowedTiers(integrityScore), [integrityScore]);
   const tierMaxStakeCents = useMemo(() => getTierMaxStake(allowedTiers), [allowedTiers]);
   const tierMaxStakeUsd = Number.isFinite(tierMaxStakeCents)
@@ -107,13 +138,45 @@ function NewContractPageContent() {
   const aegisMaxStakeUsd = integrityScore < 40
     ? Math.min(AEGIS_MAX_STAKE_USD, LOW_INTEGRITY_AEGIS_MAX_USD)
     : AEGIS_MAX_STAKE_USD;
-  const maxStakeUsd = Math.floor(Math.max(0, Math.min(tierMaxStakeUsd, aegisMaxStakeUsd)));
+  const failureAdjustedTierMaxStakeUsd = getFailureAdjustedTierMaxStakeUsd(tierMaxStakeUsd, effectiveFailureCount);
+  const maxStakeUsd = Math.floor(Math.max(0, Math.min(failureAdjustedTierMaxStakeUsd, aegisMaxStakeUsd)));
   const selectedStakeUsd = clampStakeAmount(Number.parseFloat(stakeAmount) || 0, maxStakeUsd);
-  const platformFeeUsd = selectedStakeUsd > 0 ? PLATFORM_FEE_USD : 0;
+  const usesMvpPlan = selectedStakeUsd === DEFAULT_STAKE_USD;
+  const platformFeeUsd = usesMvpPlan ? PLATFORM_FEE_USD : 0;
   const totalEntryUsd = selectedStakeUsd + platformFeeUsd;
-  const requiresKyc = selectedStakeUsd > 0 && isKycRequired(Math.round(selectedStakeUsd * 100));
+  const requiresKyc = selectedStakeUsd > 0 && requiresCreateContractKyc(selectedStakeUsd);
   const canStake = maxStakeUsd >= MIN_STAKE_USD;
   const displayTier = getDisplayTier(integrityScore).replace(/_/g, ' ');
+  const failureLimitCopy = effectiveFailureCount == null
+    ? 'Server checks failure history again at submit.'
+    : effectiveFailureCount >= FAILURE_DOWNSCALE_STRIKE_THRESHOLD
+      ? `Failure-history cap: ${formatMoney(maxStakeUsd)} after ${effectiveFailureCount} failed contracts.`
+      : 'No failure-history cap applied.';
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const profileFailureCount = getProfileFailureCount(user);
+    setFailureCount(profileFailureCount);
+
+    if (!user) return undefined;
+
+    api.getUserContracts()
+      .then((contracts) => {
+        if (cancelled) return;
+        const failedContracts = contracts.filter((contract) => contract.status === 'FAILED').length;
+        setFailureCount(failedContracts);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setFailureCount(profileFailureCount);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
 
   useEffect(() => {
     const nextStake = clampStakeAmount(Number.parseFloat(stakeAmount) || DEFAULT_STAKE_USD, maxStakeUsd);
@@ -270,6 +333,8 @@ function NewContractPageContent() {
                 <p className="mt-1 text-4xl font-black text-red-500">{formatMoney(selectedStakeUsd)}</p>
                 <p className="mt-2 text-sm text-neutral-500">
                   {displayTier} tier cap: {formatMoney(maxStakeUsd)}. Aegis safety ceiling: {formatMoney(aegisMaxStakeUsd)}.
+                  {' '}
+                  {failureLimitCopy}
                 </p>
               </div>
               <div className="rounded-lg border border-neutral-800 bg-black px-4 py-3 text-right">
@@ -298,6 +363,9 @@ function NewContractPageContent() {
               <div className="rounded-lg border border-neutral-800 bg-black p-3">
                 <p className="text-xs font-bold uppercase tracking-widest text-neutral-500">Platform fee</p>
                 <p className="mt-1 text-lg font-black text-white">{formatMoney(platformFeeUsd)}</p>
+                <p className="mt-1 text-xs text-neutral-600">
+                  {usesMvpPlan ? 'MVP plan fee' : 'Only applies to the $30 MVP plan'}
+                </p>
               </div>
               <label className="rounded-lg border border-neutral-800 bg-black p-3">
                 <span className="text-xs font-bold uppercase tracking-widest text-neutral-500">Amount</span>

--- a/src/web/contexts/AuthContext.tsx
+++ b/src/web/contexts/AuthContext.tsx
@@ -11,6 +11,8 @@ interface User {
   role: string;
   status?: string;
   created_at?: string;
+  failed_contracts?: number;
+  failedContracts?: number;
   compliance?: {
     kyc_status: string;
     age_verification_status: string;


### PR DESCRIPTION
## Summary
- replace the raw stake amount field with a bounded slider plus numeric amount control
- derive the maximum stake from integrity tier limits plus the Aegis safety ceiling
- show loss-framed stake copy, refundable stake, $9 platform fee, $39 entry total, and KYC status
- allow tracked/deferred triage work to enter BUILD_STARTED when implementation actually starts

## Validation
- `cd src/web && npx jest app/contracts/new/page.test.tsx --runInBand`
- `cd src/web && npm run lint`
- `scripts/triage/reconcile.sh audit-not-planned-closures`
- `npm run validate:claims`
- `git diff --check`
- browser smoke via system Chrome at `/contracts/new` on desktop and mobile with a test auth cookie

Closes #311