### PR TITLE
[limen HEAL-cifix-organvm-peer-audited--behavioral-blockchain-714] fix failing CI on organvm/peer-audited--behavioral-blockchain#714

### DIFF
--- a/src/api/src/modules/contracts/waitlist.service.ts
+++ b/src/api/src/modules/contracts/waitlist.service.ts
@@ -57,7 +57,7 @@ export class WaitlistService {
       `User ${userId} joined waitlist for cohort ${cohortId} at position ${mappedEntry.position}`,
     );
     if (entry.was_inserted) {
-      await this.sendEarlyAccessOnboarding(
+      void this.sendEarlyAccessOnboarding(
         userId,
         cohortId,
         mappedEntry.position,


### PR DESCRIPTION
Autonomous **limen** dispatch of task `HEAL-cifix-organvm-peer-audited--behavioral-blockchain-714`.

PR organvm/peer-audited--behavioral-blockchain#714 has FAILING CI checks and merge-drain correctly refuses to merge it. Check out the PR branch, find the root cause of the red checks (lint / types / failing test / config), fix it, push to the SAME PR branch, and confirm every check goes green. Do not open a new PR — repair the existing one so merge-drain lands it. PR: https://github.com/organvm/peer-audited--behavioral-blockchain/pull/714 [auto-emitted 2026-07-03 by self-heal so merge-drain can land it]

Refs: https://github.com/organvm/peer-audited--behavioral-blockchain/pull/714

_Produced in an isolated worktree off origin — review before merge._