### PR TITLE
[limen HEAL-cifix-organvm-peer-audited--behavioral-blockchain-719] fix failing CI on organvm/peer-audited--behavioral-blockchain#719

### DIFF
--- a/logs/agents/opencode.json
+++ b/logs/agents/opencode.json
@@ -2,10 +2,10 @@
   "agent": "opencode",
   "status": "idle",
   "accepting_tasks": true,
-  "available_tokens": 43796055,
-  "available_pct": 87.6,
-  "current_task_id": "HEAL-rebase-organvm-peer-audited--behavioral-blockchain-725",
-  "heartbeat": "2026-07-04T04:58:09.449880+00:00",
-  "token_usage_pct": 12.41,
+  "available_tokens": 43739085,
+  "available_pct": 87.5,
+  "current_task_id": "HEAL-cifix-organvm-peer-audited--behavioral-blockchain-719",
+  "heartbeat": "2026-07-04T05:02:36.303086+00:00",
+  "token_usage_pct": 12.52,
   "clock_health": "ok"
 }


### PR DESCRIPTION
Autonomous **limen** dispatch of task `HEAL-cifix-organvm-peer-audited--behavioral-blockchain-719`.

PR organvm/peer-audited--behavioral-blockchain#719 has FAILING CI checks and merge-drain correctly refuses to merge it. Check out the PR branch, find the root cause of the red checks (lint / types / failing test / config), fix it, push to the SAME PR branch, and confirm every check goes green. Do not open a new PR — repair the existing one so merge-drain lands it. PR: https://github.com/organvm/peer-audited--behavioral-blockchain/pull/719 [auto-emitted 2026-07-03 by self-heal so merge-drain can land it]

Refs: https://github.com/organvm/peer-audited--behavioral-blockchain/pull/719

_Produced in an isolated worktree off origin — review before merge._