### PR TITLE
[limen REV-styx-tier-guard] Add src/api/src/guards/tier

### DIFF
--- a/src/api/database/migrations/041_user_access_tier.sql
+++ b/src/api/database/migrations/041_user_access_tier.sql
@@ -1,0 +1,17 @@
+-- Migration 041: User access tiers for beta contract-creation caps
+
+DO $$
+BEGIN
+  CREATE TYPE access_tier AS ENUM ('free', 'early_access', 'pro');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS access_tier access_tier NOT NULL DEFAULT 'early_access';
+
+CREATE INDEX IF NOT EXISTS idx_users_access_tier ON users(access_tier);
+
+COMMENT ON COLUMN users.access_tier IS
+  'Product access tier: free cannot create contracts, early_access is capped, pro has full contract creation access.';

--- a/src/api/database/schema.sql
+++ b/src/api/database/schema.sql
@@ -2,6 +2,7 @@
 -- Enforce absolute financial integrity for user stakes and bounties.
 
 CREATE TYPE account_type AS ENUM ('ASSET', 'LIABILITY', 'EQUITY', 'REVENUE', 'EXPENSE');
+CREATE TYPE access_tier AS ENUM ('free', 'early_access', 'pro');
 
 CREATE TABLE accounts (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -58,6 +59,7 @@ CREATE TABLE users (
     integrity_score INTEGER DEFAULT 50,
     account_id UUID REFERENCES accounts(id),
     role TEXT DEFAULT 'USER',
+    access_tier access_tier NOT NULL DEFAULT 'early_access',
     enterprise_id UUID,
     status TEXT DEFAULT 'ACTIVE', last_known_state TEXT, social_guild_id UUID,
     deletion_requested_at TIMESTAMPTZ,
@@ -257,6 +259,7 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS locked_until TIMESTAMPTZ;
 CREATE INDEX idx_entries_debit_account_id ON entries(debit_account_id);
 CREATE INDEX idx_entries_credit_account_id ON entries(credit_account_id);
 CREATE INDEX idx_entries_contract_id ON entries(contract_id);
+CREATE INDEX idx_users_access_tier ON users(access_tier);
 CREATE INDEX idx_users_enterprise_id ON users(enterprise_id);
 CREATE INDEX idx_users_deletion_requested_at ON users(deletion_requested_at);
 
@@ -434,3 +437,5 @@ CREATE INDEX IF NOT EXISTS idx_fury_assignments_realm_id ON fury_assignments(rea
 
 ALTER TABLE users ADD COLUMN IF NOT EXISTS realm_preferences JSONB DEFAULT '{}';
 
+COMMENT ON COLUMN users.access_tier IS
+  'Product access tier: free cannot create contracts, early_access is capped, pro has full contract creation access.';

--- a/src/api/src/guards/tier.guard.spec.ts
+++ b/src/api/src/guards/tier.guard.spec.ts
@@ -1,0 +1,156 @@
+import { BadRequestException, ForbiddenException } from "@nestjs/common";
+import { AccessTier, TierGuard } from "./tier.guard";
+
+describe("TierGuard", () => {
+  let guard: TierGuard;
+  let mockPool: { query: jest.Mock };
+
+  beforeEach(() => {
+    mockPool = { query: jest.fn() };
+    guard = new TierGuard(mockPool as any);
+  });
+
+  function createContext(
+    user?: { id?: string } | null,
+    body?: Record<string, unknown>,
+  ) {
+    const hasUser = user !== null && user !== undefined;
+    return {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          user: hasUser ? user : undefined,
+          body,
+        }),
+      }),
+    } as any;
+  }
+
+  it("denies when no authenticated user is present", async () => {
+    await expect(guard.canActivate(createContext(null))).rejects.toThrow(
+      ForbiddenException,
+    );
+    expect(mockPool.query).not.toHaveBeenCalled();
+  });
+
+  it("denies when the authenticated user has no id", async () => {
+    await expect(guard.canActivate(createContext({}))).rejects.toThrow(
+      ForbiddenException,
+    );
+    expect(mockPool.query).not.toHaveBeenCalled();
+  });
+
+  it("denies when the user row is missing", async () => {
+    mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+    await expect(
+      guard.canActivate(createContext({ id: "ghost" }, { stakeAmount: 0 })),
+    ).rejects.toThrow(/not found/);
+  });
+
+  it("allows pro users without active-contract or escrow caps", async () => {
+    mockPool.query.mockResolvedValueOnce({
+      rows: [{ access_tier: AccessTier.PRO }],
+    });
+
+    await expect(
+      guard.canActivate(createContext({ id: "user-1" }, { stakeAmount: 500 })),
+    ).resolves.toBe(true);
+
+    expect(mockPool.query).toHaveBeenCalledTimes(1);
+    expect(mockPool.query).toHaveBeenCalledWith(
+      "SELECT access_tier FROM users WHERE id = $1",
+      ["user-1"],
+    );
+  });
+
+  it("denies free-tier users from creating contracts", async () => {
+    mockPool.query.mockResolvedValueOnce({
+      rows: [{ access_tier: AccessTier.FREE }],
+    });
+
+    await expect(
+      guard.canActivate(createContext({ id: "user-1" }, { stakeAmount: 0 })),
+    ).rejects.toThrow(/requires early access or pro/);
+  });
+
+  it("denies early-access users when requested stake is greater than $0", async () => {
+    mockPool.query.mockResolvedValueOnce({
+      rows: [{ access_tier: AccessTier.EARLY_ACCESS }],
+    });
+
+    await expect(
+      guard.canActivate(createContext({ id: "user-1" }, { stakeAmount: 1 })),
+    ).rejects.toThrow(/limited to \$0 escrow/);
+    expect(mockPool.query).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats MVP_39 pricing as a positive escrow request for early-access users", async () => {
+    mockPool.query.mockResolvedValueOnce({
+      rows: [{ access_tier: AccessTier.EARLY_ACCESS }],
+    });
+
+    await expect(
+      guard.canActivate(
+        createContext(
+          { id: "user-1" },
+          { stakeAmount: 0, pricing: { plan: "MVP_39" } },
+        ),
+      ),
+    ).rejects.toThrow(/limited to \$0 escrow/);
+  });
+
+  it("denies early-access users at the active-contract cap", async () => {
+    mockPool.query
+      .mockResolvedValueOnce({
+        rows: [{ access_tier: AccessTier.EARLY_ACCESS }],
+      })
+      .mockResolvedValueOnce({ rows: [{ count: 3 }] });
+
+    await expect(
+      guard.canActivate(createContext({ id: "user-1" }, { stakeAmount: 0 })),
+    ).rejects.toThrow(/limited to 3 active contracts/);
+
+    expect(mockPool.query).toHaveBeenNthCalledWith(
+      2,
+      `SELECT COUNT(*)::int AS count
+       FROM contracts
+       WHERE user_id = $1
+         AND status = 'ACTIVE'`,
+      ["user-1"],
+    );
+  });
+
+  it("allows early-access users below the active-contract cap with $0 escrow", async () => {
+    mockPool.query
+      .mockResolvedValueOnce({
+        rows: [{ access_tier: AccessTier.EARLY_ACCESS }],
+      })
+      .mockResolvedValueOnce({ rows: [{ count: 2 }] });
+
+    await expect(
+      guard.canActivate(createContext({ id: "user-1" }, { stakeAmount: 0 })),
+    ).resolves.toBe(true);
+  });
+
+  it("denies unrecognized access tiers", async () => {
+    mockPool.query.mockResolvedValueOnce({
+      rows: [{ access_tier: "enterprise" }],
+    });
+
+    await expect(
+      guard.canActivate(createContext({ id: "user-1" }, { stakeAmount: 0 })),
+    ).rejects.toThrow(/not recognized/);
+  });
+
+  it("surfaces malformed stake amounts before applying early-access caps", async () => {
+    mockPool.query.mockResolvedValueOnce({
+      rows: [{ access_tier: AccessTier.EARLY_ACCESS }],
+    });
+
+    await expect(
+      guard.canActivate(
+        createContext({ id: "user-1" }, { stakeAmount: "not-a-number" }),
+      ),
+    ).rejects.toThrow(BadRequestException);
+  });
+});

--- a/src/api/src/guards/tier.guard.ts
+++ b/src/api/src/guards/tier.guard.ts
@@ -1,0 +1,104 @@
+import {
+  BadRequestException,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from "@nestjs/common";
+import { Pool } from "pg";
+
+export enum AccessTier {
+  FREE = "free",
+  EARLY_ACCESS = "early_access",
+  PRO = "pro",
+}
+
+const EARLY_ACCESS_MAX_ACTIVE_CONTRACTS = 3;
+const EARLY_ACCESS_MAX_ESCROW_USD = 0;
+const MVP_39_REFUNDABLE_STAKE_USD = 30;
+
+@Injectable()
+export class TierGuard implements CanActivate {
+  constructor(private readonly pool: Pool) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const userId = request.user?.id;
+
+    if (!userId) {
+      throw new ForbiddenException("Authentication required");
+    }
+
+    const userResult = await this.pool.query(
+      "SELECT access_tier FROM users WHERE id = $1",
+      [userId],
+    );
+
+    if (userResult.rows.length === 0) {
+      throw new ForbiddenException("User account not found.");
+    }
+
+    const accessTier = this.normalizeAccessTier(
+      userResult.rows[0].access_tier,
+    );
+
+    if (accessTier === AccessTier.PRO) {
+      return true;
+    }
+
+    if (accessTier === AccessTier.FREE) {
+      throw new ForbiddenException(
+        "Contract creation requires early access or pro access.",
+      );
+    }
+
+    const requestedEscrowUsd = this.resolveRequestedEscrowUsd(request.body);
+    if (requestedEscrowUsd > EARLY_ACCESS_MAX_ESCROW_USD) {
+      throw new ForbiddenException(
+        "Early-access users are limited to $0 escrow contracts.",
+      );
+    }
+
+    const activeContracts = await this.pool.query(
+      `SELECT COUNT(*)::int AS count
+       FROM contracts
+       WHERE user_id = $1
+         AND status = 'ACTIVE'`,
+      [userId],
+    );
+    const activeCount = Number(activeContracts.rows[0]?.count ?? 0);
+
+    if (activeCount >= EARLY_ACCESS_MAX_ACTIVE_CONTRACTS) {
+      throw new ForbiddenException(
+        `Early-access users are limited to ${EARLY_ACCESS_MAX_ACTIVE_CONTRACTS} active contracts.`,
+      );
+    }
+
+    return true;
+  }
+
+  private normalizeAccessTier(value: unknown): AccessTier {
+    if (
+      value === AccessTier.FREE ||
+      value === AccessTier.EARLY_ACCESS ||
+      value === AccessTier.PRO
+    ) {
+      return value;
+    }
+
+    throw new ForbiddenException("User access tier is not recognized.");
+  }
+
+  private resolveRequestedEscrowUsd(body: any): number {
+    if (body?.pricing?.plan === "MVP_39") {
+      return MVP_39_REFUNDABLE_STAKE_USD;
+    }
+
+    const amount = Number(body?.stakeAmount ?? 0);
+    if (!Number.isFinite(amount)) {
+      throw new BadRequestException("Valid stake amount is required.");
+    }
+
+    return amount;
+  }
+}

--- a/src/api/src/modules/contracts/contracts.controller.spec.ts
+++ b/src/api/src/modules/contracts/contracts.controller.spec.ts
@@ -1,5 +1,6 @@
 import { ContractsController } from "./contracts.controller";
 import { ContractsService } from "./contracts.service";
+import { GUARDS_METADATA } from "@nestjs/common/constants";
 import { DisputeService } from "../../../services/escrow/dispute.service";
 import { StripeFboService } from "../../../services/escrow/stripe.service";
 import { LedgerService } from "../../../services/ledger/ledger.service";
@@ -10,6 +11,7 @@ import { plainToInstance } from "class-transformer";
 import { CreateContractDto, SubmitProofDto } from "./dto";
 import { SurveyService } from "./survey.service";
 import { WaitlistService } from "./waitlist.service";
+import { TierGuard } from "../../guards/tier.guard";
 
 const mockSurveyService = {} as unknown as SurveyService;
 const mockWaitlistService = {} as unknown as WaitlistService;
@@ -99,6 +101,16 @@ describe("ContractsController", () => {
         userId: "user-1",
       });
       expect(result).toEqual(mockContract);
+    });
+
+    it("should apply TierGuard to contract creation", () => {
+      const guards =
+        Reflect.getMetadata(
+          GUARDS_METADATA,
+          ContractsController.prototype.create,
+        ) ?? [];
+
+      expect(guards).toContain(TierGuard);
     });
 
     it("should propagate service errors for invalid stake", async () => {

--- a/src/api/src/modules/contracts/contracts.controller.ts
+++ b/src/api/src/modules/contracts/contracts.controller.ts
@@ -26,6 +26,7 @@ import { LedgerService } from "../../../services/ledger/ledger.service";
 import { TruthLogService } from "../../../services/ledger/truth-log.service";
 import { AuthGuard } from "../../../guards/auth.guard";
 import { BannedUserGuard } from "../../guards/banned-user.guard";
+import { TierGuard } from "../../guards/tier.guard";
 import { GeofenceGuard } from "../../common/guards/geofence.guard";
 import { ComplianceAccessGuard } from "../../common/guards/compliance-access.guard";
 import { CurrentUser } from "../../common/decorators/current-user.decorator";
@@ -57,7 +58,13 @@ export class ContractsController {
     return this.contractsService.getUserContracts(user.id);
   }
 
-  @UseGuards(AuthGuard, GeofenceGuard, ComplianceAccessGuard, BannedUserGuard)
+  @UseGuards(
+    AuthGuard,
+    GeofenceGuard,
+    ComplianceAccessGuard,
+    BannedUserGuard,
+    TierGuard,
+  )
   @Post()
   @ApiOperation({
     summary: "Create a new behavioral contract with a financial stake",

--- a/src/api/src/modules/contracts/contracts.module.ts
+++ b/src/api/src/modules/contracts/contracts.module.ts
@@ -16,6 +16,8 @@ import { HoneypotService } from "../../../services/intelligence/honeypot.service
 
 import { SurveyService } from "./survey.service";
 import { WaitlistService } from "./waitlist.service";
+import { BannedUserGuard } from "../../guards/banned-user.guard";
+import { TierGuard } from "../../guards/tier.guard";
 import {
   AnomalyService,
   ANOMALY_REDIS_CLIENT,
@@ -60,6 +62,8 @@ const redisProvider = {
     HoneypotService,
     SurveyService,
     WaitlistService,
+    BannedUserGuard,
+    TierGuard,
 
     AnomalyService,
     redisProvider,


### PR DESCRIPTION
Autonomous **limen** dispatch of task `REV-styx-tier-guard`.

Add src/api/src/guards/tier.guard.ts + an access_tier enum (free/early_access/pro) on users; @UseGuards(TierGuard) on contract-creation capping early-access to 3 active contracts/$0 escrow. New guard + migration.

_Produced in an isolated worktree off origin — review before merge._