### PR TITLE
docs(triage): close resolved docs-architecture integrity cluster (#590–#595, #600)

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -16,9 +16,8 @@ Early AI-generated feasibility studies, retained as historical research inputs. 
 
 | Document | Source | Note |
 |----------|--------|------|
-| [Truth-Blockchain Feasibility](architecture--truth-blockchain.md) | Gemini (inferred) · 2026-02-22 | Superseded by v2 (near-identical content) |
-| [Truth-Blockchain Feasibility v2](architecture--truth-blockchain-v2.md) | Gemini (inferred) · 2026-03-04 | Fuller rendering of the above |
-| [Feasibility Stack (Pillar 5)](architecture--feasibility-stack.md) | Perplexity Pro · 2026-02-22 | Same question, third take |
+| [Truth-Blockchain Feasibility v2](architecture--truth-blockchain-v2.md) | Gemini (inferred) · 2026-03-04 | Surviving, fuller of two near-identical drafts; the v1 draft was deduped away as content-equivalent |
+| [Feasibility Stack (Pillar 5)](architecture--feasibility-stack.md) | Perplexity Pro · 2026-02-22 | Same question, a second LLM's take |
 
 **Relocated / superseded** ([#594](https://github.com/a-organvm/peer-audited--behavioral-blockchain/issues/594)): module specs moved to [`docs/specs/`](../specs/); the [Alpha-to-Omega Plan (v3.0 draft)](architecture--alpha-to-omega-plan.md) is superseded by the canonical [Definitive Alpha→Omega Roadmap](../planning/planning--roadmap--alpha-to-omega--definitive--2026-03-04.md).
 

--- a/docs/architecture/architecture--truth-blockchain-v2.md
+++ b/docs/architecture/architecture--truth-blockchain-v2.md
@@ -9,8 +9,10 @@ current_role: archived research input — not as-built architecture
 ---
 
 > **⚠️ Archived AI research input.** This is an AI-generated feasibility study,
-> **not the as-built design**. It is the fuller of two near-identical renderings
-> (see [`architecture--truth-blockchain.md`](architecture--truth-blockchain.md)).
+> **not the as-built design**. It is the surviving, fuller rendering of two
+> near-identical drafts; the v1 draft (`architecture--truth-blockchain.md`) was
+> deduped away as content-equivalent — see
+> [#591](https://github.com/a-organvm/peer-audited--behavioral-blockchain/issues/591).
 > For the as-built architecture see the [ADRs](../adr/) and
 > [`architecture--technical-feasibility.md`](architecture--technical-feasibility.md).
 

--- a/docs/triage.json
+++ b/docs/triage.json
@@ -355,6 +355,23 @@
       "completed": "2026-06-12T14:03:10Z",
       "reconciled": true,
       "test_passed": true
+    },
+    {
+      "id": "docs-architecture-integrity-verify",
+      "phase": "documentation-integrity",
+      "issues": [
+        590,
+        591,
+        592,
+        593,
+        594,
+        595,
+        600
+      ],
+      "started": "2026-06-15T10:02:54Z",
+      "completed": "2026-06-15T10:03:41Z",
+      "reconciled": true,
+      "test_passed": true
     }
   ],
   "issues": {
@@ -13243,8 +13260,8 @@
       "title": "docs/architecture: test-strategy.md has filesystem drift (workspace paths, gate names, smoke scripts)",
       "labels": [],
       "action": "BUILD",
-      "state": "TRACKING",
-      "batch": "audit-closed-without-ledger",
+      "state": "CLOSED",
+      "batch": "docs-architecture-integrity-verify",
       "history": [
         {
           "from": "UNREAD",
@@ -13255,55 +13272,90 @@
           "from": "INSPECTED",
           "to": "TRACKING",
           "at": "2026-06-12T12:43:17Z"
+        },
+        {
+          "from": "TRACKING",
+          "to": "BUILD_STARTED",
+          "at": "2026-06-15T10:03:11Z"
+        },
+        {
+          "from": "BUILD_STARTED",
+          "to": "CLOSED",
+          "at": "2026-06-15T10:03:11Z"
         }
       ],
-      "evidence": null,
+      "evidence": "docs/architecture/test-strategy.md:89",
       "pr": null,
-      "state_updated": "2026-06-12T12:43:17Z",
+      "state_updated": "2026-06-15T10:03:11Z",
       "closed_at": null
     },
     "591": {
       "action": "FUTURE",
-      "batch": null,
+      "batch": "docs-architecture-integrity-verify",
       "closed_at": null,
-      "evidence": null,
+      "evidence": "docs/architecture/README.md:19",
       "history": [
         {
           "from": "UNREAD",
           "to": "FUTURE",
           "at": "2026-06-01T15:50:49Z"
+        },
+        {
+          "from": "FUTURE",
+          "to": "BUILD_STARTED",
+          "at": "2026-06-15T10:03:12Z"
+        },
+        {
+          "from": "BUILD_STARTED",
+          "to": "BUILD_DONE",
+          "at": "2026-06-15T10:03:12Z"
+        },
+        {
+          "from": "BUILD_DONE",
+          "to": "CLOSED",
+          "at": "2026-06-15T10:03:12Z"
         }
       ],
       "labels": [],
       "pr": null,
-      "state": "FUTURE",
-      "state_updated": "2026-06-01T15:50:49Z",
+      "state": "CLOSED",
+      "state_updated": "2026-06-15T10:03:12Z",
       "title": "docs/architecture: triplicate research docs (truth-blockchain v1/v2 + feasibility-stack) need dedup + provenance frontmatter"
     },
     "592": {
       "action": "TRACK",
-      "batch": null,
+      "batch": "docs-architecture-integrity-verify",
       "closed_at": null,
-      "evidence": null,
+      "evidence": "docs/specs/spec--fury-router.md:10",
       "history": [
         {
           "from": "UNREAD",
           "to": "TRACK",
           "at": "2026-06-01T15:50:49Z"
+        },
+        {
+          "from": "TRACK",
+          "to": "BUILD_STARTED",
+          "at": "2026-06-15T10:03:12Z"
+        },
+        {
+          "from": "BUILD_STARTED",
+          "to": "CLOSED",
+          "at": "2026-06-15T10:03:12Z"
         }
       ],
       "labels": [],
       "pr": null,
-      "state": "TRACK",
-      "state_updated": "2026-06-01T15:50:49Z",
+      "state": "CLOSED",
+      "state_updated": "2026-06-15T10:03:12Z",
       "title": "docs/architecture: Fury consensus parameter contradicted three ways across corpus"
     },
     "593": {
       "title": "docs/architecture: LLM-generated research docs lack authorship/provenance frontmatter",
       "labels": [],
       "action": "BUILD",
-      "state": "TRACKING",
-      "batch": "audit-closed-without-ledger",
+      "state": "CLOSED",
+      "batch": "docs-architecture-integrity-verify",
       "history": [
         {
           "from": "UNREAD",
@@ -13314,19 +13366,29 @@
           "from": "INSPECTED",
           "to": "TRACKING",
           "at": "2026-06-12T12:43:17Z"
+        },
+        {
+          "from": "TRACKING",
+          "to": "BUILD_STARTED",
+          "at": "2026-06-15T10:03:12Z"
+        },
+        {
+          "from": "BUILD_STARTED",
+          "to": "CLOSED",
+          "at": "2026-06-15T10:03:12Z"
         }
       ],
-      "evidence": null,
+      "evidence": "docs/architecture/architecture--feasibility-stack.md:2",
       "pr": null,
-      "state_updated": "2026-06-12T12:43:17Z",
+      "state_updated": "2026-06-15T10:03:12Z",
       "closed_at": null
     },
     "594": {
       "title": "docs/architecture: misclassified files (1 roadmap, 2 forward-specs) belong in planning/ and specs/",
       "labels": [],
       "action": "BUILD",
-      "state": "TRACKING",
-      "batch": "audit-closed-without-ledger",
+      "state": "CLOSED",
+      "batch": "docs-architecture-integrity-verify",
       "history": [
         {
           "from": "UNREAD",
@@ -13337,19 +13399,29 @@
           "from": "INSPECTED",
           "to": "TRACKING",
           "at": "2026-06-12T12:43:17Z"
+        },
+        {
+          "from": "TRACKING",
+          "to": "BUILD_STARTED",
+          "at": "2026-06-15T10:03:12Z"
+        },
+        {
+          "from": "BUILD_STARTED",
+          "to": "CLOSED",
+          "at": "2026-06-15T10:03:12Z"
         }
       ],
-      "evidence": null,
+      "evidence": "docs/architecture/README.md:23",
       "pr": null,
-      "state_updated": "2026-06-12T12:43:17Z",
+      "state_updated": "2026-06-15T10:03:12Z",
       "closed_at": null
     },
     "595": {
       "title": "docs/architecture and docs/adr are orphaned from each other (no cross-references)",
       "labels": [],
       "action": "BUILD",
-      "state": "TRACKING",
-      "batch": "audit-closed-without-ledger",
+      "state": "CLOSED",
+      "batch": "docs-architecture-integrity-verify",
       "history": [
         {
           "from": "UNREAD",
@@ -13360,11 +13432,21 @@
           "from": "INSPECTED",
           "to": "TRACKING",
           "at": "2026-06-12T12:43:17Z"
+        },
+        {
+          "from": "TRACKING",
+          "to": "BUILD_STARTED",
+          "at": "2026-06-15T10:03:12Z"
+        },
+        {
+          "from": "BUILD_STARTED",
+          "to": "CLOSED",
+          "at": "2026-06-15T10:03:12Z"
         }
       ],
-      "evidence": null,
+      "evidence": "docs/adr/README.md:3",
       "pr": null,
-      "state_updated": "2026-06-12T12:43:17Z",
+      "state_updated": "2026-06-15T10:03:12Z",
       "closed_at": null
     },
     "596": {
@@ -13451,8 +13533,8 @@
       "title": "README badge URL doesn't match git remote namespace",
       "labels": [],
       "action": "BUILD",
-      "state": "TRACKING",
-      "batch": "audit-closed-without-ledger",
+      "state": "CLOSED",
+      "batch": "docs-architecture-integrity-verify",
       "history": [
         {
           "from": "UNREAD",
@@ -13463,11 +13545,21 @@
           "from": "INSPECTED",
           "to": "TRACKING",
           "at": "2026-06-12T12:43:17Z"
+        },
+        {
+          "from": "TRACKING",
+          "to": "BUILD_STARTED",
+          "at": "2026-06-15T10:03:12Z"
+        },
+        {
+          "from": "BUILD_STARTED",
+          "to": "CLOSED",
+          "at": "2026-06-15T10:03:12Z"
         }
       ],
-      "evidence": null,
+      "evidence": "README.md:5",
       "pr": null,
-      "state_updated": "2026-06-12T12:43:17Z",
+      "state_updated": "2026-06-15T10:03:12Z",
       "closed_at": null
     },
     "601": {

--- a/docs/triage/pattern-log.md
+++ b/docs/triage/pattern-log.md
@@ -295,3 +295,56 @@ source.
 **Lesson:** Emergency acquisition assets should be usable before they sell. The
 first viewport must own the live urge moment, while the CTA remains singular and
 source-tagged.
+
+## batch-docs-architecture-integrity-verify — 2026-06-15 — Close resolved docs-integrity cluster + fix dangling v1 links
+
+**Issues:** #590, #591, #592, #593, #594, #595, #600.
+
+**Status:** all seven resolved and closed with on-disk evidence. Six were already
+fixed on `main` by prior architecture-corpus work but had never been closed with
+a ledger record — the exact "resolved but unproven-closed" gap the audit batch
+warned about. One (#591) carried residual drift that this batch fixed.
+
+**Verification (evidence on `main` unless noted):**
+- #590 (test-strategy path/gate drift, HIGH): `docs/architecture/test-strategy.md`
+  already uses `src/api`/`scripts/validation/`/`scripts/smoke/` and lists the 9
+  real gate files — the `apps/api` / `scripts/gates/` drift is gone.
+- #592 (Fury consensus contradicted three ways, P1): reconciled to ADR-004 across
+  the corpus. `test-strategy.md:199` states "3 auditors, 2-of-3 or 3-of-3 … no
+  $1000 threshold"; `docs/specs/spec--fury-router.md:10` carries an as-built
+  banner and FR-5 (`:73`) is corrected. No "3-of-5" or "$1000 threshold" remains.
+- #593 (provenance frontmatter, P2): both surviving research docs
+  (`feasibility-stack.md`, `truth-blockchain-v2.md`) carry
+  `provenance/authoritative/generated_by/generated_on` frontmatter + in-file banner.
+- #594 (misclassified files, P2): module specs relocated to `docs/specs/`; the
+  alpha-to-omega plan is documented as superseded by the canonical roadmap in
+  `docs/architecture/README.md:23` (kept in place, marked superseded — not moved,
+  to avoid duplicating the canonical planning copy).
+- #595 (architecture↔adr orphaned, P1): `docs/architecture/README.md` and
+  `docs/adr/README.md` now cross-reference each other and `docs/specs/`.
+- #600 (README badge namespace): `README.md:5` uses the `a-organvm/...` namespace,
+  matching the git remote.
+- #591 (triplicate dedup + provenance, fixed this batch): v1
+  `architecture--truth-blockchain.md` was correctly deduped away earlier, but two
+  **live hyperlinks** to it remained — in the architecture README table and the v2
+  in-file banner. Both updated to explanatory prose; the README table dropped the
+  dead v1 row. Snapshot bibliographies (`docs/MANIFEST.md`, `docs/FEATURE-BACKLOG.md`)
+  and archived plans were intentionally left untouched: they are dated point-in-time
+  records, not live navigation.
+
+**Local verification:** `bash -n scripts/triage/state-transition.sh` (syntax OK);
+no live markdown hyperlinks to the deleted v1 file remain in `docs/architecture`,
+`docs/specs`, `docs/adr`; every local link in `docs/architecture/README.md`
+resolves to an existing file; `node scripts/validation/07-claim-drift-check.js`
+passed (59 inline code references scanned).
+
+**Tooling fix:** `state-transition.sh` now recognizes the legacy `TRACK` state
+(pre-dates the current state machine) as a valid FROM state mirroring `TRACKING`
+(`TRACK→BUILD_STARTED|WAITING|SUPERSEDED|TRACKING`). This unblocks the ~69 issues
+still parked in the legacy `TRACK` state so future batches can transition them
+without hand-editing `triage.json`.
+
+**Lesson:** "Already fixed on disk" is not "closed." Resolved work left open is
+indistinguishable from unproven work until a ledger entry with file:line evidence
+records the verification. Verify-and-close is real triage, not a no-op — and when
+a dedup deletes a file, every live link to it is residual drift that must be swept.

--- a/scripts/triage/state-transition.sh
+++ b/scripts/triage/state-transition.sh
@@ -49,6 +49,11 @@ valid_transition() {
   "INSPECTED→BUG") return 0 ;;
   "TRACKING→BUILD_STARTED") return 0 ;;
   "TRACKING→WAITING") return 0 ;;
+  # Legacy "TRACK" state (pre-dates the current state machine; mirrors TRACKING)
+  "TRACK→BUILD_STARTED") return 0 ;;
+  "TRACK→WAITING") return 0 ;;
+  "TRACK→SUPERSEDED") return 0 ;;
+  "TRACK→TRACKING") return 0 ;;
   "FUTURE→BUILD_STARTED") return 0 ;;
   "WAITING→BUILD_STARTED") return 0 ;;
   "WAITING→SUPERSEDED") return 0 ;;


### PR DESCRIPTION
## Summary

Works through the **documentation-integrity cluster** of open issues using the repo's MANDATORY Issue Processing Protocol (`AGENTS.md`). All seven issues are now resolved with on-disk evidence recorded in `docs/triage.json`.

Six of the seven were **already fixed on `main`** by prior architecture-corpus work but had never been closed with a ledger record — the exact "resolved but unproven-closed" gap the recent audit batches warned about. One (#591) carried residual drift that this PR fixes.

## Changes

**Real fix — #591 (triplicate dedup + provenance):** the v1 research doc `architecture--truth-blockchain.md` was correctly deduped away earlier, but two **live hyperlinks** to it remained. Both swept:
- `docs/architecture/README.md` — dropped the dead v1 table row, reworded the v2/feasibility notes.
- `docs/architecture/architecture--truth-blockchain-v2.md` — banner link → explanatory prose.

**Verify-and-close (evidence already on `main`):**
| Issue | Severity | Evidence |
|---|---|---|
| #590 | HIGH | `test-strategy.md` uses `src/api`/`scripts/validation/`/`scripts/smoke/`, lists the 9 real gate files |
| #592 | P1 | Fury consensus reconciled to ADR-004 (`test-strategy.md:199`, `spec--fury-router.md:10` banner + FR-5) |
| #593 | P2 | provenance frontmatter + banner on both surviving research docs |
| #594 | P2 | module specs relocated to `docs/specs/`; alpha-omega plan marked superseded in README |
| #595 | P1 | `architecture/README.md` ↔ `adr/README.md` cross-references present |
| #600 | — | `README.md:5` badge uses the `a-organvm/...` namespace (matches git remote) |

**Tooling fix:** `state-transition.sh` now recognizes the legacy `TRACK` state as a valid FROM (mirrors `TRACKING`), unblocking the ~69 issues still parked in `TRACK` so future batches can transition them without hand-editing `triage.json`.

## Verification
- `node scripts/validation/07-claim-drift-check.js` — passed (59 inline code refs scanned)
- No live markdown hyperlinks to the deleted v1 file remain in `docs/architecture|specs|adr`
- Every local link in `docs/architecture/README.md` resolves
- `bash -n scripts/triage/state-transition.sh` — syntax OK
- `reconcile.sh docs-architecture-integrity-verify` — **0 errors**; `report.sh` dashboard clean (0 CLOSED-without-evidence)

## Out of scope (left open intentionally)
- Snapshot bibliographies (`docs/MANIFEST.md`, `docs/FEATURE-BACKLOG.md`) and archived plans still mention v1 — these are dated point-in-time records, not live navigation, so they're correctly untouched.
- Remaining open issues are genuine forward work (native mobile, legal counsel sign-off, KYC vendors, B2B partnerships) blocked on external dependencies, or larger build tickets (e.g. #599 brand propagation, #663 integration-test suite) outside this docs-integrity batch.

https://claude.ai/code/session_012gpzMk2BNT5Q2Q6wPkQeUh

---
_Generated by [Claude Code](https://claude.ai/code/session_012gpzMk2BNT5Q2Q6wPkQeUh)_