### PR TITLE
fix(payments): fail closed on mock client secret outside dev/test (#32)

### DIFF
--- a/src/api/src/modules/payments/payment-router.service.spec.ts
+++ b/src/api/src/modules/payments/payment-router.service.spec.ts
@@ -61,27 +61,49 @@ describe('PaymentRouterService', () => {
       userId: 'user-2',
     };
 
-    it('should create a Stripe payment intent with mock client secret in dev', async () => {
+    const originalEnv = process.env.NODE_ENV;
+    afterEach(() => {
+      process.env.NODE_ENV = originalEnv;
+    });
+
+    it('should create a Stripe payment intent with mock client secret in development', async () => {
+      process.env.NODE_ENV = 'development';
       const result = await service.createPaymentIntent(baseOptions, 'STRIPE');
       expect(result.processor).toBe('STRIPE');
       expect(result.clientSecret).toMatch(/^pi_stripe_mock_/);
     });
 
-    it('should create a Corepay payment intent with mock token in dev', async () => {
+    it('should create a Corepay payment intent with mock token in development', async () => {
+      process.env.NODE_ENV = 'development';
       const result = await service.createPaymentIntent(baseOptions, 'HIGH_RISK_COREPAY');
       expect(result.processor).toBe('HIGH_RISK_COREPAY');
       expect(result.clientSecret).toMatch(/^tok_corepay_mock_/);
     });
 
+    it('should create a mock client secret in the test environment', async () => {
+      process.env.NODE_ENV = 'test';
+      const result = await service.createPaymentIntent(baseOptions, 'STRIPE');
+      expect(result.clientSecret).toMatch(/^pi_stripe_mock_/);
+    });
+
     it('should throw ServiceUnavailableException in production', async () => {
-      const originalEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = 'production';
-      try {
-        await expect(service.createPaymentIntent(baseOptions, 'STRIPE'))
-          .rejects.toThrow('Payment processor not configured');
-      } finally {
-        process.env.NODE_ENV = originalEnv;
-      }
+      await expect(service.createPaymentIntent(baseOptions, 'STRIPE'))
+        .rejects.toThrow('Payment processor not configured');
+    });
+
+    it('should throw ServiceUnavailableException in staging (never return a fabricated secret)', async () => {
+      process.env.NODE_ENV = 'staging';
+      const promise = service.createPaymentIntent(baseOptions, 'STRIPE');
+      await expect(promise).rejects.toThrow('Payment processor not configured');
+      // Defensive: the fabricated `pi_stripe_mock_*` secret must never reach a caller.
+      await expect(promise).rejects.not.toMatchObject({ clientSecret: expect.anything() });
+    });
+
+    it('should fail closed when NODE_ENV is unset/misconfigured', async () => {
+      delete process.env.NODE_ENV;
+      await expect(service.createPaymentIntent(baseOptions, 'STRIPE'))
+        .rejects.toThrow('Payment processor not configured');
     });
   });
 });

--- a/src/api/src/modules/payments/payment-router.service.ts
+++ b/src/api/src/modules/payments/payment-router.service.ts
@@ -48,17 +48,29 @@ export class PaymentRouterService {
 
   /**
    * Creates a payment intent via the selected processor.
-   * In dev/test, returns mock client secrets. In production, throws until
-   * a real processor integration is configured.
+   *
+   * The mock client-secret fallback is ALLOWLISTED to `development`/`test`
+   * only. Any other environment — `staging`, `production`, or an
+   * unset/misconfigured NODE_ENV — fails closed with a 503 rather than
+   * silently handing the frontend a fabricated `pi_stripe_mock_*` secret
+   * that Stripe.js can never redeem (see issue #32). This must be a
+   * fail-closed allowlist, not a `=== "production"` blocklist, so that a
+   * staging or misconfigured deployment cannot leak a fake secret.
    */
   async createPaymentIntent(
     options: PaymentIntentOptions,
     processor: PaymentProcessor,
   ): Promise<{ clientSecret: string; processor: PaymentProcessor }> {
-    const isProduction = process.env.NODE_ENV === "production";
-    if (isProduction) {
+    const nodeEnv = process.env.NODE_ENV;
+    const mockFallbackAllowed = nodeEnv === "development" || nodeEnv === "test";
+    if (!mockFallbackAllowed) {
       throw new ServiceUnavailableException("Payment processor not configured");
     }
+
+    this.logger.warn(
+      `Using MOCK payment processor (${processor}) for user ${options.userId} in "${nodeEnv}" environment; ` +
+        "no real charge will be created. This path is only valid for local development/testing.",
+    );
 
     if (processor === "STRIPE") {
       // Defer to existing StripeFboService in a real implementation


### PR DESCRIPTION
Closes #32

## Defect

`PaymentRouterService.createPaymentIntent` gated the mock client-secret fallback with a **blocklist**:

```ts
const isProduction = process.env.NODE_ENV === "production";
if (isProduction) { throw new ServiceUnavailableException(...); }
```

This only locks down `production`. In `staging` — and in any deployment with an unset or misconfigured `NODE_ENV` — the check is false, so the service still returns a fabricated `pi_stripe_mock_*` (or `tok_corepay_mock_*`) secret. Stripe.js can never redeem that secret, causing silent frontend failures and masking configuration errors in non-local environments. This is exactly the "staging or misconfigured production" leak described in the issue.

## Fix

Replace the production-only blocklist with a **fail-closed allowlist**. The mock fallback is permitted only when `NODE_ENV` is `development` or `test`; every other value (`staging`, `production`, unset) throws `ServiceUnavailableException("Payment processor not configured")`. A warning is now logged whenever the mock path is taken, per the issue's expected behavior.

Files changed:
- `src/api/src/modules/payments/payment-router.service.ts` — allowlist gate + mock-mode warning log
- `src/api/src/modules/payments/payment-router.service.spec.ts` — new coverage

Tests added/updated prove: dev and test still return mock secrets (unchanged); staging, production, and unset `NODE_ENV` all reject without ever leaking a secret.

## Verification

Run from `src/api`:

```
$ npx tsc --noEmit
TSC_EXIT=0   (clean)

$ npx jest src/modules/payments/payment-router.service.spec.ts --runInBand
Test Suites: 1 passed, 1 total
Tests:       13 passed, 13 total

$ npx jest src/modules/payments --runInBand
Test Suites: 8 passed, 8 total
Tests:       81 passed, 81 total
```

## Scope note / residual

The issue also lists the `sk_test_mock_key` SDK-init fallback in `payments.controller.ts`, `escrow/stripe.service.ts`, and `identity-provider.service.ts` as related. Those initialize a Stripe client with a placeholder API key; they do not return a fabricated `pi_*` client secret to the frontend, which is the titled defect and the focus of the Expected Behavior section. To keep this change tight and avoid touching unrelated modules, they are left out of scope; the fabricated-client-secret leak (the actual security defect) is fully closed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018CzqfcfCbBFdHZpRE8ZbZF)_