### PR TITLE
fix(ci): unblock and activate coverage-threshold gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,13 @@ jobs:
       - name: Execute Tests + Lint (Turborepo)
         # NOTE: do not forward `--coverage --ci` here. Those are jest-only flags:
         # `--ci` makes the vitest workspaces (ask-styx, test-harness) throw
-        # `CACError: Unknown option --ci`, and `--coverage` currently fails api
-        # suite-loading. Each workspace owns its own test invocation. Re-introducing
-        # coverage-threshold gating is tracked as a follow-up once coverage mode is
-        # fixed (see docs/audit/2026-05-26-index-propagation-and-vacuum-log.md).
+        # `CACError: Unknown option --ci`. Each workspace owns its own test
+        # invocation instead. Coverage-threshold gating is now ACTIVE: the jest
+        # workspaces (api, web, mobile, desktop) run `jest --coverage` in their
+        # own `test` script and enforce `coverageThreshold` from their jest
+        # config. Coverage mode was unblocked by switching those workspaces to
+        # the V8 `coverageProvider` (the default "babel" provider crashed on the
+        # repo-wide minimatch>=10 override via babel-plugin-istanbul/test-exclude).
         #
         # `test` dependsOn `^build` (upstream builds only, no per-workspace build).
         # `lint` is independent so turbo parallelizes both.

--- a/src/api/jest.config.cjs
+++ b/src/api/jest.config.cjs
@@ -10,6 +10,12 @@ module.exports = {
     ...tsJestTransformCfg,
   },
   testPathIgnorePatterns: ["/node_modules/", "/dist/"],
+  // Use the V8 coverage provider rather than the default "babel" provider.
+  // The babel provider instruments via babel-plugin-istanbul → test-exclude,
+  // whose minimatch@3 callable API is broken by the repo-wide minimatch>=10
+  // override (test-exclude calls minimatch() but v10 exports an object).
+  // V8 coverage reads native coverage and sidesteps that chain entirely.
+  coverageProvider: "v8",
   coverageThreshold: {
     global: {
       lines: 70,

--- a/src/api/package.json
+++ b/src/api/package.json
@@ -7,7 +7,7 @@
     "dev": "node ../../scripts/dev/run-api.mjs",
     "build": "nest build",
     "lint": "tsc --noEmit",
-    "test": "jest --forceExit",
+    "test": "jest --coverage --forceExit",
     "migrate": "node ../../scripts/dev/run-migrate.mjs"
   },
   "dependencies": {

--- a/src/desktop/jest.config.js
+++ b/src/desktop/jest.config.js
@@ -9,6 +9,10 @@ module.exports = {
     ...tsJestTransformCfg,
   },
   testPathIgnorePatterns: ["/node_modules/", "/dist/"],
+  // V8 coverage provider: the default "babel" provider instruments via
+  // babel-plugin-istanbul → test-exclude, whose minimatch@3 callable API is
+  // broken by the repo-wide minimatch>=10 override. V8 sidesteps that chain.
+  coverageProvider: "v8",
   coverageThreshold: {
     global: {
       lines: 50,

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -8,7 +8,7 @@
     "lint": "tsc --noEmit",
     "preview": "vite preview",
     "tauri": "tauri",
-    "test": "jest"
+    "test": "jest --coverage"
   },
   "dependencies": {
     "lucide-react": "^1.17.0",

--- a/src/mobile/jest.config.js
+++ b/src/mobile/jest.config.js
@@ -19,6 +19,10 @@ module.exports = {
       "<rootDir>/__mocks__/async-storage.ts",
     "^react-native$": "<rootDir>/__mocks__/react-native.ts",
   },
+  // V8 coverage provider: the default "babel" provider instruments via
+  // babel-plugin-istanbul → test-exclude, whose minimatch@3 callable API is
+  // broken by the repo-wide minimatch>=10 override. V8 sidesteps that chain.
+  coverageProvider: "v8",
   coverageThreshold: {
     global: {
       lines: 50,

--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -7,7 +7,7 @@
     "start": "react-native start",
     "build": "tsc --noEmit",
     "lint": "tsc --noEmit",
-    "test": "jest"
+    "test": "jest --coverage"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "3.1.1",

--- a/src/test-harness/package.json
+++ b/src/test-harness/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "vitest",
+    "test": "vitest run",
     "lint": "tsc --noEmit",
     "audit": "tsx src/index.ts"
   },

--- a/src/web/jest.config.js
+++ b/src/web/jest.config.js
@@ -15,6 +15,10 @@ module.exports = {
   testPathIgnorePatterns: ["/node_modules/", "/.next/"],
   modulePathIgnorePatterns: ["<rootDir>/.next/"],
   watchPathIgnorePatterns: ["<rootDir>/.next/"],
+  // V8 coverage provider: the default "babel" provider instruments via
+  // babel-plugin-istanbul → test-exclude, whose minimatch@3 callable API is
+  // broken by the repo-wide minimatch>=10 override. V8 sidesteps that chain.
+  coverageProvider: "v8",
   coverageThreshold: {
     global: {
       lines: 40,

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "lint": "tsc --noEmit",
     "start": "next start",
-    "test": "jest"
+    "test": "jest --coverage"
   },
   "dependencies": {
     "lucide-react": "^1.17.0",


### PR DESCRIPTION
## Summary

Addresses the longest-standing tracked technical debt in this repo: **coverage-threshold gating was configured but could not run.** The CI workflow comment recorded it as a follow-up "once coverage mode is fixed." This PR fixes coverage mode and turns the gating on.

## Root cause

Jest's default `coverageProvider` is `"babel"`, which instruments source via `babel-plugin-istanbul` → `test-exclude@6`. `test-exclude@6` calls `minimatch(...)` as a **callable default export** (the v3 API). The repo-wide override `"minimatch": ">=10.2.1"` forces minimatch v10 everywhere, and v10's CommonJS entry exports an **object** (`{ minimatch, Minimatch, ... }`), not a callable. So running any jest workspace with `--coverage` crashed every suite at load time:

```
TypeError: minimatch is not a function
  → 107 of 109 api suites "failed to run"
```

That is why `--coverage` was stripped from CI and the thresholds never enforced.

## Fix

Switch the four jest workspaces (`api`, `web`, `mobile`, `desktop`) to `coverageProvider: "v8"`. V8 coverage reads native V8 data and bypasses the `babel-plugin-istanbul`/`test-exclude` chain entirely — **no dependency, override, or lockfile changes required.** Each workspace already had a `coverageThreshold` configured but it never ran; the `test` scripts now run `jest --coverage`, so the thresholds gate in CI.

Considered and rejected: scoping the `minimatch` override (`test-exclude → minimatch@3.1.2`). It works only on a clean full reinstall and npm's nested-override merge behavior proved inconsistent across npm versions; a clean lockfile regen also perturbed an unrelated `bullmq`/`ioredis` subtree. The `coverageProvider` switch is a one-line, dependency-free fix.

## Verification

All workspaces green via `turbo run test lint` (22/22 tasks), every configured threshold cleared:

| workspace | stmts | branch | func | lines | threshold (lines/branch/func/stmts) |
|-----------|-------|--------|------|-------|-------------------------------------|
| api       | 83.0  | 74.9   | 80.6 | 83.0  | 70 / 60 / 60 / 70 |
| web       | 66.7  | 61.0   | 38.3 | 66.7  | 40 / 30 / 30 / 40 |
| mobile    | 80.7  | 68.9   | 63.5 | 80.7  | 50 / 40 / 40 / 50 |
| desktop   | 87.1  | 75.5   | 70.2 | 87.1  | 50 / 40 / 40 / 50 |

(api: 1198 tests / 106 suites pass under coverage.)

## Also included

- `src/test-harness`: `"test": "vitest"` → `"vitest run"`, matching every other vitest workspace and removing a latent watch-mode hang.
- `ci.yml`: refreshed the stale comment that described coverage gating as a pending follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsH9sQ4JKk1z8ghVwDssHY)_