### PR TITLE
test(contracts): prove bounty link references real contract id (#34)

### DIFF
--- a/src/api/src/modules/contracts/contracts.service.behavioral.spec.ts
+++ b/src/api/src/modules/contracts/contracts.service.behavioral.spec.ts
@@ -317,6 +317,45 @@ describe("ContractsService — Behavioral Physics", () => {
       expect(parsed.recovery.acknowledgments.voluntary).toBe(true);
     });
 
+    // Regression: issue #34 — the whistleblower bounty link must be persisted
+    // against the REAL persisted contract id, not a temporary/placeholder value.
+    // The contract is inserted first (PENDING_STAKE) so its id exists before the
+    // bounty row references it.
+    it("should link the bounty to the real persisted contract id (issue #34)", async () => {
+      mockSuccessfulRecoveryFlow();
+
+      await service.createContract(recoveryDto);
+
+      const contractInsert = mockPool.query.mock.calls.find(
+        ([sql]: [string]) =>
+          typeof sql === "string" && sql.includes("INSERT INTO contracts"),
+      );
+      expect(contractInsert).toBeDefined();
+      // bounty_link_id is the 9th parameter ($9) on the contract insert
+      const persistedBountyLinkId = contractInsert![1][8];
+      expect(typeof persistedBountyLinkId).toBe("string");
+      expect((persistedBountyLinkId as string).length).toBeGreaterThan(0);
+
+      const bountyInsert = mockPool.query.mock.calls.find(
+        ([sql]: [string]) =>
+          typeof sql === "string" && sql.includes("INSERT INTO bounties"),
+      );
+      expect(bountyInsert).toBeDefined();
+
+      // The bounty must reference the actual contract id returned by the insert
+      // ("contract-r1" from mockSuccessfulRecoveryFlow) — not a placeholder such
+      // as 'pending' or a null/temporary id.
+      const [bountyContractId, bountyLinkId] = bountyInsert![1] as [
+        string,
+        string,
+      ];
+      expect(bountyContractId).toBe("contract-r1");
+      expect(bountyContractId).not.toBe("pending");
+      // The bounty link id stored on the bounty row matches the one persisted on
+      // the contract, keeping the Fury bounty economy in sync with its contract.
+      expect(bountyLinkId).toBe(persistedBountyLinkId);
+    });
+
     it("should not call RecoveryProtocolService for non-RECOVERY oaths", async () => {
       // Standard flow for COGNITIVE oath
       mockPool.query.mockResolvedValueOnce({ rows: [activeUser] });


### PR DESCRIPTION
Closes #34

## Defect
Issue #34 reported that `contracts.service.ts` set the whistleblower bounty link status from a temporary/hardcoded value (`'pending', // temporary — will update with contract ID`) instead of associating the bounty with the real, persisted contract id, so the Fury bounty economy could not reliably reference the originating contract.

## Current state of the code
The service logic was already corrected (commit `02f442a`, referenced in the issue thread) and is present on `main`. Both contract-creation paths now:
1. Insert the contract first with status `PENDING_STAKE`, capturing the real `contractId` from `RETURNING id`.
2. Call `holdStake` with that real `contractId`.
3. Insert the bounty row via `INSERT INTO bounties (contract_id, bounty_link_id) VALUES ($1, $2)` using the actual `contractId`.

No `temporary`/placeholder string or TODO remains in `contracts.service.ts` (verified by grep). The `bounties` table (migration `002_whistleblower_bounty.sql`) declares `contract_id UUID REFERENCES contracts(id)` with `status DEFAULT 'ACTIVE'`.

The issue was reopened by the closure-governance audit because there was no durable implementation evidence pinning the corrected behavior.

## Fix in this PR
Adds a focused regression test under the contracts module that proves the corrected behavior, supplying the missing durable evidence:
- Asserts the `INSERT INTO bounties` call receives the actual persisted contract id (`contract-r1`), not a placeholder such as `'pending'`.
- Asserts the bounty link id stored on the bounty row matches the `bounty_link_id` persisted on the contract insert, keeping the Fury bounty economy in sync with its originating contract.

File changed:
- `src/api/src/modules/contracts/contracts.service.behavioral.spec.ts` (+39, one new test in the `recovery contracts` describe block)

## Verification (from `src/api`)
- `npx tsc --noEmit` → exit 0 (clean)
- `npx jest src/modules/contracts --runInBand` → `Tests: 1 skipped, 179 passed, 180 total` (9 suites passed, 1 skipped)
- New test isolated (`-t "issue #34"`) → `1 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018CzqfcfCbBFdHZpRE8ZbZF)_