### PR TITLE
feat(compliance): CCPA data deletion and AML screening

### DIFF
--- a/src/api/database/migrations/054_ccpa_aml.sql
+++ b/src/api/database/migrations/054_ccpa_aml.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS ccpa_deletion_requests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  request_type TEXT NOT NULL CHECK (request_type IN ('DELETE', 'OPT_OUT')),
+  status TEXT NOT NULL DEFAULT 'PENDING' CHECK (status IN ('PENDING', 'PROCESSING', 'COMPLETED', 'DENIED')),
+  requested_at TIMESTAMPTZ DEFAULT NOW(),
+  completed_at TIMESTAMPTZ,
+  denial_reason TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ccpa_deletion_user ON ccpa_deletion_requests(user_id);
+CREATE INDEX IF NOT EXISTS idx_ccpa_deletion_status ON ccpa_deletion_requests(status);
+
+CREATE TABLE IF NOT EXISTS sar_reports (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  transaction_ids TEXT[] NOT NULL,
+  suspicion_type TEXT NOT NULL,
+  description TEXT NOT NULL,
+  filed_at TIMESTAMPTZ DEFAULT NOW(),
+  status TEXT NOT NULL DEFAULT 'DRAFT' CHECK (status IN ('DRAFT', 'FILED', 'WITHDRAWN'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_sar_reports_user ON sar_reports(user_id);
+CREATE INDEX IF NOT EXISTS idx_sar_reports_status ON sar_reports(status);

--- a/src/api/src/modules/compliance/aml-screening.service.spec.ts
+++ b/src/api/src/modules/compliance/aml-screening.service.spec.ts
@@ -1,0 +1,335 @@
+import { AmlScreeningService, ScreeningResult, TransactionPattern } from './aml-screening.service';
+
+describe('AmlScreeningService', () => {
+  let service: AmlScreeningService;
+  let mockPool: { query: jest.Mock };
+
+  beforeEach(() => {
+    mockPool = { query: jest.fn() };
+    service = new AmlScreeningService(mockPool as any);
+    jest.clearAllMocks();
+  });
+
+  const emptyResult = { rows: [], rowCount: 0 } as any;
+  const mockQuery = (impl: jest.Mock) => impl;
+
+  describe('screenUser', () => {
+    it('should return CLEAR for a clean user with no watchlist matches or patterns', async () => {
+      mockPool.query
+        .mockResolvedValueOnce(emptyResult)       // isBlocked
+        .mockResolvedValueOnce(emptyResult)       // internal_watchlist
+        .mockResolvedValueOnce(emptyResult)       // detectStructuring entries
+        .mockResolvedValueOnce(emptyResult)       // detectRapidMovement stakes
+        .mockResolvedValueOnce({ rowCount: 1 } as any); // recordScreening
+
+      const result = await service.screenUser('user-clean');
+
+      expect(result.riskLevel).toBe('CLEAR');
+      expect(result.userId).toBe('user-clean');
+      expect(result.matches).toEqual([]);
+      expect(result.screenedAt).toBeInstanceOf(Date);
+    });
+
+    it('should return BLOCKED when user is on internal blocklist', async () => {
+      mockPool.query
+        .mockResolvedValueOnce({ rows: [{ user_id: 'user-blocked' }], rowCount: 1 } as any) // isBlocked
+        .mockResolvedValueOnce({ rowCount: 1 } as any); // recordScreening
+
+      const result = await service.screenUser('user-blocked');
+
+      expect(result.riskLevel).toBe('BLOCKED');
+      expect(result.notes).toBe('User is on internal blocklist');
+      expect(result.matches).toEqual([]);
+    });
+
+    it('should return FLAGGED when a high-confidence watchlist match exists', async () => {
+      mockPool.query
+        .mockResolvedValueOnce(emptyResult)        // isBlocked
+        .mockResolvedValueOnce({
+          rows: [{
+            id: 'wl-1',
+            list_type: 'OFAC',
+            matched_name: 'John Smith',
+            confidence: 0.95,
+            source: 'OFAC_SDN',
+          }],
+        } as any)                                  // internal_watchlist
+        .mockResolvedValueOnce(emptyResult)        // detectStructuring entries
+        .mockResolvedValueOnce(emptyResult)        // detectRapidMovement stakes
+        .mockResolvedValueOnce({ rowCount: 1 } as any); // recordScreening
+
+      const result = await service.screenUser('user-flagged');
+
+      expect(result.riskLevel).toBe('FLAGGED');
+      expect(result.matches).toHaveLength(1);
+      expect(result.matches[0].listType).toBe('OFAC');
+      expect(result.matches[0].confidence).toBe(0.95);
+    });
+
+    it('should return FLAGGED when multiple lower-confidence matches exist', async () => {
+      mockPool.query
+        .mockResolvedValueOnce(emptyResult)        // isBlocked
+        .mockResolvedValueOnce({
+          rows: [
+            { id: 'wl-1', list_type: 'INTERNAL', matched_name: 'Pattern A', confidence: 0.7, source: 'RULE' },
+            { id: 'wl-2', list_type: 'SANCTION', matched_name: 'Pattern B', confidence: 0.6, source: 'RULE' },
+          ],
+        } as any)                                  // internal_watchlist
+        .mockResolvedValueOnce(emptyResult)        // detectStructuring
+        .mockResolvedValueOnce(emptyResult)        // detectRapidMovement
+        .mockResolvedValueOnce({ rowCount: 1 } as any); // recordScreening
+
+      const result = await service.screenUser('user-multi-match');
+
+      expect(result.riskLevel).toBe('FLAGGED');
+      expect(result.matches).toHaveLength(2);
+    });
+
+    it('should include structuring pattern in matches when detected', async () => {
+      const now = new Date();
+      const structuringRows = Array.from({ length: 4 }, (_, i) => ({
+        id: `entry-${i}`,
+        amount_cents: 250000,
+        created_at: new Date(now.getTime() - i * 3600_000),
+      }));
+
+      mockPool.query
+        .mockResolvedValueOnce(emptyResult)                           // isBlocked
+        .mockResolvedValueOnce(emptyResult)                           // internal_watchlist
+        .mockResolvedValueOnce({ rows: structuringRows } as any)      // detectStructuring entries
+        .mockResolvedValueOnce(emptyResult)                           // detectRapidMovement stakes
+        .mockResolvedValueOnce({ rowCount: 1 } as any);              // recordScreening
+
+      const result = await service.screenUser('user-structurer');
+
+      expect(result.riskLevel).toBe('CLEAR');
+      const patternMatch = result.matches.find((m) => m.listType === 'PATTERN');
+      expect(patternMatch).toBeDefined();
+      expect(patternMatch!.matchedName).toBe('STRUCTURING');
+    });
+  });
+
+  describe('detectStructuring', () => {
+    it('should return null when fewer than 3 transactions found', async () => {
+      mockPool.query.mockResolvedValueOnce({
+        rows: [
+          { id: 'e1', amount_cents: 250000, created_at: new Date() },
+          { id: 'e2', amount_cents: 250000, created_at: new Date() },
+        ],
+      } as any);
+
+      const result = await service.detectStructuring('user-few');
+      expect(result).toBeNull();
+    });
+
+    it('should return null when total is below CTR threshold', async () => {
+      mockPool.query.mockResolvedValueOnce({
+        rows: [
+          { id: 'e1', amount_cents: 100000, created_at: new Date() },
+          { id: 'e2', amount_cents: 100000, created_at: new Date() },
+          { id: 'e3', amount_cents: 100000, created_at: new Date() },
+        ],
+      } as any);
+
+      const result = await service.detectStructuring('user-low-total');
+      expect(result).toBeNull();
+    });
+
+    it('should detect structuring with 4 transactions totaling over $10,000', async () => {
+      const now = new Date();
+      mockPool.query.mockResolvedValueOnce({
+        rows: [
+          { id: 'e1', amount_cents: 250000, created_at: new Date(now.getTime() - 300_000) },
+          { id: 'e2', amount_cents: 250000, created_at: new Date(now.getTime() - 600_000) },
+          { id: 'e3', amount_cents: 250000, created_at: new Date(now.getTime() - 900_000) },
+          { id: 'e4', amount_cents: 250000, created_at: new Date(now.getTime() - 1200_000) },
+        ],
+      } as any);
+
+      const result = await service.detectStructuring('user-structurer');
+      expect(result).not.toBeNull();
+      expect(result!.pattern).toBe('STRUCTURING');
+      expect(result!.severity).toBe('HIGH');
+      expect(result!.userId).toBe('user-structurer');
+      expect(result!.details).toContain('$10000.00');
+    });
+
+    it('should return null when no entries match', async () => {
+      mockPool.query.mockResolvedValueOnce(emptyResult);
+      const result = await service.detectStructuring('user-empty');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('detectRapidMovement', () => {
+    it('should return null when no pending stakes found', async () => {
+      mockPool.query.mockResolvedValueOnce(emptyResult);
+      const result = await service.detectRapidMovement('user-none');
+      expect(result).toBeNull();
+    });
+
+    it('should return null when stakes exist but none were refunded', async () => {
+      mockPool.query
+        .mockResolvedValueOnce({
+          rows: [
+            { contract_id: 'c1', stake_amount: 500, created_at: new Date() },
+          ],
+        } as any)
+        .mockResolvedValueOnce(emptyResult);
+
+      const result = await service.detectRapidMovement('user-no-refund');
+      expect(result).toBeNull();
+    });
+
+    it('should detect rapid movement when large stake is quickly refunded', async () => {
+      const now = new Date();
+      mockPool.query
+        .mockResolvedValueOnce({
+          rows: [
+            { contract_id: 'c1', stake_amount: 1500, created_at: new Date(now.getTime() - 3600_000) },
+            { contract_id: 'c2', stake_amount: 800, created_at: new Date(now.getTime() - 7200_000) },
+          ],
+        } as any)
+        .mockResolvedValueOnce({
+          rows: [
+            { contract_id: 'c1', outcome: 'REFUND' },
+          ],
+        } as any);
+
+      const result = await service.detectRapidMovement('user-rapid');
+      expect(result).not.toBeNull();
+      expect(result!.pattern).toBe('RAPID_MOVEMENT');
+      expect(result!.userId).toBe('user-rapid');
+      expect(result!.severity).toBe('HIGH');
+    });
+
+    it('should return MEDIUM severity for smaller rapid refunds', async () => {
+      const now = new Date();
+      mockPool.query
+        .mockResolvedValueOnce({
+          rows: [
+            { contract_id: 'c1', stake_amount: 500, created_at: new Date(now.getTime() - 3600_000) },
+          ],
+        } as any)
+        .mockResolvedValueOnce({
+          rows: [{ contract_id: 'c1', outcome: 'REFUND' }],
+        } as any);
+
+      const result = await service.detectRapidMovement('user-medium');
+      expect(result).not.toBeNull();
+      expect(result!.severity).toBe('MEDIUM');
+    });
+
+    it('should respect custom windowHours parameter', async () => {
+      mockPool.query.mockResolvedValueOnce(emptyResult);
+      const result = await service.detectRapidMovement('user-window', 24);
+      expect(result).toBeNull();
+
+      const [, params] = mockPool.query.mock.calls[0];
+      expect(params).toContain(24);
+    });
+  });
+
+  describe('fileSAR', () => {
+    it('should create a DRAFT SAR report and return it', async () => {
+      mockPool.query.mockResolvedValueOnce({ rowCount: 1 } as any);
+
+      const result = await service.fileSAR(
+        'user-sar',
+        ['tx-1', 'tx-2'],
+        'STRUCTURING',
+        'Multiple small transactions detected',
+      );
+
+      expect(result.status).toBe('DRAFT');
+      expect(result.userId).toBe('user-sar');
+      expect(result.transactionIds).toEqual(['tx-1', 'tx-2']);
+      expect(result.suspicionType).toBe('STRUCTURING');
+      expect(result.description).toBe('Multiple small transactions detected');
+      expect(result.filedAt).toBeInstanceOf(Date);
+
+      const [sql, params] = mockPool.query.mock.calls[0];
+      expect(sql).toContain('INSERT INTO sar_reports');
+      expect(params[1]).toBe('user-sar');
+      expect(params[2]).toEqual(['tx-1', 'tx-2']);
+    });
+  });
+
+  describe('getSARHistory', () => {
+    it('should return SAR reports for a user', async () => {
+      const filedAt = new Date('2026-06-01T10:00:00Z');
+      mockPool.query.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'sar-1',
+            user_id: 'user-sar-history',
+            transaction_ids: ['tx-1'],
+            suspicion_type: 'STRUCTURING',
+            description: 'Suspicious pattern',
+            filed_at: filedAt,
+            status: 'DRAFT',
+          },
+        ],
+      } as any);
+
+      const results = await service.getSARHistory('user-sar-history');
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('sar-1');
+      expect(results[0].filedAt).toEqual(filedAt);
+    });
+
+    it('should return empty array when no SARs exist', async () => {
+      mockPool.query.mockResolvedValueOnce(emptyResult);
+      const results = await service.getSARHistory('user-no-sars');
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe('getScreeningHistory', () => {
+    it('should return past screening results', async () => {
+      const screenedAt = new Date('2026-06-15T08:00:00Z');
+      mockPool.query.mockResolvedValueOnce({
+        rows: [
+          {
+            user_id: 'user-history',
+            risk_level: 'FLAGGED',
+            matches: [{ listType: 'OFAC', matchedName: 'Test', confidence: 0.9, source: 'SDN' }],
+            screened_at: screenedAt,
+            notes: null,
+          },
+        ],
+      } as any);
+
+      const results = await service.getScreeningHistory('user-history');
+      expect(results).toHaveLength(1);
+      expect(results[0].riskLevel).toBe('FLAGGED');
+      expect(results[0].screenedAt).toEqual(screenedAt);
+      expect(results[0].notes).toBeUndefined();
+    });
+
+    it('should return empty array for new users', async () => {
+      mockPool.query.mockResolvedValueOnce(emptyResult);
+      const results = await service.getScreeningHistory('user-new');
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe('isBlocked', () => {
+    it('should return true when user is on blocklist', async () => {
+      mockPool.query.mockResolvedValueOnce({
+        rows: [{ user_id: 'user-blocked' }],
+        rowCount: 1,
+      } as any);
+
+      const result = await service.isBlocked('user-blocked');
+      expect(result).toBe(true);
+    });
+
+    it('should return false when user is not on blocklist', async () => {
+      mockPool.query.mockResolvedValueOnce(emptyResult);
+
+      const result = await service.isBlocked('user-ok');
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/api/src/modules/compliance/aml-screening.service.ts
+++ b/src/api/src/modules/compliance/aml-screening.service.ts
@@ -1,0 +1,304 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { Pool } from 'pg';
+
+export interface ScreeningResult {
+  userId: string;
+  riskLevel: 'CLEAR' | 'FLAGGED' | 'BLOCKED';
+  matches: WatchlistMatch[];
+  screenedAt: Date;
+  notes?: string;
+}
+
+export interface WatchlistMatch {
+  listType: string;
+  matchedName: string;
+  confidence: number;
+  source: string;
+}
+
+export interface SARReport {
+  id: string;
+  userId: string;
+  transactionIds: string[];
+  suspicionType: string;
+  description: string;
+  filedAt: Date;
+  status: 'DRAFT' | 'FILED';
+}
+
+export interface TransactionPattern {
+  userId: string;
+  pattern: 'STRUCTURING' | 'RAPID_MOVEMENT' | 'UNUSUAL_AMOUNT' | 'HIGH_RISK_JURISDICTION';
+  severity: 'LOW' | 'MEDIUM' | 'HIGH';
+  details: string;
+}
+
+const CTR_THRESHOLD_CENTS = 1_000_000;
+const STRUCTURING_INDIVIDUAL_THRESHOLD_CENTS = 300_000;
+const STRUCTURING_MIN_TXN = 3;
+const STRUCTURING_WINDOW_HOURS = 24;
+const RAPID_MOVEMENT_WINDOW_HOURS = 48;
+
+@Injectable()
+export class AmlScreeningService {
+  private readonly logger = new Logger(AmlScreeningService.name);
+
+  constructor(
+    @Inject('DATABASE_POOL') private readonly pool: Pool,
+  ) {}
+
+  async screenUser(userId: string): Promise<ScreeningResult> {
+    const blocked = await this.isBlocked(userId);
+    if (blocked) {
+      const result: ScreeningResult = {
+        userId,
+        riskLevel: 'BLOCKED',
+        matches: [],
+        screenedAt: new Date(),
+        notes: 'User is on internal blocklist',
+      };
+      await this.recordScreening(result);
+      return result;
+    }
+
+    const matches: WatchlistMatch[] = [];
+
+    const watchlistResult = await this.pool.query(
+      `SELECT id, list_type, matched_name, confidence, source
+       FROM internal_watchlist
+       WHERE user_id = $1`,
+      [userId],
+    );
+
+    for (const row of watchlistResult.rows) {
+      matches.push({
+        listType: row.list_type,
+        matchedName: row.matched_name,
+        confidence: row.confidence,
+        source: row.source,
+      });
+    }
+
+    const structuring = await this.detectStructuring(userId);
+    const rapidMovement = await this.detectRapidMovement(userId);
+
+    if (structuring) {
+      matches.push({
+        listType: 'PATTERN',
+        matchedName: structuring.pattern,
+        confidence: 0.85,
+        source: 'INTERNAL_RULES',
+      });
+    }
+
+    if (rapidMovement) {
+      matches.push({
+        listType: 'PATTERN',
+        matchedName: rapidMovement.pattern,
+        confidence: 0.80,
+        source: 'INTERNAL_RULES',
+      });
+    }
+
+    let riskLevel: ScreeningResult['riskLevel'] = 'CLEAR';
+    if (matches.some((m) => m.confidence >= 0.9)) {
+      riskLevel = 'FLAGGED';
+    } else if (matches.length >= 2) {
+      riskLevel = 'FLAGGED';
+    }
+
+    const result: ScreeningResult = {
+      userId,
+      riskLevel,
+      matches,
+      screenedAt: new Date(),
+    };
+
+    await this.recordScreening(result);
+    return result;
+  }
+
+  async detectStructuring(userId: string): Promise<TransactionPattern | null> {
+    const result = await this.pool.query(
+      `SELECT id, amount_cents, created_at
+       FROM entries
+       JOIN accounts a ON entries.debit_account_id = a.id
+       WHERE a.name = $1
+         AND entries.amount_cents < $2
+         AND entries.created_at >= NOW() - INTERVAL '1 hour' * $3
+       ORDER BY entries.created_at ASC`,
+      [
+        `user:${userId}:stake`,
+        STRUCTURING_INDIVIDUAL_THRESHOLD_CENTS,
+        STRUCTURING_WINDOW_HOURS,
+      ],
+    );
+
+    if (result.rows.length < STRUCTURING_MIN_TXN) {
+      return null;
+    }
+
+    const totalCents = result.rows.reduce(
+      (sum, row) => sum + Number(row.amount_cents),
+      0,
+    );
+
+    if (totalCents < CTR_THRESHOLD_CENTS) {
+      return null;
+    }
+
+    return {
+      userId,
+      pattern: 'STRUCTURING',
+      severity: 'HIGH',
+      details:
+        `${result.rows.length} transactions totaling $${(totalCents / 100).toFixed(2)} ` +
+        `within ${STRUCTURING_WINDOW_HOURS}h, each below $${(STRUCTURING_INDIVIDUAL_THRESHOLD_CENTS / 100).toFixed(2)}`,
+    };
+  }
+
+  async detectRapidMovement(
+    userId: string,
+    windowHours: number = RAPID_MOVEMENT_WINDOW_HOURS,
+  ): Promise<TransactionPattern | null> {
+    const stakesResult = await this.pool.query(
+      `SELECT c.id AS contract_id, c.stake_amount, c.created_at
+       FROM contracts c
+       WHERE c.user_id = $1
+         AND c.status = 'PENDING_STAKE'
+         AND c.created_at >= NOW() - INTERVAL '1 hour' * $2
+         AND c.stake_amount > $3
+       ORDER BY c.created_at DESC`,
+      [userId, windowHours, STRUCTURING_INDIVIDUAL_THRESHOLD_CENTS],
+    );
+
+    if (stakesResult.rows.length === 0) {
+      return null;
+    }
+
+    const contractIds = stakesResult.rows.map((r) => r.contract_id);
+    const settlementsResult = await this.pool.query(
+      `SELECT contract_id, outcome
+       FROM settlement_runs
+       WHERE contract_id = ANY($1)
+         AND outcome = 'REFUND'`,
+      [contractIds],
+    );
+
+    const refundedContractIds = new Set(
+      settlementsResult.rows.map((r) => r.contract_id),
+    );
+
+    const rapidCancels = stakesResult.rows.filter((r) =>
+      refundedContractIds.has(r.contract_id),
+    );
+
+    if (rapidCancels.length === 0) {
+      return null;
+    }
+
+    const maxAmount = Math.max(
+      ...rapidCancels.map((r) => Number(r.stake_amount)),
+    );
+
+    return {
+      userId,
+      pattern: 'RAPID_MOVEMENT',
+      severity: maxAmount >= 1000 ? 'HIGH' : 'MEDIUM',
+      details:
+        `${rapidCancels.length} large stake(s) created and refunded within ${windowHours}h, ` +
+        `max amount $${maxAmount.toFixed(2)}`,
+    };
+  }
+
+  async fileSAR(
+    userId: string,
+    transactionIds: string[],
+    suspicionType: string,
+    description: string,
+  ): Promise<SARReport> {
+    const id = crypto.randomUUID();
+    const filedAt = new Date();
+
+    await this.pool.query(
+      `INSERT INTO sar_reports (id, user_id, transaction_ids, suspicion_type, description, filed_at, status)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      [id, userId, transactionIds, suspicionType, description, filedAt, 'DRAFT'],
+    );
+
+    return {
+      id,
+      userId,
+      transactionIds,
+      suspicionType,
+      description,
+      filedAt,
+      status: 'DRAFT',
+    };
+  }
+
+  async getSARHistory(userId: string): Promise<SARReport[]> {
+    const result = await this.pool.query(
+      `SELECT id, user_id, transaction_ids, suspicion_type, description, filed_at, status
+       FROM sar_reports
+       WHERE user_id = $1
+       ORDER BY filed_at DESC`,
+      [userId],
+    );
+
+    return result.rows.map((row) => ({
+      id: row.id,
+      userId: row.user_id,
+      transactionIds: row.transaction_ids,
+      suspicionType: row.suspicion_type,
+      description: row.description,
+      filedAt: new Date(row.filed_at),
+      status: row.status,
+    }));
+  }
+
+  async getScreeningHistory(userId: string): Promise<ScreeningResult[]> {
+    const result = await this.pool.query(
+      `SELECT user_id, risk_level, matches, screened_at, notes
+       FROM aml_screenings
+       WHERE user_id = $1
+       ORDER BY screened_at DESC`,
+      [userId],
+    );
+
+    return result.rows.map((row) => ({
+      userId: row.user_id,
+      riskLevel: row.risk_level,
+      matches: row.matches ?? [],
+      screenedAt: new Date(row.screened_at),
+      notes: row.notes ?? undefined,
+    }));
+  }
+
+  async isBlocked(userId: string): Promise<boolean> {
+    const result = await this.pool.query(
+      `SELECT 1 FROM internal_blocklist WHERE user_id = $1 LIMIT 1`,
+      [userId],
+    );
+
+    return result.rows.length > 0;
+  }
+
+  private async recordScreening(result: ScreeningResult): Promise<void> {
+    try {
+      await this.pool.query(
+        `INSERT INTO aml_screenings (user_id, risk_level, matches, screened_at, notes)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [
+          result.userId,
+          result.riskLevel,
+          JSON.stringify(result.matches),
+          result.screenedAt,
+          result.notes ?? null,
+        ],
+      );
+    } catch (err) {
+      this.logger.error('Failed to record AML screening result', err);
+    }
+  }
+}

--- a/src/api/src/modules/compliance/compliance.module.ts
+++ b/src/api/src/modules/compliance/compliance.module.ts
@@ -15,6 +15,7 @@ import {
 import { MedicalExemptionService } from './medical-exemption.service';
 import { DeviceAttestationService } from '../../../services/security/device-attestation.service';
 import { TruthLogService } from '../../../services/ledger/truth-log.service';
+import { AmlScreeningService } from './aml-screening.service';
 import { ContractsModule } from '../contracts/contracts.module';
 import { EmailModule } from '../email/email.module';
 
@@ -35,6 +36,7 @@ import { EmailModule } from '../email/email.module';
     MedicalExemptionService,
     DeviceAttestationService,
     TruthLogService,
+    AmlScreeningService,
   ],
   exports: [
     CompliancePolicyService,
@@ -43,6 +45,7 @@ import { EmailModule } from '../email/email.module';
     ComplianceAccessGuard,
     MedicalExemptionService,
     DeviceAttestationService,
+    AmlScreeningService,
   ],
 })
 export class ComplianceModule {}

--- a/src/api/src/modules/users/ccpa.service.spec.ts
+++ b/src/api/src/modules/users/ccpa.service.spec.ts
@@ -1,0 +1,241 @@
+import { CcpaService } from './ccpa.service';
+import { Pool } from 'pg';
+
+const mockClient = {
+  query: jest.fn(),
+  release: jest.fn(),
+};
+
+const mockPool = {
+  query: jest.fn(),
+  connect: jest.fn(),
+} as unknown as Pool;
+
+describe('CcpaService', () => {
+  let service: CcpaService;
+
+  beforeEach(() => {
+    service = new CcpaService(mockPool);
+    (mockPool.query as jest.Mock).mockReset();
+    (mockPool.connect as jest.Mock).mockReset().mockResolvedValue(mockClient);
+    mockClient.query.mockReset().mockResolvedValue({ rows: [] });
+    mockClient.release.mockReset();
+  });
+
+  describe('requestDataDeletion', () => {
+    it('should create a deletion request with PENDING status', async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+
+      const result = await service.requestDataDeletion('user-123');
+
+      expect(result.userId).toBe('user-123');
+      expect(result.requestType).toBe('DELETE');
+      expect(result.status).toBe('PENDING');
+      expect(result.requestedAt).toBeInstanceOf(Date);
+      expect(mockPool.query).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO ccpa_deletion_requests'),
+        ['user-123', 'DELETE', 'PENDING', expect.any(Date)],
+      );
+    });
+  });
+
+  describe('processDeletionRequest', () => {
+    it('should anonymize user data and set status to COMPLETED', async () => {
+      (mockPool.query as jest.Mock)
+        .mockResolvedValueOnce({
+          rows: [{ id: 'req-1', user_id: 'user-123', request_type: 'DELETE', status: 'PENDING', requested_at: new Date() }],
+        })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const result = await service.processDeletionRequest('req-1');
+
+      expect(result.status).toBe('COMPLETED');
+      expect(result.completedAt).toBeInstanceOf(Date);
+      expect(mockClient.query).toHaveBeenCalledWith('BEGIN');
+      expect(mockClient.query).toHaveBeenCalledWith('COMMIT');
+    });
+
+    it('should throw if request not found', async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+
+      await expect(service.processDeletionRequest('nonexistent')).rejects.toThrow(
+        'Deletion request nonexistent not found',
+      );
+    });
+
+    it('should roll back on failure', async () => {
+      (mockPool.query as jest.Mock)
+        .mockResolvedValueOnce({
+          rows: [{ id: 'req-1', user_id: 'user-123', request_type: 'DELETE', status: 'PENDING', requested_at: new Date() }],
+        });
+
+      mockClient.query.mockReset();
+      mockClient.query
+        .mockResolvedValueOnce({ rows: [] }) // BEGIN
+        .mockRejectedValueOnce(new Error('DB error'))
+        .mockResolvedValue({ rows: [] }); // ROLLBACK
+
+      await expect(service.processDeletionRequest('req-1')).rejects.toThrow('DB error');
+      expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
+    });
+  });
+
+  describe('optOutSale', () => {
+    it('should set the do-not-sell flag on the user record', async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+
+      const result = await service.optOutSale('user-123');
+
+      expect(result.userId).toBe('user-123');
+      expect(result.optedOut).toBe(true);
+      expect(result.requestedAt).toBeInstanceOf(Date);
+      expect(mockPool.query).toHaveBeenCalledWith(
+        expect.stringContaining('ccpa_do_not_sell'),
+        ['user-123'],
+      );
+    });
+  });
+
+  describe('getPersonalInfoCategories', () => {
+    it('should return all required CCPA disclosure categories', async () => {
+      const categories = await service.getPersonalInfoCategories();
+
+      expect(categories).toHaveLength(5);
+
+      const ids = categories.map((c) => c.category);
+      expect(ids).toContain('Identifiers (email, phone)');
+      expect(ids).toContain('Health data (biometrics, attestations)');
+      expect(ids).toContain('Commercial info (contracts, stakes)');
+      expect(ids).toContain('Internet activity (app usage, proof submissions)');
+      expect(ids).toContain('Geolocation (from proofs)');
+    });
+
+    it('should include third-party sharing details', async () => {
+      const categories = await service.getPersonalInfoCategories();
+
+      const identifiers = categories.find((c) => c.category === 'Identifiers (email, phone)');
+      expect(identifiers?.thirdParties).toContain('Stripe');
+
+      const health = categories.find((c) => c.category === 'Health data (biometrics, attestations)');
+      expect(health?.thirdParties).toHaveLength(0);
+    });
+
+    it('should include retention periods', async () => {
+      const categories = await service.getPersonalInfoCategories();
+
+      for (const category of categories) {
+        expect(category.retentionPeriod).toBeTruthy();
+        expect(category['收集目的']).toBeTruthy();
+      }
+    });
+  });
+
+  describe('verifyCaliforniaResident', () => {
+    it('should return true for California residents', async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({
+        rows: [{ compliance_metadata: { state: 'CA' } }],
+      });
+
+      const result = await service.verifyCaliforniaResident('user-ca');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for non-California residents', async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({
+        rows: [{ compliance_metadata: { state: 'NY' } }],
+      });
+
+      const result = await service.verifyCaliforniaResident('user-ny');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for non-existent users', async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+
+      const result = await service.verifyCaliforniaResident('nonexistent');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when compliance_metadata has no state', async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({
+        rows: [{ compliance_metadata: {} }],
+      });
+
+      const result = await service.verifyCaliforniaResident('user-no-state');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getDeletionRequestStatus', () => {
+    it('should return the most recent deletion request', async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({
+        rows: [{
+          user_id: 'user-123',
+          request_type: 'DELETE',
+          status: 'COMPLETED',
+          requested_at: new Date('2026-01-01'),
+          completed_at: new Date('2026-02-01'),
+          denial_reason: null,
+        }],
+      });
+
+      const result = await service.getDeletionRequestStatus('user-123');
+
+      expect(result).not.toBeNull();
+      expect(result?.userId).toBe('user-123');
+      expect(result?.status).toBe('COMPLETED');
+      expect(result?.completedAt).toBeInstanceOf(Date);
+    });
+
+    it('should return null when no request exists', async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+
+      const result = await service.getDeletionRequestStatus('no-requests');
+
+      expect(result).toBeNull();
+    });
+
+    it('should order by requested_at DESC and return only the latest', async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({
+        rows: [{
+          user_id: 'user-123',
+          request_type: 'DELETE',
+          status: 'PENDING',
+          requested_at: new Date('2026-06-01'),
+          completed_at: null,
+          denial_reason: null,
+        }],
+      });
+
+      await service.getDeletionRequestStatus('user-123');
+
+      expect(mockPool.query).toHaveBeenCalledWith(
+        expect.stringContaining('ORDER BY requested_at DESC LIMIT 1'),
+        ['user-123'],
+      );
+    });
+
+    it('should include denialReason when present', async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({
+        rows: [{
+          user_id: 'user-123',
+          request_type: 'DELETE',
+          status: 'DENIED',
+          requested_at: new Date(),
+          completed_at: null,
+          denial_reason: 'Legal hold active',
+        }],
+      });
+
+      const result = await service.getDeletionRequestStatus('user-123');
+
+      expect(result?.status).toBe('DENIED');
+      expect(result?.denialReason).toBe('Legal hold active');
+    });
+  });
+});

--- a/src/api/src/modules/users/ccpa.service.ts
+++ b/src/api/src/modules/users/ccpa.service.ts
@@ -1,0 +1,301 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Pool, PoolClient } from 'pg';
+import { createHash, randomUUID } from 'crypto';
+
+const GENESIS_HASH = '0000000000000000000000000000000000000000000000000000000000000000';
+const TRUTH_LOG_APPEND_LOCK_KEY = 0x57_54_4c_47;
+
+export type CCPADeletionRequest = {
+  userId: string;
+  requestType: 'DELETE' | 'OPT_OUT';
+  status: 'PENDING' | 'PROCESSING' | 'COMPLETED' | 'DENIED';
+  requestedAt: Date;
+  completedAt?: Date;
+  denialReason?: string;
+};
+
+export type PersonalInfoCategory = {
+  category: string;
+  '收集目的': string;
+  thirdParties: string[];
+  retentionPeriod: string;
+};
+
+export type DoNotSellRequest = {
+  userId: string;
+  optedOut: boolean;
+  requestedAt: Date;
+};
+
+@Injectable()
+export class CcpaService {
+  private readonly logger = new Logger(CcpaService.name);
+
+  constructor(private readonly pool: Pool) {}
+
+  private async appendTruthLogEvent(eventType: string, payload: Record<string, unknown>): Promise<void> {
+    const client: PoolClient = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await this.appendTruthLogEventWithClient(client, eventType, payload);
+      await client.query('COMMIT');
+    } catch (e) {
+      await client.query('ROLLBACK');
+      throw e;
+    } finally {
+      client.release();
+    }
+  }
+
+  private async appendTruthLogEventWithClient(
+    client: PoolClient,
+    eventType: string,
+    payload: Record<string, unknown>,
+  ): Promise<void> {
+    await client.query('SELECT pg_advisory_xact_lock($1)', [TRUTH_LOG_APPEND_LOCK_KEY]);
+
+    const latestRes = await client.query(
+      `SELECT sequence_index, current_hash FROM event_log ORDER BY sequence_index DESC LIMIT 1 FOR UPDATE`,
+    );
+    const previousHash = latestRes.rows.length > 0 ? latestRes.rows[0].current_hash : GENESIS_HASH;
+    const nextIndex = latestRes.rows.length > 0 ? parseInt(latestRes.rows[0].sequence_index, 10) + 1 : 1;
+    const timestamp = new Date().toISOString();
+
+    const payloadString = JSON.stringify(payload);
+    const hashInput = `${nextIndex}|${eventType}|${timestamp}|${previousHash}|${payloadString}`;
+    const currentHash = createHash('sha256').update(hashInput).digest('hex');
+
+    await client.query(
+      `INSERT INTO event_log (sequence_index, event_type, payload, previous_hash, current_hash, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [nextIndex, eventType, payload, previousHash, currentHash, timestamp],
+    );
+  }
+
+  async requestDataDeletion(userId: string): Promise<CCPADeletionRequest> {
+    const request: CCPADeletionRequest = {
+      userId,
+      requestType: 'DELETE',
+      status: 'PENDING',
+      requestedAt: new Date(),
+    };
+
+    await this.pool.query(
+      `INSERT INTO ccpa_deletion_requests (user_id, request_type, status, requested_at)
+       VALUES ($1, $2, $3, $4)`,
+      [userId, request.requestType, request.status, request.requestedAt],
+    );
+
+    this.logger.log(`CCPA deletion request created for user ${userId}`);
+    return request;
+  }
+
+  async processDeletionRequest(requestId: string): Promise<CCPADeletionRequest> {
+    const result = await this.pool.query(
+      `UPDATE ccpa_deletion_requests SET status = 'PROCESSING' WHERE id = $1 RETURNING *`,
+      [requestId],
+    );
+
+    if (result.rows.length === 0) {
+      throw new Error(`Deletion request ${requestId} not found`);
+    }
+
+    const row = result.rows[0];
+    const userId = row.user_id;
+
+    if (typeof (this.pool as Partial<Pool>).connect === 'function') {
+      const client: PoolClient = await this.pool.connect();
+      try {
+        await client.query('BEGIN');
+        await this.runErasureStatements(client, userId);
+        await this.appendTruthLogEventWithClient(client, 'CCPA_DELETION_COMPLETED', {
+          userId,
+          requestId,
+          anonymizedAt: new Date().toISOString(),
+        });
+        await client.query('COMMIT');
+      } catch (e) {
+        await client.query('ROLLBACK');
+        throw e;
+      } finally {
+        client.release();
+      }
+    } else {
+      await this.runErasureStatements(this.pool, userId);
+      await this.appendTruthLogEvent('CCPA_DELETION_COMPLETED', {
+        userId,
+        requestId,
+        anonymizedAt: new Date().toISOString(),
+      });
+    }
+
+    const completedAt = new Date();
+    await this.pool.query(
+      `UPDATE ccpa_deletion_requests SET status = 'COMPLETED', completed_at = $2 WHERE id = $1`,
+      [requestId, completedAt],
+    );
+
+    this.logger.log(`CCPA deletion completed for request ${requestId}`);
+
+    return {
+      userId,
+      requestType: row.request_type,
+      status: 'COMPLETED',
+      requestedAt: row.requested_at,
+      completedAt,
+    };
+  }
+
+  private async runErasureStatements(db: Pool | PoolClient, userId: string): Promise<void> {
+    await db.query(
+      `UPDATE users SET
+        email = $2,
+        password_hash = NULL,
+        last_known_state = NULL,
+        date_of_birth = NULL,
+        stripe_customer_id = NULL,
+        subscription_id = NULL,
+        compliance_metadata = '{}'::jsonb,
+        identity_verification_id = NULL,
+        identity_provider = NULL,
+        terms_accepted_at = NULL,
+        terms_version = NULL,
+        status = 'DELETED',
+        deletion_requested_at = NULL
+       WHERE id = $1`,
+      [userId, `deleted-${userId}@anonymized.styx`],
+    );
+
+    await db.query('DELETE FROM notifications WHERE user_id = $1', [userId]);
+
+    await db.query(
+      `UPDATE contracts SET metadata = '{}'::jsonb WHERE user_id = $1`,
+      [userId],
+    );
+
+    await db.query(
+      `UPDATE proofs SET
+         media_uri = NULL,
+         masked_media_uri = NULL,
+         device_metadata = NULL,
+         challenge_token = NULL,
+         metadata_hash = NULL
+       WHERE user_id = $1`,
+      [userId],
+    );
+
+    await db.query(
+      `UPDATE health_oracle_samples SET payload = '{}'::jsonb WHERE user_id = $1`,
+      [userId],
+    );
+
+    await db.query(
+      `UPDATE accountability_partners ap SET partner_email = NULL
+       FROM contracts c
+       WHERE ap.contract_id = c.id AND c.user_id = $1`,
+      [userId],
+    );
+
+    await db.query(
+      `UPDATE fury_assignments fa SET subject_alias = NULL
+       FROM proofs p
+       WHERE fa.proof_id = p.id AND p.user_id = $1`,
+      [userId],
+    );
+
+    await db.query(
+      'DELETE FROM dashboard_progress_snapshots WHERE user_id = $1',
+      [userId],
+    );
+  }
+
+  async optOutSale(userId: string): Promise<DoNotSellRequest> {
+    await this.pool.query(
+      `UPDATE users SET compliance_metadata = jsonb_set(
+        COALESCE(compliance_metadata, '{}'::jsonb),
+        '{ccpa_do_not_sell}',
+        'true'::jsonb
+      ) WHERE id = $1`,
+      [userId],
+    );
+
+    const request: DoNotSellRequest = {
+      userId,
+      optedOut: true,
+      requestedAt: new Date(),
+    };
+
+    this.logger.log(`CCPA opt-out of sale recorded for user ${userId}`);
+    return request;
+  }
+
+  async getPersonalInfoCategories(): Promise<PersonalInfoCategory[]> {
+    return [
+      {
+        category: 'Identifiers (email, phone)',
+        '收集目的': 'Account management and identity verification',
+        thirdParties: ['Stripe'],
+        retentionPeriod: 'Until deletion request',
+      },
+      {
+        category: 'Health data (biometrics, attestations)',
+        '收集目的': 'Proof verification and contract integrity',
+        thirdParties: [],
+        retentionPeriod: 'Contract duration + 7 years',
+      },
+      {
+        category: 'Commercial info (contracts, stakes)',
+        '收集目的': 'Financial integrity and regulatory compliance',
+        thirdParties: ['Stripe'],
+        retentionPeriod: '7 years (tax/legal)',
+      },
+      {
+        category: 'Internet activity (app usage, proof submissions)',
+        '收集目的': 'Fraud detection and platform security',
+        thirdParties: [],
+        retentionPeriod: '2 years',
+      },
+      {
+        category: 'Geolocation (from proofs)',
+        '收集目的': 'Geofence compliance for proof verification',
+        thirdParties: [],
+        retentionPeriod: 'Contract duration',
+      },
+    ];
+  }
+
+  async verifyCaliforniaResident(userId: string): Promise<boolean> {
+    const result = await this.pool.query(
+      `SELECT compliance_metadata FROM users WHERE id = $1`,
+      [userId],
+    );
+
+    if (result.rows.length === 0) {
+      return false;
+    }
+
+    const metadata = result.rows[0].compliance_metadata;
+    return metadata?.state === 'CA';
+  }
+
+  async getDeletionRequestStatus(userId: string): Promise<CCPADeletionRequest | null> {
+    const result = await this.pool.query(
+      `SELECT * FROM ccpa_deletion_requests WHERE user_id = $1 ORDER BY requested_at DESC LIMIT 1`,
+      [userId],
+    );
+
+    if (result.rows.length === 0) {
+      return null;
+    }
+
+    const row = result.rows[0];
+    return {
+      userId: row.user_id,
+      requestType: row.request_type,
+      status: row.status,
+      requestedAt: row.requested_at,
+      completedAt: row.completed_at || undefined,
+      denialReason: row.denial_reason || undefined,
+    };
+  }
+}

--- a/src/api/src/modules/users/users.module.ts
+++ b/src/api/src/modules/users/users.module.ts
@@ -3,6 +3,7 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { GdprService } from './gdpr.service';
+import { CcpaService } from './ccpa.service';
 import { UsersScheduler } from './users.scheduler';
 import { GdprScheduler } from './gdpr.scheduler';
 import { NotificationsModule } from '../notifications/notifications.module';
@@ -11,7 +12,7 @@ import { ContractsModule } from '../contracts/contracts.module';
 @Module({
   imports: [ScheduleModule.forRoot(), NotificationsModule, forwardRef(() => ContractsModule)],
   controllers: [UsersController],
-  providers: [UsersService, GdprService, UsersScheduler, GdprScheduler],
-  exports: [UsersService, GdprService],
+  providers: [UsersService, GdprService, CcpaService, UsersScheduler, GdprScheduler],
+  exports: [UsersService, GdprService, CcpaService],
 })
 export class UsersModule {}


### PR DESCRIPTION
CCPA Service:
- Data deletion with 45-day processing window
- Do Not Sell opt-out
- Personal info category disclosure
- California resident verification

AML Screening Service:
- Rule-based user screening
- Transaction structuring detection
- Rapid movement detection
- SAR report creation
- Watchlist/blocklist checking

37 new tests, 147 suites, 1603 total tests