### PR TITLE
fix(demo): give demo users a jurisdiction; seed FBO accounts; fix state-match collision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ docs/planning/planning--parallel-*-prompts--*.md
 # Local verification scratch (see scripts/demo/README.md)
 /src/api/.circle-smoke.mjs
 /src/api/.column-audit.mjs
+/src/api/.ccpa-sweep-check.mjs
 
 # Committed terraform binaries removed 2026-07-30 (113MB); install via tfenv/brew
 /terraform

--- a/docs/planning/concentric-circles-execution.md
+++ b/docs/planning/concentric-circles-execution.md
@@ -238,8 +238,32 @@ read. What remains is counsel review and procurement — see the final subsectio
       `SPLIT_PART(x, '-', 2)` returns `''` for undelimited values, so `US` and `CA`
       compared equal — the country-level fallback account matched *every* state.
       Only visible once real rows existed
+- [x] **CCPA deletions are now actually executed.**
+      `CcpaService.processDeletionRequest` had zero callers — no admin route, no
+      scheduler, no queue consumer. A California resident could submit a request, get
+      a `201`, and see a `PENDING` row while the data was retained indefinitely, past
+      the §1798.130(a)(2) deadline. Every visible signal said the feature worked.
+      `CcpaScheduler` (4:30 AM, half an hour after the GDPR sweep so the two erasure
+      paths never contend for the same rows or the TruthLog append lock) now drives
+      `processPendingDeletions`, mirroring the GDPR sweep including its PII-safe
+      failure logging. `OPT_OUT` rows are excluded — those are do-not-sell flags, and
+      sweeping them would delete the accounts of users who only opted out of sale
+- [x] Fixed a stranding bug the sweep exposed: the `status = 'PROCESSING'` stamp sits
+      outside the erasure transaction, so a rollback did not undo it and one failed
+      erasure pinned that request at `PROCESSING` forever — never retried, never
+      completed. It now returns to `PENDING` on failure, which is safe because the
+      erasure itself is transactional
+- [x] Guarded the demo seed against re-writing jurisdiction data onto an erased user.
+      Erasure sets `last_known_state = NULL` and `compliance_metadata = '{}'`, which is
+      exactly what the seed's idempotency predicate looks for, so a re-run would have
+      partially reversed a completed CCPA deletion
 
-### Remaining engineering — one open decision:
+### Remaining engineering — open decisions, not defects:
+- [ ] **CCPA deletion grace window** is set to 7 days (`CCPA_DELETION_GRACE_DAYS` in
+      `ccpa.service.ts`). CCPA allows 45 days to respond and the sibling GDPR path
+      holds for 30; 30 here would leave only 15 days of slack for a failed sweep to be
+      noticed and retried. It is a policy parameter, not a technical constraint —
+      worth confirming alongside the other counsel items below.
 - [ ] `FboAccountService` has **zero consumers**. It is registered and exported in
       `payments.module.ts`, has a passing spec, and is called by nothing.
       `SettlementService` operates on internal ledger accounts
@@ -291,6 +315,12 @@ runner to baseline-stamp (skip) the rest of the chain.
    the TypeScript is consistent with itself and nothing about whether the query runs.
    Twelve columns that did not exist, and a jurisdiction match that compared `US` equal
    to `CA`, all shipped under passing tests.
+8. **(Added 2026-07-30)** Before calling a feature done, grep for **callers**, not just
+   for the file. `SecurityModule`, `AmlController`, `PractitionerIntelligenceService`,
+   `FboAccountService` and `CcpaService.processDeletionRequest` were each written,
+   tested, and reachable by nobody. The CCPA one is the cautionary case: it returned
+   `201`, wrote a `PENDING` row, and retained the data forever — an unreachable
+   compliance feature is worse than an absent one, because it reports success.
 
 ---
 

--- a/docs/planning/concentric-circles-execution.md
+++ b/docs/planning/concentric-circles-execution.md
@@ -1,8 +1,42 @@
 # Concentric Circles Execution Plan
 
 **Date:** 2026-07-23
-**Status update:** 2026-07-30 (truth pass — this build, branch `feat/omega-completion`)
+**Status update:** 2026-07-30 (post-merge truth pass — all engineering work is on `main`)
 **Goal:** Ship all phases (Alpha→Omega) as concentric circles. Each circle is launchable independently. Previous circles improve while the next one builds.
+
+---
+
+## Post-Merge State (2026-07-30)
+
+Everything the previous revision described as "added by this branch" is merged. The
+landing sequence was #844 (landing-page heal, which had held `main` red since
+2026-07-23), then #845 (Circle 3–5 wiring + schema-drift repair), #828/#846
+(dependency and workspace hygiene), and #847 (demo jurisdiction substrate).
+
+**Verified against a running system, not just a test suite:**
+
+| Check | Result |
+| --- | --- |
+| `main` CI | green — first successful pipeline since 2026-07-23 |
+| `turbo run test` | 11/11 tasks — **2,937 tests across 260 suites** (api 1902/161, web 386/46, mobile 299/32, shared 202/9, desktop 148/12) |
+| `turbo run build lint` | 21/21 tasks |
+| Fresh empty database | 70 migrations + base seed + circles seed, **zero errors**, idempotent on re-run |
+| Live circle smoke | **23/23 probes** against a booted API |
+
+The test count supersedes the "1,107 tests passing" figure quoted in older revisions.
+
+### What running it caught that the tests could not
+
+Every spec mocks the pg `Pool`, so no SQL had ever executed against a real database.
+Booting the API against a migrated Postgres found what 2,900+ passing unit tests did
+not — most seriously that `proofs.content_type` did not exist, which broke proof
+submission **and the entire Fury peer-audit queue** on `main`. A static audit found 12
+such columns; migrations `063`–`065` reconcile them. Fresh installs were also
+structurally broken: the migration runner stamped all 70 migrations as applied without
+running them, so 46 tables could never exist.
+
+This is now a standing caution, not a historical note: **a green suite here does not
+mean the SQL runs.** Anything touching a query needs a live check.
 
 ---
 
@@ -10,7 +44,8 @@
 
 Earlier revisions of this plan marked Circle 3 "COMPLETE" and listed Circle 4/5 items
 as ✅ when the underlying services had been **built and tested but never wired into the
-running application**. Concrete examples verified against the tree at time of writing:
+running application**. Concrete examples verified against the tree at time of writing
+(all now fixed and merged):
 
 - `SecurityModule` (anti-Sybil, `src/api/src/modules/security/security.module.ts`) was
   never imported by `src/api/src/app.module.ts` — none of its `/security/*` routes were
@@ -35,30 +70,30 @@ running application**. Concrete examples verified against the tree at time of wr
 
 ## Current State (as of 2026-07-30)
 
-- 7 packages; test counts pending the orchestrator's central CI run for this branch
-  (the previously advertised "1,107 tests passing" predates the Circle 3–5 merges and
-  is stale — do not quote it)
-- 25+ NestJS modules built; **not all registered in `app.module.ts`** (see preamble —
-  this branch wires the stragglers)
-- Circle 1 PR backlog merged; **the Circle 1 gate (CI green, zero open PRs) is not yet
-  verified closed**
-- CCPA + AML (PR #835) and anti-Sybil + practitioner intelligence (PR #833) are merged
-  code; AML routes and the security module were unwired until this branch
+- 7 packages, **2,937 tests across 260 suites**, all green
+- 25+ NestJS modules, **all now registered** — `SecurityModule`, `AmlController`, and
+  `PractitionerIntelligenceService` were wired in #845
+- Circle 1 gate **closed**: `main` CI green, PR backlog cleared
+- Every circle has at least one reachable demo surface; `/circles` is the public index
 
 ---
 
 ## Circle 1: Clear the Backlog (merge all PRs)
 **Goal:** All existing code work merged to main. Clean slate.
 **Launch gate:** All 16 PRs merged, CI green, zero open PRs.
-**Status:** MERGED, GATE NOT CLOSED — the 16 tracked PRs were merged, but the gate
-also requires CI green on main and zero open PRs, and neither has been re-verified
-after the Circle 3–5 merges. Do not call this circle closed until the orchestrator's
-central CI run is green and the open-PR count is confirmed zero.
+**Status:** ✅ **CLOSED (2026-07-30).**
+
+The gate had been stuck not on the 16 tracked PRs but on `main` itself: a merge
+(`a83461a`) deleted the landing page's hero — headline, tagline, beta badge — while
+leaving `page.test.tsx` asserting the old copy. That single break kept `main` red on
+every push for a week and blocked five dependabot PRs behind it. Fixed in #844.
 
 - [x] #704, #705, #707, #709, #700, #703, #713, #715, #718, #731, #797, #808, #810,
       #811, #814, #819 merged
-- [ ] CI green on main (re-verify after this branch lands)
-- [ ] Zero open PRs confirmed
+- [x] CI green on `main`
+- [x] PR backlog cleared — #836 superseded by #845; #842 auto-closed once its bump
+      landed; #843 superseded by #846; #838 to be regenerated by Dependabot under the
+      corrected config
 
 ---
 
@@ -81,7 +116,9 @@ central CI run is green and the open-PR count is confirmed zero.
       switch endpoints (`admin.controller.ts` `GET/POST /admin/kill-switch`)
 - [x] Crisis detection — `src/api/services/security/crisis-detection.service.ts`,
       `crisis-intervention.service.ts`, `crisis-notification.service.ts`, crisis module
-- [ ] Kill switch **persistence** — in-memory until this branch (see Circle 5 wiring)
+- [x] Kill switch **persistence** — DB-backed (migration `060_system_flags.sql`);
+      verified by arming it, killing the API process, restarting, and confirming
+      refund-only mode survived
 
 ### 2b: External dependencies (human-gated, still open)
 - [ ] Legal counsel retention
@@ -97,22 +134,27 @@ central CI run is green and the open-PR count is confirmed zero.
 ## Circle 3: Gamma — Proof Integrity at Scale
 **Goal:** Scale the reviewer network. Trust the evidence.
 **Launch gate:** Health data integration, video proof pipeline, reviewer redaction, anti-collusion.
-**Status:** BUILT (PR #829 merged 2026-07-23); WIRING + HARDENING COMPLETED BY THIS BRANCH.
-The previous "COMPLETE" claim conflated merged code with reachable, production-grade
-behavior.
+**Status:** ✅ **ENGINEERING COMPLETE** — built in #829, wired and hardened in #845.
+The earlier "COMPLETE" claim conflated merged code with reachable, production-grade
+behavior; this one is verified against a running system (`/fury` queue, proof submit,
+attestation rejection paths all exercised live).
 
 - [x] Collusion ring detection — `src/api/services/security/collusion-detection.service.ts`
 - [x] Fitbit daily readiness — `src/api/services/health/fitbit.service.ts`,
       `src/api/src/modules/contracts/fitbit.controller.ts` (registered in
       `contracts.module.ts`)
-- [ ] **Verified** Fitbit ingestion — the existing controller accepts authenticated
-      user-submitted readiness; provider-verified ingestion (signature/token
-      verification against Fitbit) is added by this branch
+- [x] **Verified** Fitbit ingestion — provider signature verification + OAuth token
+      storage (migration `062_fitbit_oauth_tokens.sql`); an unsigned webhook is
+      rejected (verified live)
 - [x] Device attestation framework — `src/api/services/security/device-attestation.service.ts`
       (key registry, replay counters, structural checks; migration `051`)
-- [ ] **Real attestation crypto** — App Attest certificate-chain and Play Integrity JWT
-      signature verification (the service's own doc-comment lists these as required for
-      production); added by this branch
+- [x] **Real attestation crypto** — App Attest X509 certificate-chain validation with
+      root-CA pinning and nonce-extension binding (OID 1.2.840.113635.100.8.2), and
+      Play Integrity JWKS signature verification with caching plus `exp`/package-name
+      checks. **Fail-closed**: with no `APPLE_APP_ATTEST_APP_ID` /
+      `GOOGLE_PLAY_INTEGRITY_JWKS_URL` it refuses to verify rather than
+      rubber-stamping. For demos set `DEVICE_ATTESTATION_DEV_BYPASS=true` — verdicts
+      come back labeled `DEV_BYPASS`, never `STRONG` (see `scripts/demo/README.md` §2c)
 - [x] HealthKit ingestion + Whoop (from Circle 2)
 - [x] Video transcoding pipeline — `src/api/src/modules/proofs/video-processing.*`
 - [x] Reviewer redaction (from Circle 2)
@@ -123,7 +165,9 @@ behavior.
 ## Circle 4: Delta — Retention + Network Effects
 **Goal:** Will people come back? Build the engagement loop.
 **Launch gate:** Danger-zone protections, accountability partners, progress dashboard, push notifications.
-**Status:** BUILT (PRs #830, #831 merged 2026-07-23); demo-facing surfaces wired by this branch.
+**Status:** ✅ **ENGINEERING COMPLETE** for the launch-gate items — built in #830/#831,
+demo-facing surfaces wired in #845. Three post-gate items remain unstarted (below);
+they are scope beyond the stated gate, not regressions.
 
 - [x] Danger-zone protections — `src/api/src/modules/behavioral/danger-zone.service.ts`
 - [x] Accountability partner protocol — `accountability-partner.service.ts`, migration `052`
@@ -132,8 +176,11 @@ behavior.
 - [x] Endowed progress engine — `endowed-progress.service.ts`
 - [x] Push notification infrastructure — migration `044`
 - [x] Weekend risk multiplier — migration `022`
-- [ ] Circles (pods) member-facing pages in `src/web/app` — added by this branch
-      (no `circles` route existed before it)
+- [x] Circles (pods) member-facing pages in `src/web/app` — added in #845 (no
+      `circles` route existed before it); `/circles` is now the public demo index
+
+Post-gate scope, still unstarted — these were never part of the Circle 4 launch gate:
+
 - [ ] Identity-based onboarding (user archetype profiling at intake) — not started
 - [ ] Pod/Arena experiment framework (A/B cohort comparison) — not started
 - [ ] In-app messaging within pods — not started
@@ -143,11 +190,12 @@ behavior.
 ## Circle 5: Omega — Enterprise Expansion
 **Goal:** Can enterprises buy this? Legal, compliance, revenue.
 **Launch gate:** Legal whitepaper, enterprise compliance, revenue packaging.
-**Status:** IN PROGRESS. PR #833 (anti-Sybil, practitioner intelligence) and PR #835
-(CCPA deletion, AML screening) are **merged** — the prior revision wrongly listed
-CCPA/AML as "Remaining." What actually remained was wiring, which this branch does.
+**Status:** ✅ **ENGINEERING COMPLETE; HUMAN-GATED ITEMS OPEN.** #833 (anti-Sybil,
+practitioner intelligence) and #835 (CCPA deletion, AML screening) supplied the code;
+#845 wired it into reachable routes and UI; #847 seeded the substrate those routes
+read. What remains is counsel review and procurement — see the final subsection.
 
-### Merged before this branch:
+### Merged in #833 / #835:
 - [x] Anti-Sybil layer — `src/api/src/modules/security/anti-sybil.service.ts`,
       migration `053_anti_sybil.sql` (PR #833)
 - [x] Practitioner risk intelligence —
@@ -158,21 +206,48 @@ CCPA/AML as "Remaining." What actually remained was wiring, which this branch do
       migrations `054` + `059_aml_tables.sql` (PR #835)
 - [x] SOC 2 groundwork — hash-chained TruthLog
       (`src/api/services/ledger/truth-log.service.ts`), guards
-      (`src/api/src/guards/auth.guard.ts`, `src/api/src/common/guards/role.guard.ts`)
+      (`src/api/guards/auth.guard.ts`, `src/api/src/common/guards/role.guard.ts`)
 
-### Wired/added by this branch (`feat/omega-completion`):
-- [ ] Register `SecurityModule` in `app.module.ts`; register `AmlController` in
-      `compliance.module.ts`; register `PractitionerIntelligenceService` in
-      `behavioral.module.ts`
-- [ ] Migrations 058, 060–062 (fills the 057→059 numbering gap; kill-switch state,
-      retention policy, and demo-seed support tables)
-- [ ] Real attestation crypto (see Circle 3)
-- [ ] Verified Fitbit ingestion (see Circle 3)
-- [ ] Persisted kill switch (DB-backed refund-only mode surviving restart; replaces the
-      static boolean in `jurisdiction-disposition.mapper.ts`)
-- [ ] Data-retention scheduler (automated purge per retention policy, complementing the
-      existing 4 AM GDPR erasure sweep in `src/api/src/modules/users/gdpr.scheduler.ts`)
-- [ ] Demo seed + KYC / practitioner / circles pages in `src/web/app`
+### Wired/added in #845:
+- [x] `SecurityModule` registered in `app.module.ts`; `AmlController` registered in
+      `compliance.module.ts`; `PractitionerIntelligenceService` provided in
+      `behavioral.module.ts` — all `/security/*`, `/compliance/aml/*` and practitioner
+      routes are now reachable (verified live, including the 403 denial paths)
+- [x] Migrations 058, 060–062 (fills the 057→059 numbering gap; kill-switch state,
+      retention policy, practitioner and Fitbit OAuth tables)
+- [x] Migrations 063–065 — schema-drift reconciliation; `063` recovers columns that
+      existed only in `schema.sql` and never in the migration chain, `064` adds
+      `proofs.content_type`/`description`/`uploaded_at` and `attestations.source`
+      (whose absence was breaking proof submission and the Fury queue on `main`),
+      `065` drops the DECO plaintext columns
+- [x] Real attestation crypto (see Circle 3)
+- [x] Verified Fitbit ingestion (see Circle 3)
+- [x] Persisted kill switch — DB-backed refund-only mode replacing the static boolean
+      in `jurisdiction-disposition.mapper.ts`; survives a process kill (verified)
+- [x] Data-retention scheduler — automated purge per retention policy, complementing
+      the 4 AM GDPR erasure sweep in `src/api/src/modules/users/gdpr.scheduler.ts`
+- [x] Demo seed + KYC / practitioner / circles pages in `src/web/app`
+
+### Added in #847:
+- [x] Demo jurisdiction substrate — all twelve demo users placed across the three
+      geofencing tiers, and `fbo_accounts` seeded. Without it `/admin/jurisdictions`
+      rendered every user as an identical TIER_3 fallback, CCPA deletion returned 403
+      for everyone (it gates on `compliance_metadata.state = 'CA'`, and no user had a
+      state), and FBO routing was inert against an empty table
+- [x] Fixed a state-match collision in `fbo-account.service.ts`: a bare
+      `SPLIT_PART(x, '-', 2)` returns `''` for undelimited values, so `US` and `CA`
+      compared equal — the country-level fallback account matched *every* state.
+      Only visible once real rows existed
+
+### Remaining engineering — one open decision:
+- [ ] `FboAccountService` has **zero consumers**. It is registered and exported in
+      `payments.module.ts`, has a passing spec, and is called by nothing.
+      `SettlementService` operates on internal ledger accounts
+      (`debit_account_id`/`credit_account_id`); this service maps to external Stripe
+      *connected* accounts. Wiring them together means deciding that payouts route
+      through jurisdiction-partitioned custody — a compliance and architecture call
+      that changes money movement, not a defect to patch. #847 made the data and the
+      query correct so the decision is cheap to act on either way.
 
 ### Remaining (human-gated — cannot be closed by engineering):
 - [ ] Legal defense whitepaper counsel review — review-ready draft now at
@@ -188,6 +263,21 @@ CCPA/AML as "Remaining." What actually remained was wiring, which this branch do
 
 ---
 
+## Running the demo
+
+Every circle has a reachable surface. `scripts/demo/README.md` is the operator's guide —
+boot sequence (including a no-Docker local-Postgres path), the twelve demo logins, and
+what to look at on each page. `/circles` is the public index that walks Alpha → Omega
+and links each one.
+
+Ordering is load-bearing: **migrate → base seed (`src/api/database/seed.sql`) → circles
+seed (`scripts/demo/seed-circles.sql`)**. The circles seed references base-seed system
+accounts, so running it first fails on a foreign key. Never provision from `schema.sql` —
+it is a reference snapshot, and an initdb-provisioned database causes the migration
+runner to baseline-stamp (skip) the rest of the chain.
+
+---
+
 ## Execution Strategy
 1. **Circle 1 first** - merge everything, get a clean baseline
 2. **Circle 2 in parallel** - start P0 blockers while PRs are merging
@@ -196,6 +286,11 @@ CCPA/AML as "Remaining." What actually remained was wiring, which this branch do
 5. **Previous circles improve** - while building Circle 3, Circle 2 gets hardening/bugfixes
 6. **(Added 2026-07-30)** A circle's checkbox is only ✅ when code is written, tested,
    AND wired into a reachable surface — merged-but-unregistered modules do not count.
+7. **(Added 2026-07-30)** For anything touching SQL, "tested" means **executed against a
+   real database**. Every spec in this repo mocks the pg `Pool`, so a green suite proves
+   the TypeScript is consistent with itself and nothing about whether the query runs.
+   Twelve columns that did not exist, and a jurisdiction match that compared `US` equal
+   to `CA`, all shipped under passing tests.
 
 ---
 

--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -63,7 +63,7 @@ Verified path on a machine with Homebrew Postgres and no Docker:
 ```bash
 createdb styx_demo
 cd src/api
-DATABASE_URL=postgresql://localhost:5432/styx_demo npm run migrate   # 68 migrations
+DATABASE_URL=postgresql://localhost:5432/styx_demo npm run migrate   # 70 migrations
 psql styx_demo -f database/seed.sql
 psql styx_demo -f ../../scripts/demo/seed-circles.sql
 ```

--- a/scripts/demo/seed-circles.sql
+++ b/scripts/demo/seed-circles.sql
@@ -115,10 +115,26 @@ UPDATE users SET alias = v.alias FROM (VALUES
 -- Both columns are written because the codebase reads two different sources:
 -- geofencing persists last_known_state, CCPA reads compliance_metadata.state.
 -- Seeding only one leaves the other half of Circle 5 dark.
+--
+-- INITIALIZE, NEVER OVERWRITE. This is a live-database seed the README promises
+-- is safe to re-run, and last_known_state is not a demo-owned field:
+-- compliance-policy.service.ts persists the caller's real state on every
+-- request (evaluateUserComplianceForRequest). Assigning unconditionally would
+-- reset a demo user who has since been geofenced elsewhere back to the
+-- hard-coded value here, and silently route their contracts to the stale
+-- jurisdiction's FBO account. Each field is therefore set only when it is
+-- absent, and the two are guarded independently because they drift apart —
+-- CCPA's opt-out path writes compliance_metadata without touching
+-- last_known_state.
 UPDATE users SET
-  last_known_state = v.state,
-  compliance_metadata = COALESCE(compliance_metadata, '{}'::jsonb)
-                        || jsonb_build_object('state', v.state)
+  last_known_state = COALESCE(users.last_known_state, v.state),
+  compliance_metadata =
+    CASE
+      WHEN COALESCE(users.compliance_metadata, '{}'::jsonb) ? 'state'
+        THEN users.compliance_metadata
+      ELSE COALESCE(users.compliance_metadata, '{}'::jsonb)
+           || jsonb_build_object('state', COALESCE(users.last_known_state, v.state))
+    END
 FROM (VALUES
   -- TIER_1 (full access) — the flagship demo paths
   ('d1000000-0000-0000-0000-000000000001'::uuid, 'CA'),  -- river   — CCPA demo subject
@@ -138,15 +154,17 @@ FROM (VALUES
 ) AS v(id, state)
 WHERE users.id = v.id
   -- Never write to an erased user. CcpaService.runErasureStatements sets
-  -- last_known_state = NULL, compliance_metadata = '{}' and status = 'DELETED';
-  -- without this guard the predicate below matches every erased demo user
-  -- (NULL IS DISTINCT FROM 'CA' is true) and a re-run would restore both
-  -- location fields, partially reversing a completed CCPA deletion. Seeding
-  -- the CA residents is what made that path reachable in the first place, so
-  -- this guard has to land with it.
+  -- last_known_state = NULL, compliance_metadata = '{}' and status = 'DELETED'.
+  -- Initialize-only semantics are not enough on their own here: erasure leaves
+  -- both fields exactly as "absent" as a fresh row, so without this guard a
+  -- re-run would refill them and partially reverse a completed CCPA deletion.
+  -- Seeding the CA residents is what made that path reachable in the first
+  -- place, so this guard has to land with it.
   AND users.status <> 'DELETED'
-  AND (users.last_known_state IS DISTINCT FROM v.state
-       OR compliance_metadata ->> 'state' IS DISTINCT FROM v.state);
+  -- Only touch rows that are actually missing something, so a settled database
+  -- reports zero updated rows instead of rewriting identical values.
+  AND (users.last_known_state IS NULL
+       OR NOT (COALESCE(users.compliance_metadata, '{}'::jsonb) ? 'state'));
 
 -- ---------------------------------------------------------------------------
 -- FBO custody accounts (Circle 5 — Stripe for-benefit-of routing)

--- a/scripts/demo/seed-circles.sql
+++ b/scripts/demo/seed-circles.sql
@@ -93,6 +93,74 @@ UPDATE users SET alias = v.alias FROM (VALUES
   ('d1000000-0000-0000-0000-00000000000c'::uuid, 'Acheron HR Lead')
 ) AS v(id, alias) WHERE users.id = v.id AND users.alias IS DISTINCT FROM v.alias;
 
+-- ---------------------------------------------------------------------------
+-- Jurisdiction placement (users.last_known_state + compliance_metadata.state)
+-- ---------------------------------------------------------------------------
+-- Without this every demo user sits at NULL, and three Circle-5 surfaces go
+-- quiet in ways that look like working software:
+--   * /admin/jurisdictions renders one undifferentiated TIER_3 blob, because
+--     compliance-policy.service.ts falls back to TIER_3 for a missing state.
+--   * POST /users/me/ccpa/deletion-request always 403s — ccpa.service.ts gates
+--     on compliance_metadata.state = 'CA' (CCPA rights attach to California
+--     residents), so with no state nobody can ever exercise it.
+--   * fbo-account.service.ts joins users.last_known_state to
+--     fbo_accounts.jurisdiction; against NULL the join never matches and every
+--     contract silently takes the 'US' fallback, hiding the routing entirely.
+--
+-- The spread deliberately covers all three tiers from services/geofencing.ts so
+-- the jurisdiction console shows real contrast: TIER_1 full access, TIER_2
+-- refund-only (NY), TIER_3 blocked (WA). The two blocked/restricted users are
+-- non-pod consumers, so no seeded contract flow depends on them.
+--
+-- Both columns are written because the codebase reads two different sources:
+-- geofencing persists last_known_state, CCPA reads compliance_metadata.state.
+-- Seeding only one leaves the other half of Circle 5 dark.
+UPDATE users SET
+  last_known_state = v.state,
+  compliance_metadata = COALESCE(compliance_metadata, '{}'::jsonb)
+                        || jsonb_build_object('state', v.state)
+FROM (VALUES
+  -- TIER_1 (full access) — the flagship demo paths
+  ('d1000000-0000-0000-0000-000000000001'::uuid, 'CA'),  -- river   — CCPA demo subject
+  ('d1000000-0000-0000-0000-000000000002'::uuid, 'TX'),  -- ash
+  ('d1000000-0000-0000-0000-000000000003'::uuid, 'FL'),  -- juno
+  ('d1000000-0000-0000-0000-000000000004'::uuid, 'IL'),  -- wren
+  ('d1000000-0000-0000-0000-000000000005'::uuid, 'CA'),  -- sage    — second CA resident
+  -- TIER_2 (refund-only) and TIER_3 (blocked) — non-pod, nothing depends on them
+  ('d1000000-0000-0000-0000-000000000006'::uuid, 'NY'),  -- indigo  — REFUND_ONLY
+  ('d1000000-0000-0000-0000-000000000007'::uuid, 'WA'),  -- marlow  — BLOCKED
+  -- Furies, practitioner, enterprise admin
+  ('d1000000-0000-0000-0000-000000000008'::uuid, 'CA'),  -- alecto
+  ('d1000000-0000-0000-0000-000000000009'::uuid, 'TX'),  -- megaera
+  ('d1000000-0000-0000-0000-00000000000a'::uuid, 'OH'),  -- tisiphone
+  ('d1000000-0000-0000-0000-00000000000b'::uuid, 'CA'),  -- dr.moira
+  ('d1000000-0000-0000-0000-00000000000c'::uuid, 'CA')   -- hr.lead
+) AS v(id, state)
+WHERE users.id = v.id
+  AND (users.last_known_state IS DISTINCT FROM v.state
+       OR compliance_metadata ->> 'state' IS DISTINCT FROM v.state);
+
+-- ---------------------------------------------------------------------------
+-- FBO custody accounts (Circle 5 — Stripe for-benefit-of routing)
+-- ---------------------------------------------------------------------------
+-- fbo-account.service.ts routes a contract to the account whose jurisdiction
+-- matches the owner's state, and falls back to getActiveAccount('US'). The
+-- table shipped empty, so both halves returned null and the routing was
+-- untestable against demo data.
+--
+-- Jurisdictions are registered as ISO-3166-2 subdivisions ('US-CA') while
+-- geofencing persists bare state codes ('CA'); the service normalizes on the
+-- suffix. Seeding both shapes plus the bare 'US' fallback exercises every
+-- branch of that join.
+INSERT INTO fbo_accounts (id, platform_account_id, platform_name, jurisdiction, is_active, deactivated_at) VALUES
+  ('fb000000-0000-0000-0000-000000000001', 'acct_demo_fbo_us_ca', 'STRIPE', 'US-CA', TRUE,  NULL),
+  ('fb000000-0000-0000-0000-000000000002', 'acct_demo_fbo_us_tx', 'STRIPE', 'US-TX', TRUE,  NULL),
+  ('fb000000-0000-0000-0000-000000000003', 'acct_demo_fbo_us_ny', 'STRIPE', 'US-NY', TRUE,  NULL),
+  ('fb000000-0000-0000-0000-000000000004', 'acct_demo_fbo_us',    'STRIPE', 'US',    TRUE,  NULL),
+  -- A deactivated account so "is_active = FALSE is skipped" is visible, not assumed.
+  ('fb000000-0000-0000-0000-000000000005', 'acct_demo_fbo_us_wa', 'STRIPE', 'US-WA', FALSE, NOW() - INTERVAL '9 days')
+ON CONFLICT DO NOTHING;
+
 -- Enterprise seats (admin seat + member seats for the Acheron employees)
 INSERT INTO enterprise_seats (id, enterprise_id, user_id, seat_type, active) VALUES
   ('e5100000-0000-0000-0000-000000000001', 'e0000000-0000-0000-0000-000000000001', 'd1000000-0000-0000-0000-00000000000c', 'ADMIN',  TRUE),

--- a/scripts/demo/seed-circles.sql
+++ b/scripts/demo/seed-circles.sql
@@ -137,6 +137,14 @@ FROM (VALUES
   ('d1000000-0000-0000-0000-00000000000c'::uuid, 'CA')   -- hr.lead
 ) AS v(id, state)
 WHERE users.id = v.id
+  -- Never write to an erased user. CcpaService.runErasureStatements sets
+  -- last_known_state = NULL, compliance_metadata = '{}' and status = 'DELETED';
+  -- without this guard the predicate below matches every erased demo user
+  -- (NULL IS DISTINCT FROM 'CA' is true) and a re-run would restore both
+  -- location fields, partially reversing a completed CCPA deletion. Seeding
+  -- the CA residents is what made that path reachable in the first place, so
+  -- this guard has to land with it.
+  AND users.status <> 'DELETED'
   AND (users.last_known_state IS DISTINCT FROM v.state
        OR compliance_metadata ->> 'state' IS DISTINCT FROM v.state);
 

--- a/src/api/src/modules/payments/fbo-account.service.spec.ts
+++ b/src/api/src/modules/payments/fbo-account.service.spec.ts
@@ -153,6 +153,44 @@ describe('FboAccountService', () => {
       expect(result?.platformAccountId).toBe('acct_ny');
     });
 
+    it('normalizes undelimited jurisdictions to themselves so the country-level account cannot match a state', async () => {
+      // Regression guard for a collision that only shows up against real rows,
+      // which this suite cannot see because it mocks the pool.
+      //
+      // SPLIT_PART(x, '-', 2) returns '' for any value without a delimiter, so a
+      // bare 'US' jurisdiction and a bare 'CA' state both collapse to '' and
+      // compare equal. That made the country-level fallback account match every
+      // state, and would let a 'CA' (Canada) jurisdiction match a Texas
+      // resident — silently defeating jurisdiction-specific custody routing.
+      //
+      // The fix wraps each side in COALESCE(NULLIF(SPLIT_PART(...), ''), x), so
+      // undelimited values stay as themselves. Asserted on the SQL text because
+      // the comparison happens in Postgres, not in TypeScript.
+      mockPool.query.mockResolvedValue({ rows: [] });
+
+      await service.getAccountForContract('contract-collision');
+
+      const sql: string = mockPool.query.mock.calls[0][0];
+
+      for (const column of ['fa.jurisdiction', 'u.last_known_state']) {
+        expect(sql).toContain(
+          `COALESCE(NULLIF(SPLIT_PART(${column}, '-', 2), ''), ${column})`,
+        );
+      }
+
+      // Every SPLIT_PART must sit inside a NULLIF; a bare one reintroduces the
+      // collision, so the two counts have to match exactly.
+      const occurrences = (haystack: string, needle: string) =>
+        haystack.split(needle).length - 1;
+      expect(occurrences(sql, 'SPLIT_PART(')).toBe(
+        occurrences(sql, 'NULLIF(SPLIT_PART('),
+      );
+
+      // Deterministic pick: without ORDER BY, LIMIT 1 could return any matching
+      // row depending on the plan.
+      expect(sql).toContain('ORDER BY');
+    });
+
     it('should fall back to the default US account when no jurisdiction match exists', async () => {
       const now = new Date('2026-01-01T00:00:00Z');
       mockPool.query

--- a/src/api/src/modules/payments/fbo-account.service.spec.ts
+++ b/src/api/src/modules/payments/fbo-account.service.spec.ts
@@ -186,9 +186,14 @@ describe('FboAccountService', () => {
         occurrences(sql, 'NULLIF(SPLIT_PART('),
       );
 
-      // Deterministic pick: without ORDER BY, LIMIT 1 could return any matching
-      // row depending on the plan.
-      expect(sql).toContain('ORDER BY');
+      // Deterministic pick, newest-first. Without ORDER BY, LIMIT 1 could return
+      // any matching row depending on the plan. The direction matters too: the
+      // schema does not enforce one active account per jurisdiction, so the
+      // normal rotation sequence (register the replacement, then deactivate the
+      // old one) leaves both active for a window, and ascending order would
+      // route contracts to the account about to be retired.
+      expect(sql).toContain('ORDER BY fa.created_at DESC');
+      expect(sql).not.toContain('ORDER BY fa.created_at ASC');
     });
 
     it('should fall back to the default US account when no jurisdiction match exists', async () => {

--- a/src/api/src/modules/payments/fbo-account.service.ts
+++ b/src/api/src/modules/payments/fbo-account.service.ts
@@ -103,17 +103,25 @@ export class FboAccountService {
     //
     // The two sides store different formats: geofencing persists bare state
     // codes ('CA'), while FBO accounts are registered per ISO-3166-2
-    // subdivision ('US-CA'). Compare on the normalized suffix so
-    // jurisdiction-specific custody routing is not silently bypassed.
+    // subdivision ('US-CA'). Both are normalized to the subdivision code before
+    // comparison so jurisdiction-specific custody routing is not bypassed.
+    //
+    // The normalization must not be written as a bare SPLIT_PART(x, '-', 2):
+    // that returns '' for any value without a delimiter, so 'US' and 'CA' both
+    // collapse to '' and compare equal — which made the country-level fallback
+    // account match every state, and would let a 'CA' (Canada) jurisdiction
+    // match a Texas resident. COALESCE(NULLIF(...), x) keeps undelimited values
+    // as themselves, so 'US' stays 'US' and only ever matches via the explicit
+    // getActiveAccount('US') fallback below.
     const result = await this.pool.query(
       `SELECT fa.id, fa.platform_account_id, fa.platform_name, fa.jurisdiction, fa.is_active, fa.created_at
        FROM contracts c
        JOIN users u ON u.id = c.user_id
        JOIN fbo_accounts fa
-         ON UPPER(SPLIT_PART(fa.jurisdiction, '-', 2)) = UPPER(SPLIT_PART(u.last_known_state, '-', 2))
-         OR UPPER(fa.jurisdiction) = UPPER(u.last_known_state)
-         OR UPPER(SPLIT_PART(fa.jurisdiction, '-', 2)) = UPPER(u.last_known_state)
+         ON UPPER(COALESCE(NULLIF(SPLIT_PART(fa.jurisdiction, '-', 2), ''), fa.jurisdiction))
+          = UPPER(COALESCE(NULLIF(SPLIT_PART(u.last_known_state, '-', 2), ''), u.last_known_state))
        WHERE c.id = $1 AND fa.is_active = TRUE
+       ORDER BY fa.created_at ASC
        LIMIT 1`,
       [contractId],
     );

--- a/src/api/src/modules/payments/fbo-account.service.ts
+++ b/src/api/src/modules/payments/fbo-account.service.ts
@@ -113,6 +113,12 @@ export class FboAccountService {
     // match a Texas resident. COALESCE(NULLIF(...), x) keeps undelimited values
     // as themselves, so 'US' stays 'US' and only ever matches via the explicit
     // getActiveAccount('US') fallback below.
+    //
+    // Newest-first, not oldest-first. The schema does not enforce one active
+    // account per jurisdiction, so the normal rotation sequence — register the
+    // replacement, then deactivate the old one — leaves both rows active for a
+    // window. Ascending order would route contracts to the account that is
+    // about to be retired for exactly as long as that window lasts.
     const result = await this.pool.query(
       `SELECT fa.id, fa.platform_account_id, fa.platform_name, fa.jurisdiction, fa.is_active, fa.created_at
        FROM contracts c
@@ -121,7 +127,7 @@ export class FboAccountService {
          ON UPPER(COALESCE(NULLIF(SPLIT_PART(fa.jurisdiction, '-', 2), ''), fa.jurisdiction))
           = UPPER(COALESCE(NULLIF(SPLIT_PART(u.last_known_state, '-', 2), ''), u.last_known_state))
        WHERE c.id = $1 AND fa.is_active = TRUE
-       ORDER BY fa.created_at ASC
+       ORDER BY fa.created_at DESC
        LIMIT 1`,
       [contractId],
     );

--- a/src/api/src/modules/users/ccpa.scheduler.spec.ts
+++ b/src/api/src/modules/users/ccpa.scheduler.spec.ts
@@ -1,0 +1,69 @@
+import { CcpaScheduler } from './ccpa.scheduler';
+import { CcpaService } from './ccpa.service';
+
+describe('CcpaScheduler', () => {
+  let scheduler: CcpaScheduler;
+  let mockCcpaService: { processPendingDeletions: jest.Mock };
+
+  beforeEach(() => {
+    mockCcpaService = { processPendingDeletions: jest.fn() };
+    scheduler = new CcpaScheduler(mockCcpaService as unknown as CcpaService);
+    jest.clearAllMocks();
+  });
+
+  it('should call ccpaService.processPendingDeletions', async () => {
+    mockCcpaService.processPendingDeletions.mockResolvedValueOnce({
+      processed: 0,
+      skipped: 0,
+    });
+
+    await scheduler.processPendingDeletions();
+
+    expect(mockCcpaService.processPendingDeletions).toHaveBeenCalledTimes(1);
+  });
+
+  it('should log when deletions are processed', async () => {
+    mockCcpaService.processPendingDeletions.mockResolvedValueOnce({
+      processed: 2,
+      skipped: 1,
+    });
+
+    const logSpy = jest.spyOn((scheduler as any).logger, 'log');
+
+    await scheduler.processPendingDeletions();
+
+    expect(logSpy).toHaveBeenCalledWith(
+      'CCPA erasure sweep: processed=2, skipped=1',
+    );
+  });
+
+  it('should not log when no work was done', async () => {
+    mockCcpaService.processPendingDeletions.mockResolvedValueOnce({
+      processed: 0,
+      skipped: 0,
+    });
+
+    const logSpy = jest.spyOn((scheduler as any).logger, 'log');
+
+    await scheduler.processPendingDeletions();
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('should log a sweep that only produced failures', async () => {
+    // skipped > 0 with processed === 0 still has to surface — a sweep that
+    // fails every row must not look identical to a sweep with nothing to do.
+    mockCcpaService.processPendingDeletions.mockResolvedValueOnce({
+      processed: 0,
+      skipped: 4,
+    });
+
+    const logSpy = jest.spyOn((scheduler as any).logger, 'log');
+
+    await scheduler.processPendingDeletions();
+
+    expect(logSpy).toHaveBeenCalledWith(
+      'CCPA erasure sweep: processed=0, skipped=4',
+    );
+  });
+});

--- a/src/api/src/modules/users/ccpa.scheduler.ts
+++ b/src/api/src/modules/users/ccpa.scheduler.ts
@@ -1,0 +1,22 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { CcpaService } from './ccpa.service';
+
+@Injectable()
+export class CcpaScheduler {
+  private readonly logger = new Logger(CcpaScheduler.name);
+
+  constructor(private readonly ccpa: CcpaService) {}
+
+  // 4:30 AM daily — half an hour after the GDPR sweep, so the two erasure
+  // paths never contend for the same rows or the TruthLog append lock.
+  @Cron('30 4 * * *')
+  async processPendingDeletions(): Promise<void> {
+    const result = await this.ccpa.processPendingDeletions();
+    if (result.processed > 0 || result.skipped > 0) {
+      this.logger.log(
+        `CCPA erasure sweep: processed=${result.processed}, skipped=${result.skipped}`,
+      );
+    }
+  }
+}

--- a/src/api/src/modules/users/ccpa.service.spec.ts
+++ b/src/api/src/modules/users/ccpa.service.spec.ts
@@ -238,4 +238,122 @@ describe('CcpaService', () => {
       expect(result?.denialReason).toBe('Legal hold active');
     });
   });
+
+  describe('processPendingDeletions', () => {
+    // Before this sweep existed, processDeletionRequest had no callers at all:
+    // a request was recorded PENDING and nothing ever ran the erasure, which
+    // reports success while retaining the data past the CCPA §1798.130(a)(2)
+    // deadline.
+
+    it('selects only PENDING DELETE requests past the grace window, oldest first', async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+
+      const result = await service.processPendingDeletions();
+
+      const [sql, params] = (mockPool.query as jest.Mock).mock.calls[0];
+      expect(sql).toContain("status = 'PENDING'");
+      // OPT_OUT rows are do-not-sell flags, not erasures — sweeping them would
+      // delete the accounts of users who only opted out of data sale.
+      expect(sql).toContain("request_type = 'DELETE'");
+      expect(sql).toContain('requested_at <=');
+      expect(sql).toContain('ORDER BY requested_at ASC');
+      expect(params).toEqual([7]);
+      expect(result).toEqual({ processed: 0, skipped: 0 });
+    });
+
+    it('processes every due request and counts them', async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({
+        rows: [{ id: 'req-1' }, { id: 'req-2' }],
+      });
+      const spy = jest
+        .spyOn(service, 'processDeletionRequest')
+        .mockResolvedValue({} as never);
+
+      const result = await service.processPendingDeletions();
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledWith('req-1');
+      expect(spy).toHaveBeenCalledWith('req-2');
+      expect(result).toEqual({ processed: 2, skipped: 0 });
+      spy.mockRestore();
+    });
+
+    it('keeps sweeping after a failure and never logs the userId or error detail', async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({
+        rows: [{ id: 'req-bad' }, { id: 'req-good' }],
+      });
+      const spy = jest
+        .spyOn(service, 'processDeletionRequest')
+        .mockRejectedValueOnce(new Error('user-123 leaked into the message'))
+        .mockResolvedValueOnce({} as never);
+      const errorSpy = jest.spyOn((service as any).logger, 'error');
+
+      const result = await service.processPendingDeletions();
+
+      // One bad row must not abort the sweep.
+      expect(result).toEqual({ processed: 1, skipped: 1 });
+      expect(spy).toHaveBeenCalledTimes(2);
+
+      // The erasure path does not come back to clean its logs up, so the
+      // message carries a correlation id and the error class only.
+      const logged = errorSpy.mock.calls[0][0] as string;
+      expect(logged).toContain('correlationId=');
+      expect(logged).toContain('error=Error');
+      expect(logged).not.toContain('user-123');
+      expect(logged).not.toContain('leaked into the message');
+      spy.mockRestore();
+    });
+  });
+
+  describe('processDeletionRequest failure recovery', () => {
+    it("returns a failed request to PENDING so the next sweep retries it", async () => {
+      // The 'PROCESSING' stamp is its own statement, outside the erasure
+      // transaction, so a rollback does not undo it. Without this reset a
+      // failed erasure strands the request at 'PROCESSING' forever — the sweep
+      // only picks up 'PENDING', so the data is never deleted and nothing
+      // retries.
+      (mockPool.query as jest.Mock)
+        .mockResolvedValueOnce({
+          rows: [{ user_id: 'user-123', request_type: 'DELETE', requested_at: new Date() }],
+        })
+        .mockResolvedValueOnce({ rows: [] }); // the reset back to PENDING
+
+      mockClient.query.mockImplementation((sql: string) => {
+        if (typeof sql === 'string' && sql.startsWith('BEGIN')) return Promise.resolve({ rows: [] });
+        if (typeof sql === 'string' && sql.startsWith('ROLLBACK')) return Promise.resolve({ rows: [] });
+        return Promise.reject(new Error('erasure blew up'));
+      });
+
+      await expect(service.processDeletionRequest('req-1')).rejects.toThrow('erasure blew up');
+
+      const resetCall = (mockPool.query as jest.Mock).mock.calls.find(
+        ([sql]) => typeof sql === 'string' && sql.includes("SET status = 'PENDING'"),
+      );
+      expect(resetCall).toBeDefined();
+      expect(resetCall[0]).toContain("AND status = 'PROCESSING'");
+      expect(resetCall[1]).toEqual(['req-1']);
+
+      // The transaction must still have been rolled back.
+      expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
+      expect(mockClient.release).toHaveBeenCalled();
+    });
+
+    it('does not let a failed status reset mask the original erasure error', async () => {
+      (mockPool.query as jest.Mock)
+        .mockResolvedValueOnce({
+          rows: [{ user_id: 'user-123', request_type: 'DELETE', requested_at: new Date() }],
+        })
+        .mockRejectedValueOnce(new Error('bookkeeping also failed'));
+
+      mockClient.query.mockImplementation((sql: string) => {
+        if (typeof sql === 'string' && (sql.startsWith('BEGIN') || sql.startsWith('ROLLBACK'))) {
+          return Promise.resolve({ rows: [] });
+        }
+        return Promise.reject(new Error('erasure blew up'));
+      });
+
+      // The caller must see why the erasure failed, not why the cleanup did.
+      await expect(service.processDeletionRequest('req-1')).rejects.toThrow('erasure blew up');
+    });
+  });
 });

--- a/src/api/src/modules/users/ccpa.service.ts
+++ b/src/api/src/modules/users/ccpa.service.ts
@@ -5,6 +5,21 @@ import { createHash, randomUUID } from 'crypto';
 const GENESIS_HASH = '0000000000000000000000000000000000000000000000000000000000000000';
 const TRUTH_LOG_APPEND_LOCK_KEY = 0x57_54_4c_47;
 
+// How long a DELETE request sits before the sweep executes it.
+//
+// CCPA §1798.130(a)(2) gives the business 45 days to respond, which is a
+// ceiling, not a target — the erasure has to have happened by then. This holds
+// the request briefly so a user who submitted by mistake, or whose account is
+// compromised, has a window to contact support before the data is gone, while
+// leaving a wide margin under the statutory deadline.
+//
+// The sibling GDPR path (gdpr.service.ts) uses 30 days for the same reason. 7
+// is chosen here rather than 30 because CCPA's window is 45 days, not the
+// GDPR-style month, so a 30-day hold would leave only 15 days of slack for a
+// failed sweep to be noticed and retried. Adjust with counsel — this is a
+// policy parameter, not a technical constraint.
+const CCPA_DELETION_GRACE_DAYS = 7;
+
 export type CCPADeletionRequest = {
   userId: string;
   requestType: 'DELETE' | 'OPT_OUT';
@@ -90,6 +105,53 @@ export class CcpaService {
     return request;
   }
 
+  /**
+   * Execute every DELETE request that has cleared the grace window.
+   *
+   * Without this, `processDeletionRequest` had no callers at all: a California
+   * resident could submit a deletion request, it was recorded `PENDING`, and
+   * nothing ever ran the erasure. That is worse than an absent feature — it
+   * reports success to the user and to any compliance review while retaining
+   * the data indefinitely, past the CCPA §1798.130(a)(2) deadline.
+   *
+   * Mirrors `GdprService.processPendingDeletions`, including its failure
+   * posture: one bad row must not abort the sweep, and the erasure path never
+   * logs the raw userId or error detail, because the flow does not come back to
+   * clean those logs up. Failures surface as a non-identifying correlation id
+   * plus the error class.
+   *
+   * OPT_OUT requests are deliberately excluded — those are do-not-sell flags,
+   * not erasures, and are handled by `optOutOfSale`.
+   */
+  async processPendingDeletions(): Promise<{ processed: number; skipped: number }> {
+    const pending = await this.pool.query(
+      `SELECT id FROM ccpa_deletion_requests
+       WHERE status = 'PENDING'
+         AND request_type = 'DELETE'
+         AND requested_at <= NOW() - ($1 || ' days')::interval
+       ORDER BY requested_at ASC`,
+      [CCPA_DELETION_GRACE_DAYS],
+    );
+
+    let processed = 0;
+    let skipped = 0;
+
+    for (const row of pending.rows) {
+      try {
+        await this.processDeletionRequest(row.id);
+        processed++;
+      } catch (err) {
+        const correlationId = randomUUID();
+        this.logger.error(
+          `Failed to process CCPA deletion request (correlationId=${correlationId}, error=${err instanceof Error ? err.name : 'Unknown'})`,
+        );
+        skipped++;
+      }
+    }
+
+    return { processed, skipped };
+  }
+
   async processDeletionRequest(requestId: string): Promise<CCPADeletionRequest> {
     const result = await this.pool.query(
       `UPDATE ccpa_deletion_requests SET status = 'PROCESSING' WHERE id = $1 RETURNING *`,
@@ -103,30 +165,54 @@ export class CcpaService {
     const row = result.rows[0];
     const userId = row.user_id;
 
-    if (typeof (this.pool as Partial<Pool>).connect === 'function') {
-      const client: PoolClient = await this.pool.connect();
-      try {
-        await client.query('BEGIN');
-        await this.runErasureStatements(client, userId);
-        await this.appendTruthLogEventWithClient(client, 'CCPA_DELETION_COMPLETED', {
+    // The 'PROCESSING' stamp above is its own statement, outside the erasure
+    // transaction, so a rollback does not undo it. Left alone, a failed erasure
+    // strands the request at 'PROCESSING' forever: the sweep only picks up
+    // 'PENDING', so nothing retries and the user's data is never deleted —
+    // silently blowing the CCPA §1798.130(a)(2) deadline. Returning it to
+    // 'PENDING' is safe precisely because the erasure is transactional: on
+    // failure the data is untouched, so the next sweep can retry cleanly.
+    try {
+      if (typeof (this.pool as Partial<Pool>).connect === 'function') {
+        const client: PoolClient = await this.pool.connect();
+        try {
+          await client.query('BEGIN');
+          await this.runErasureStatements(client, userId);
+          await this.appendTruthLogEventWithClient(client, 'CCPA_DELETION_COMPLETED', {
+            userId,
+            requestId,
+            anonymizedAt: new Date().toISOString(),
+          });
+          await client.query('COMMIT');
+        } catch (e) {
+          // A failed rollback must never mask the error that caused it.
+          try {
+            await client.query('ROLLBACK');
+          } catch {
+            /* swallowed deliberately — the original error is rethrown below */
+          }
+          throw e;
+        } finally {
+          client.release();
+        }
+      } else {
+        await this.runErasureStatements(this.pool, userId);
+        await this.appendTruthLogEvent('CCPA_DELETION_COMPLETED', {
           userId,
           requestId,
           anonymizedAt: new Date().toISOString(),
         });
-        await client.query('COMMIT');
-      } catch (e) {
-        await client.query('ROLLBACK');
-        throw e;
-      } finally {
-        client.release();
       }
-    } else {
-      await this.runErasureStatements(this.pool, userId);
-      await this.appendTruthLogEvent('CCPA_DELETION_COMPLETED', {
-        userId,
-        requestId,
-        anonymizedAt: new Date().toISOString(),
-      });
+    } catch (e) {
+      try {
+        await this.pool.query(
+          `UPDATE ccpa_deletion_requests SET status = 'PENDING' WHERE id = $1 AND status = 'PROCESSING'`,
+          [requestId],
+        );
+      } catch {
+        /* best-effort: never mask the erasure failure with a bookkeeping failure */
+      }
+      throw e;
     }
 
     const completedAt = new Date();

--- a/src/api/src/modules/users/users.module.ts
+++ b/src/api/src/modules/users/users.module.ts
@@ -6,13 +6,21 @@ import { GdprService } from './gdpr.service';
 import { CcpaService } from './ccpa.service';
 import { UsersScheduler } from './users.scheduler';
 import { GdprScheduler } from './gdpr.scheduler';
+import { CcpaScheduler } from './ccpa.scheduler';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { ContractsModule } from '../contracts/contracts.module';
 
 @Module({
   imports: [ScheduleModule.forRoot(), NotificationsModule, forwardRef(() => ContractsModule)],
   controllers: [UsersController],
-  providers: [UsersService, GdprService, CcpaService, UsersScheduler, GdprScheduler],
+  providers: [
+    UsersService,
+    GdprService,
+    CcpaService,
+    UsersScheduler,
+    GdprScheduler,
+    CcpaScheduler,
+  ],
   exports: [UsersService, GdprService, CcpaService],
 })
 export class UsersModule {}


### PR DESCRIPTION
Three Circle-5 surfaces looked healthy and were not actually reachable in the demo, because the substrate they read was never seeded. Fixing that then exposed a real bug in the routing SQL.

## What was dark

All twelve demo users had `last_known_state = NULL` and no `compliance_metadata.state`; `fbo_accounts` was empty. Every consequence was silent:

| Surface | What actually happened |
|---|---|
| `/admin/jurisdictions` | `compliance-policy.service.ts` falls back to `TIER_3` when the state is missing, so all twelve users rendered as hard-blocked for the same reason — one undifferentiated block. |
| `POST /users/me/ccpa/deletion-request` | `ccpa.service.ts` gates on `compliance_metadata.state = CA`. No user had a state, so **the CCPA path could never return anything but 403** — for anyone, ever. |
| FBO custody routing | `fbo-account.service.ts` joins `users.last_known_state` to `fbo_accounts.jurisdiction`. Against an empty table both the join and the `getActiveAccount(US)` fallback returned null. |

My own smoke script had been passing all three, because the expectation lists were wide enough to absorb the failures (`expect: [200, 201, 202, 403]` on the CCPA probe). That is fixed here too.

## The seed

Users are placed across all three tiers from `services/geofencing.ts`, so the jurisdiction console shows real contrast instead of a uniform fallback:

- **TIER_1 (full access)** — river/sage `CA`, ash `TX`, juno `FL`, wren `IL`
- **TIER_2 (refund-only)** — indigo `NY`
- **TIER_3 (blocked)** — marlow `WA`

Both `last_known_state` and `compliance_metadata.state` are written, because the codebase reads **two different sources** for "what state is this user in" — geofencing persists the former, CCPA reads the latter. Seeding one leaves the other half of Circle 5 dark. The restricted and blocked users are non-pod consumers, so no seeded contract flow depends on them.

Five FBO accounts are seeded including one deactivated, so *"`is_active = FALSE` is skipped"* is demonstrated rather than assumed.

## The bug seeding it exposed

The jurisdiction match was written as:

```sql
UPPER(SPLIT_PART(fa.jurisdiction, -, 2)) = UPPER(SPLIT_PART(u.last_known_state, -, 2))
```

`SPLIT_PART` returns `` for any value without a delimiter — so a bare `US` jurisdiction and a bare `CA` state **both collapse to `` and compare equal**. The country-level fallback account matched *every* state, and a `CA` (Canada) jurisdiction would match a Texas resident. That is precisely the silently-bypassed custody routing the surrounding comment warns against, and against an empty table it was invisible. Verified directly in Postgres:

```
UPPER(SPLIT_PART(US,-,2)) = UPPER(SPLIT_PART(CA,-,2))  ->  true
```

Both sides are now normalized with `COALESCE(NULLIF(SPLIT_PART(...), ), x)`, which leaves undelimited values as themselves — `US-CA` → `CA`, `CA` → `CA`, `US` → `US`. The country account is now reachable only through the explicit fallback below the join. An `ORDER BY` was added because `LIMIT 1` over multiple matches was plan-dependent.

**The spec mocks the pool, so it cannot execute SQL and never caught this** — the same systemic blind spot that hid the schema drift in #845. Added a regression guard asserting every `SPLIT_PART` sits inside a `NULLIF`, and mutation-tested it: reintroducing the bare form fails the suite.

## Verification

- Fresh database → 70 migrations → base seed → circles seed: **zero errors**, idempotent on re-run
- Routing resolves `CA→us_ca`, `TX→us_tx`, `NY→us_ny`; `FL`/`IL` fall through to the US account; `WA` falls through because its account is deactivated
- Live circle smoke: **23/23 probes** (was 21/22 with two probes passing on wrong URLs)
- Payments suite: **13/13 files, 123/123 tests**

## One thing left open — a decision, not a defect

`FboAccountService` is registered and exported in `payments.module.ts` but has **zero consumers**. It is dead code with a passing spec. `SettlementService` operates on internal ledger accounts (`debit_account_id`/`credit_account_id`); this service maps to external Stripe *connected* accounts. Wiring them together means deciding that payouts route through jurisdiction-partitioned custody — a compliance/architecture call that changes money movement, not a bug fix. I have made the data and the query correct so the decision is cheap to act on, and left the wiring to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxSMvLhpVcxMJmQBPSKpB9

## Summary by Sourcery

Seed demo jurisdictions and FBO accounts so Circle-5 routing surfaces are exercised correctly, and fix a jurisdiction matching bug in FBO custody routing.

New Features:
- Populate demo users with last_known_state and compliance_metadata.state values across access tiers to enable realistic jurisdiction-based behavior in the demo.
- Seed Stripe FBO accounts for key US jurisdictions plus a country-level and deactivated account to drive custody routing scenarios.

Bug Fixes:
- Correct FBO jurisdiction matching SQL to avoid undelimited country codes colliding with state codes and add deterministic ordering for single-row selection.

Documentation:
- Update demo setup README to reflect the current migration count for initializing the database.

Tests:
- Add a regression test for FBO account routing SQL to ensure proper normalization of jurisdiction and state values, guard against unsafe SPLIT_PART usage, and assert ordered selection behavior.