### PR TITLE
[limen HEAL-cifix-organvm-peer-audited--behavioral-blockchain-729] fix failing CI on organvm/peer-audited--behavioral-blockchain#729

### DIFF
--- a/logs/agents/opencode.json
+++ b/logs/agents/opencode.json
@@ -2,10 +2,10 @@
   "agent": "opencode",
   "status": "idle",
   "accepting_tasks": true,
-  "available_tokens": 42940177,
-  "available_pct": 85.9,
-  "current_task_id": "HEAL-cifix-organvm-peer-audited--behavioral-blockchain-728",
-  "heartbeat": "2026-07-04T05:20:42.986075+00:00",
-  "token_usage_pct": 14.12,
+  "available_tokens": 40885031,
+  "available_pct": 81.8,
+  "current_task_id": "HEAL-cifix-organvm-peer-audited--behavioral-blockchain-729",
+  "heartbeat": "2026-07-04T05:32:45.213655+00:00",
+  "token_usage_pct": 18.23,
   "clock_health": "ok"
 }


### PR DESCRIPTION
Autonomous **limen** dispatch of task `HEAL-cifix-organvm-peer-audited--behavioral-blockchain-729`.

PR organvm/peer-audited--behavioral-blockchain#729 has FAILING CI checks and merge-drain correctly refuses to merge it. Check out the PR branch, find the root cause of the red checks (lint / types / failing test / config), fix it, push to the SAME PR branch, and confirm every check goes green. Do not open a new PR — repair the existing one so merge-drain lands it. PR: https://github.com/organvm/peer-audited--behavioral-blockchain/pull/729 [auto-emitted 2026-07-03 by self-heal so merge-drain can land it]

Refs: https://github.com/organvm/peer-audited--behavioral-blockchain/pull/729

_Produced in an isolated worktree off origin — review before merge._