### PR TITLE
[limen HEAL-cifix-organvm-peer-audited--behavioral-blockchain-752] fix failing CI on organvm/peer-audited--behavioral-blockchain#752

### DIFF
--- a/logs/agents/opencode.json
+++ b/logs/agents/opencode.json
@@ -2,10 +2,10 @@
   "agent": "opencode",
   "status": "idle",
   "accepting_tasks": true,
-  "available_tokens": 39668257,
-  "available_pct": 79.3,
-  "current_task_id": "HEAL-cifix-organvm-peer-audited--behavioral-blockchain-733",
-  "heartbeat": "2026-07-04T06:15:10.487198+00:00",
-  "token_usage_pct": 20.66,
+  "available_tokens": 37854166,
+  "available_pct": 75.7,
+  "current_task_id": "HEAL-cifix-organvm-peer-audited--behavioral-blockchain-752",
+  "heartbeat": "2026-07-04T06:36:05.290303+00:00",
+  "token_usage_pct": 24.29,
   "clock_health": "ok"
 }


### PR DESCRIPTION
Autonomous **limen** dispatch of task `HEAL-cifix-organvm-peer-audited--behavioral-blockchain-752`.

PR organvm/peer-audited--behavioral-blockchain#752 has FAILING CI checks and merge-drain correctly refuses to merge it. Check out the PR branch, find the root cause of the red checks (lint / types / failing test / config), fix it, push to the SAME PR branch, and confirm every check goes green. Do not open a new PR — repair the existing one so merge-drain lands it. PR: https://github.com/organvm/peer-audited--behavioral-blockchain/pull/752 [auto-emitted 2026-07-03 by self-heal so merge-drain can land it]

Refs: https://github.com/organvm/peer-audited--behavioral-blockchain/pull/752

_Produced in an isolated worktree off origin — review before merge._