### PR TITLE
chore(ci): make branch protection one layer, gated on CI instead of bot threads

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -113,12 +113,14 @@ npx tsx scripts/validation/05-behavioral-physics-check.ts  # Algorithm constants
 3. Run `make test` and `npx turbo run lint` locally.
 4. Open a Pull Request into `main` using the PR template — start it as a
    **draft** while iterating, mark **ready for review** when CI is green.
-5. Address review feedback; resolve all conversations.
+5. Address review feedback. Resolving threads is good practice but is **not**
+   required to merge — several review bots open threads automatically and those
+   stay open after they go stale.
 6. Merging requires the **`build_and_test`, CodeQL, and Secret Pattern
-   Detection** checks green, **1+ approval incl. CODEOWNERS**, and the branch
-   up to date. Click **Merge when ready** — the **merge queue** revalidates
-   against the post-merge result and **squash-merges** (the only allowed
-   method). Direct pushes to `main` are blocked.
+   Detection** checks green. Approvals are not required (this repo has a single
+   maintainer, and GitHub does not permit self-approval). **Squash** is the only
+   allowed merge method. Direct pushes to `main` are blocked.
+   Rationale and the full policy: `.github/rulesets/README.md`.
 
 ### PR Checklist
 

--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -30,18 +30,30 @@ To import through the UI instead: Settings → **Rules** → **Rulesets** →
 `.github/workflows/branch-protection.yml` runs it on changes to this directory,
 on pushes to `main`, and weekly.
 
-Reading rulesets requires repo-admin rights, and `administration` is **not** a
-grantable `GITHUB_TOKEN` scope — the default workflow token can never do it. To
-make the CI check authoritative, add a repository secret:
+Every **rule and parameter** in `main.json` is verified with the default
+`GITHUB_TOKEN`, because the rules are read from
+`GET /repos/{owner}/{repo}/rules/branches/{branch}`, which needs no special
+permission.
+
+Two things need repo-admin rights, which `GITHUB_TOKEN` **cannot** be granted
+(`administration` is not a grantable workflow scope):
+
+1. the ruleset's own fields — `enforcement`, `conditions`, `bypass_actors`
+   (a non-admin token gets a redacted copy with these withheld);
+2. whether **classic branch protection** exists — it is enforced as a union with
+   rulesets but does **not** appear in the effective-rules endpoint, so without
+   admin rights its return is undetectable.
+
+To cover both, add a repository secret:
 
 | Secret                    | Value                                                              |
 | ------------------------- | ------------------------------------------------------------------ |
 | `BRANCH_PROTECTION_TOKEN` | Fine-grained PAT scoped to this repo with **Administration: read** |
 
-Without it the job emits a warning and passes, so a missing secret never blocks
-a merge — but drift is then only caught by running `check` locally. The job is
-deliberately **not** a required status check: it reports on repository
-configuration, not on the code in the PR.
+Without it the job still verifies the rules and prints an explicit
+`NOT VERIFIED` list rather than implying full coverage. The job is deliberately
+**not** a required status check: it reports on repository configuration, not on
+the code in the PR, so it must never block a code change.
 
 ## What it enforces
 

--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,48 +1,71 @@
 # Branch protection as code
 
-`main.json` is the GitHub **ruleset** that protects `main`. It is the source of
-truth for branch protection so the policy is reviewable and versioned rather
-than living only in repo settings. See
+`main.json` is the GitHub **ruleset** that protects `main`, and it is the _only_
+layer of protection on this repo (see [One layer, not two](#one-layer-not-two)).
+It is the source of truth so the policy is reviewable and versioned rather than
+living only in repo settings. See
 [`docs/architecture/branching-and-release-strategy.md`](../../docs/architecture/branching-and-release-strategy.md)
 §4 for the rationale.
 
-> GitHub branch protection cannot be set from the repo contents alone — it must
-> be applied to the repository settings once (and re-applied when this file
-> changes). Do it via the UI import or the API below.
+> GitHub cannot read this file from the repo contents — it must be pushed to the
+> API whenever it changes. `scripts/branch-protection.sh` does that, and its
+> `check` mode detects when the live settings have drifted away from this file.
 
-## Apply via UI
-
-Settings → **Rules** → **Rulesets** → **New ruleset** → **Import a ruleset** →
-upload `main.json`.
-
-## Apply / update via API
+## Apply / verify
 
 ```bash
-OWNER=a-organvm
-REPO=peer-audited--behavioral-blockchain
-
-# Create (first time)
-gh api -X POST "repos/$OWNER/$REPO/rulesets" \
-  -H "Accept: application/vnd.github+json" \
-  --input .github/rulesets/main.json
-
-# Update (subsequent changes — replace <id> with the ruleset id)
-gh api -X PUT "repos/$OWNER/$REPO/rulesets/<id>" \
-  -H "Accept: application/vnd.github+json" \
-  --input .github/rulesets/main.json
-
-# List existing rulesets to find the id
-gh api "repos/$OWNER/$REPO/rulesets"
+scripts/branch-protection.sh check   # does live match this file?
+scripts/branch-protection.sh apply   # push this file to GitHub
 ```
+
+`check` runs in CI (`.github/workflows/branch-protection.yml`) on every change to
+this directory and on pushes to `main`. It resolves the ruleset by **name**, so
+deleting and recreating it in the UI does not break the script.
+
+To import through the UI instead: Settings → **Rules** → **Rulesets** →
+**New ruleset** → **Import a ruleset** → upload `main.json`.
 
 ## What it enforces
 
-- No direct pushes / force-pushes / deletion of `main`.
-- PR required: 1+ approval, **CODEOWNERS** review, stale-approval dismissal,
-  conversation resolution; **squash** is the only allowed merge method.
-- Required, strict (up-to-date) status checks: `build_and_test`,
-  `Analyze (javascript-typescript)`, `Secret Pattern Detection`.
-- Linear history + merge queue (squash, all-green grouping).
+- No direct pushes, force-pushes, or deletion of `main`; linear history.
+- A PR is required. **Squash** is the only allowed merge method.
+- Required status checks: `build_and_test`, `Analyze (javascript-typescript)`,
+  `Secret Pattern Detection`.
+- Repo **admins can bypass**, so the owner can never be locked out of their own
+  repository.
+
+Deliberately **not** enforced, and why:
+
+| Not required               | Why                                                                                                                                                                                                                                                            |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Approving reviews          | Solo maintainer. GitHub does not let you approve your own PR, so requiring even one approval makes every PR permanently unmergeable.                                                                                                                           |
+| CODEOWNERS review          | Same reason.                                                                                                                                                                                                                                                   |
+| Conversation resolution    | Three review bots (CodeRabbit, Sourcery, CodeQL) post threads automatically. Those threads stay merge-blocking even after they go `outdated`, so this gates merges on stale bot chatter while carrying no safety signal — reviews themselves are not required. |
+| Strict (up-to-date) checks | Forces every open PR to rebase after each merge to `main`. Real value only with concurrent contributors landing conflicting work.                                                                                                                              |
+| Merge queue                | Same — needs contention to be worth its latency.                                                                                                                                                                                                               |
+
+Promote any of these the moment the repo gains a second regular committer. They
+are the right controls for a team and pure friction for one person.
+
+## One layer, not two
+
+GitHub has **two independent** protection systems — classic _branch protection_
+and _rulesets_ — and enforces the **union** of both. A rule relaxed here stays in
+force if classic protection still sets it, and classic protection is invisible
+from the Rulesets UI.
+
+This is not hypothetical. Until 2026-07-30 this repo had both:
+
+- this file requiring status checks (**never applied** — the live ruleset was a
+  stripped-down copy), and
+- classic protection requiring conversation resolution.
+
+The effective policy was therefore "stale bot threads block merges, but CI does
+not have to pass" — the exact inverse of the intent, and the reason `main` could
+sit red for a week while merges stayed blocked on resolved-but-outdated threads.
+
+**Do not re-add classic branch protection.** `scripts/branch-protection.sh check`
+fails if it reappears.
 
 ## Keeping check names in sync
 
@@ -51,8 +74,15 @@ The `required_status_checks[].context` values must exactly match GitHub
 this file and re-apply, or merges will block forever waiting on a check that
 never reports. Current mapping:
 
-| Context here | Produced by |
-|--------------|-------------|
-| `build_and_test` | `.github/workflows/ci.yml` job `build_and_test` |
-| `Analyze (javascript-typescript)` | `.github/workflows/codeql.yml` |
-| `Secret Pattern Detection` | `.github/workflows/secret-scan.yml` job name |
+| Context here                      | Produced by                                     |
+| --------------------------------- | ----------------------------------------------- |
+| `build_and_test`                  | `.github/workflows/ci.yml` job `build_and_test` |
+| `Analyze (javascript-typescript)` | `.github/workflows/codeql.yml`                  |
+| `Secret Pattern Detection`        | `.github/workflows/secret-scan.yml` job name    |
+
+Verify a context actually reports before adding it:
+
+```bash
+gh pr checks <pr-number>          # names reported on a PR
+gh api repos/{owner}/{repo}/commits/main/check-runs --jq '.check_runs[].name'
+```

--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -18,12 +18,30 @@ scripts/branch-protection.sh check   # does live match this file?
 scripts/branch-protection.sh apply   # push this file to GitHub
 ```
 
-`check` runs in CI (`.github/workflows/branch-protection.yml`) on every change to
-this directory and on pushes to `main`. It resolves the ruleset by **name**, so
-deleting and recreating it in the UI does not break the script.
+Both need a token with **repo-admin** rights; `gh auth login` as the repo owner
+covers it. `check` resolves the ruleset by **name**, so deleting and recreating
+it in the UI does not break the script.
 
 To import through the UI instead: Settings → **Rules** → **Rulesets** →
 **New ruleset** → **Import a ruleset** → upload `main.json`.
+
+### Running `check` in CI
+
+`.github/workflows/branch-protection.yml` runs it on changes to this directory,
+on pushes to `main`, and weekly.
+
+Reading rulesets requires repo-admin rights, and `administration` is **not** a
+grantable `GITHUB_TOKEN` scope — the default workflow token can never do it. To
+make the CI check authoritative, add a repository secret:
+
+| Secret                    | Value                                                              |
+| ------------------------- | ------------------------------------------------------------------ |
+| `BRANCH_PROTECTION_TOKEN` | Fine-grained PAT scoped to this repo with **Administration: read** |
+
+Without it the job emits a warning and passes, so a missing secret never blocks
+a merge — but drift is then only caught by running `check` locally. The job is
+deliberately **not** a required status check: it reports on repository
+configuration, not on the code in the PR.
 
 ## What it enforces
 

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -2,7 +2,13 @@
   "name": "main-protection",
   "target": "branch",
   "enforcement": "active",
-  "bypass_actors": [],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
   "conditions": {
     "ref_name": {
       "include": ["~DEFAULT_BRANCH"],
@@ -17,17 +23,17 @@
       "type": "pull_request",
       "parameters": {
         "required_approving_review_count": 0,
-        "dismiss_stale_reviews_on_push": true,
+        "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": false,
         "require_last_push_approval": false,
-        "required_review_thread_resolution": true,
+        "required_review_thread_resolution": false,
         "allowed_merge_methods": ["squash"]
       }
     },
     {
       "type": "required_status_checks",
       "parameters": {
-        "strict_required_status_checks_policy": true,
+        "strict_required_status_checks_policy": false,
         "do_not_enforce_on_create": false,
         "required_status_checks": [
           { "context": "build_and_test" },

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -28,13 +28,17 @@ on:
     - cron: "0 12 * * 1"
   workflow_dispatch:
 
-# `administration` is NOT a grantable GITHUB_TOKEN scope, so the default token
-# can never read rulesets — reading them requires repo-admin rights. Supply a
-# fine-grained PAT with "Administration: read" as the repository secret
-# BRANCH_PROTECTION_TOKEN to make this job authoritative. Without it the script
-# exits 3 and the job warns rather than failing, so a missing secret never
-# blocks anyone; drift is then caught by the weekly run once the secret exists,
-# or locally via `scripts/branch-protection.sh check`.
+# The rules themselves are read from GET /repos/{o}/{r}/rules/branches/{branch},
+# which needs no special permission — so every rule and parameter in
+# `main.json` is verified here with the default token.
+#
+# Two things still need repo-admin rights, which `GITHUB_TOKEN` cannot be
+# granted (`administration` is not a grantable workflow scope): the ruleset's
+# own fields (enforcement/conditions/bypass_actors), and the presence of classic
+# branch protection — which is enforced as a union with rulesets but does not
+# appear in the effective-rules endpoint. Set BRANCH_PROTECTION_TOKEN to a
+# fine-grained PAT with "Administration: read" to cover both. Without it the run
+# still verifies the rules and prints an explicit NOT VERIFIED list.
 permissions:
   contents: read
 
@@ -59,7 +63,7 @@ jobs:
           set -e
           case "$status" in
             0) echo "::notice::Live branch protection matches .github/rulesets/main.json" ;;
-            3) echo "::warning::Cannot read rulesets — reading them needs repo-admin rights, which GITHUB_TOKEN cannot be granted. Add a fine-grained PAT with 'Administration: read' as the BRANCH_PROTECTION_TOKEN secret to enable this check. Drift not verified; run 'scripts/branch-protection.sh check' locally meanwhile." ;;
+            3) echo "::warning::Could not read the effective branch rules, so nothing was verified. Run 'scripts/branch-protection.sh check' locally as the repo owner." ;;
             *) echo "::error::Live branch protection has drifted from .github/rulesets/main.json. Reconcile with 'scripts/branch-protection.sh apply'."
                exit 1 ;;
           esac

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -28,11 +28,15 @@ on:
     - cron: "0 12 * * 1"
   workflow_dispatch:
 
+# `administration` is NOT a grantable GITHUB_TOKEN scope, so the default token
+# can never read rulesets — reading them requires repo-admin rights. Supply a
+# fine-grained PAT with "Administration: read" as the repository secret
+# BRANCH_PROTECTION_TOKEN to make this job authoritative. Without it the script
+# exits 3 and the job warns rather than failing, so a missing secret never
+# blocks anyone; drift is then caught by the weekly run once the secret exists,
+# or locally via `scripts/branch-protection.sh check`.
 permissions:
   contents: read
-  # Required to read rulesets. If the token is not granted it, the script exits
-  # 3 and this job warns instead of failing.
-  administration: read
 
 jobs:
   drift:
@@ -47,7 +51,7 @@ jobs:
 
       - name: Compare live protection to .github/rulesets/main.json
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set +e
           ./scripts/branch-protection.sh check
@@ -55,7 +59,7 @@ jobs:
           set -e
           case "$status" in
             0) echo "::notice::Live branch protection matches .github/rulesets/main.json" ;;
-            3) echo "::warning::Cannot read rulesets with this token (needs repo admin). Drift not verified — run 'scripts/branch-protection.sh check' locally." ;;
+            3) echo "::warning::Cannot read rulesets — reading them needs repo-admin rights, which GITHUB_TOKEN cannot be granted. Add a fine-grained PAT with 'Administration: read' as the BRANCH_PROTECTION_TOKEN secret to enable this check. Drift not verified; run 'scripts/branch-protection.sh check' locally meanwhile." ;;
             *) echo "::error::Live branch protection has drifted from .github/rulesets/main.json. Reconcile with 'scripts/branch-protection.sh apply'."
                exit 1 ;;
           esac

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,61 @@
+name: Branch Protection Drift
+
+# `.github/rulesets/main.json` is the source of truth for `main`'s protection,
+# but GitHub cannot read it from the repo — it has to be pushed to the API. That
+# gap let the file and the live settings disagree for a week without anyone
+# noticing. This job closes it.
+#
+# Deliberately NOT in the required status checks: it reports on repository
+# configuration, not on the code in the PR, so it must never be the reason a
+# code change cannot merge.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/rulesets/**"
+      - ".github/workflows/branch-protection.yml"
+      - "scripts/branch-protection*"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/rulesets/**"
+      - ".github/workflows/branch-protection.yml"
+      - "scripts/branch-protection*"
+  schedule:
+    # Weekly, so drift introduced through the UI surfaces on its own rather than
+    # waiting for someone to touch the ruleset file.
+    - cron: "0 12 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Required to read rulesets. If the token is not granted it, the script exits
+  # 3 and this job warns instead of failing.
+  administration: read
+
+jobs:
+  drift:
+    name: branch_protection_drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+
+      - name: Compare live protection to .github/rulesets/main.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          ./scripts/branch-protection.sh check
+          status=$?
+          set -e
+          case "$status" in
+            0) echo "::notice::Live branch protection matches .github/rulesets/main.json" ;;
+            3) echo "::warning::Cannot read rulesets with this token (needs repo admin). Drift not verified — run 'scripts/branch-protection.sh check' locally." ;;
+            *) echo "::error::Live branch protection has drifted from .github/rulesets/main.json. Reconcile with 'scripts/branch-protection.sh apply'."
+               exit 1 ;;
+          esac

--- a/docs/architecture/branching-and-release-strategy.md
+++ b/docs/architecture/branching-and-release-strategy.md
@@ -53,35 +53,71 @@ All commits follow [Conventional Commits](https://www.conventionalcommits.org/):
    change history. Merge commits and rebase-merge are disabled.
 4. The squash commit title must be a valid Conventional Commit (the PR title is
    used) so release-drafter categorizes it correctly.
-5. Merging requires **all required checks green**, **1+ approving review
-   including CODEOWNERS**, **all conversations resolved**, and the branch
-   **up to date with `main`** (enforced by the merge queue / strict checks).
+5. Merging requires **all required checks green**. Reviews are welcome but not
+   required, and review threads do not block the merge — see §4 for why.
 
 ### Merge queue
-`main` uses GitHub's **merge queue**. The queue re-runs required checks against
-the post-merge result (`merge_group` event in `ci.yml`), eliminating "green PR
-breaks main because it was behind" races. Authors click *Merge when ready*; the
-queue serializes and validates.
+Not enabled. `ci.yml` still handles the `merge_group` event, so turning the
+queue on is a settings change with no code work. Enable it when concurrent
+contributors start landing conflicting work; with a single committer it adds
+serialization latency and prevents nothing.
 
 ## 4. Branch protection (enforced as code)
 
 Protection for `main` is defined as a GitHub **ruleset** in
-`.github/rulesets/main.json` (import via *Settings → Rules → Rulesets → Import*,
-or `gh api` — see `.github/rulesets/README.md`). It encodes:
+`.github/rulesets/main.json`, applied and verified with
+`scripts/branch-protection.sh` (see `.github/rulesets/README.md`). It encodes:
 
 - Require a pull request before merging — **no direct pushes to `main`**.
-- Require **1+ approving review** + **CODEOWNERS review** + **dismiss stale
-  approvals on new commits** + **require conversation resolution**.
-- Require **status checks to pass** and the branch to be **up to date**
-  (strict). Required contexts:
+- Require **status checks to pass**. Required contexts:
   - `build_and_test` (unit tests + build + lint + validation gates 04/06/07)
   - `Analyze (javascript-typescript)` (CodeQL)
   - `Secret Pattern Detection`
-- Require **linear history** (pairs with squash-merge).
+- Require **linear history** (pairs with squash-merge); **squash** is the only
+  allowed merge method.
 - Block **force-pushes** and **branch deletion** on `main`.
+- Allow **repo admins to bypass**, so the owner cannot be locked out.
 
 Advisory (not required) checks — promote to required once stabilized: `e2e`
 (browser flakiness), `beta_readiness` (needs live infra URLs), `terraform_validate`.
+
+### What is deliberately not required
+
+Approving reviews, CODEOWNERS review, conversation resolution, and strict
+(up-to-date-branch) checks are all **off**. They are team controls, and this repo
+has one committer:
+
+- GitHub does not let you approve your own PR, so requiring an approval would
+  make every PR permanently unmergeable.
+- Three review bots (CodeRabbit, Sourcery, CodeQL) open threads automatically.
+  Those threads keep blocking merges after they go `outdated`, so requiring
+  resolution gates merges on stale bot chatter while carrying no safety signal —
+  the reviews themselves are not required.
+- Strict checks force every open PR to rebase after each merge to `main`, which
+  only pays for itself under concurrent conflicting work.
+
+Restore them when a second regular committer arrives. The protection that
+actually matters for a solo repo is *required status checks*, which is the one
+piece that was missing.
+
+### One protection layer, not two
+
+GitHub has **two independent** systems — classic *branch protection* and
+*rulesets* — and enforces the **union** of both. Classic protection is invisible
+from the Rulesets UI, so a rule relaxed in the ruleset can stay in force with no
+visible cause.
+
+Until 2026-07-30 this repo had both, and they disagreed: this file required
+status checks but had **never been applied** (the live ruleset was a stripped
+copy), while classic protection required conversation resolution. The effective
+policy was "stale bot threads block merges, but CI need not pass" — the inverse
+of the intent, and why `main` could stay red for a week while merges were blocked
+on outdated threads.
+
+Classic protection has been removed. `.github/workflows/branch-protection.yml`
+runs `scripts/branch-protection.sh check` on ruleset changes, on pushes to
+`main`, and weekly; it fails if the live settings drift from this file or if
+classic protection reappears.
 
 ## 5. Environments & promotion flow
 

--- a/scripts/branch-protection-diff.mjs
+++ b/scripts/branch-protection-diff.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * Compare live GitHub branch protection against `.github/rulesets/main.json`.
+ *
+ * Driven by `scripts/branch-protection.sh check`, which supplies the live
+ * ruleset on stdin and signals classic-protection presence via CLASSIC=1.
+ *
+ * Exits 0 when they match, 1 on drift (with a per-field report).
+ */
+import fs from "node:fs";
+
+const specPath = process.argv[2];
+if (!specPath) {
+  console.error(
+    "usage: branch-protection-diff.mjs <spec.json>  (live ruleset JSON on stdin)",
+  );
+  process.exit(2);
+}
+
+const spec = JSON.parse(fs.readFileSync(specPath, "utf8"));
+const live = JSON.parse(fs.readFileSync(0, "utf8"));
+const drift = [];
+
+/**
+ * Order-insensitive canonical form. The API echoes object keys in its own
+ * order, and none of the arrays in a ruleset are order-significant
+ * (`bypass_actors`, `required_status_checks`, `allowed_merge_methods`,
+ * `include`/`exclude`), so both are normalized before comparison. Without this
+ * the check reports drift every run and gets ignored — the failure mode a
+ * drift check exists to prevent.
+ */
+const canon = (v) => {
+  if (Array.isArray(v)) {
+    return v
+      .map(canon)
+      .sort((a, b) => (JSON.stringify(a) < JSON.stringify(b) ? -1 : 1));
+  }
+  if (v && typeof v === "object") {
+    return Object.fromEntries(
+      Object.keys(v)
+        .sort()
+        .map((k) => [k, canon(v[k])]),
+    );
+  }
+  return v;
+};
+
+const show = (v) => JSON.stringify(canon(v));
+const cmp = (path, want, got) => {
+  if (show(want) !== show(got)) {
+    drift.push(`${path}\n    file: ${show(want)}\n    live: ${show(got)}`);
+  }
+};
+
+for (const key of [
+  "name",
+  "target",
+  "enforcement",
+  "conditions",
+  "bypass_actors",
+]) {
+  if (key in spec) cmp(key, spec[key], live[key]);
+}
+
+const liveByType = new Map((live.rules ?? []).map((r) => [r.type, r]));
+for (const want of spec.rules ?? []) {
+  const got = liveByType.get(want.type);
+  if (!got) {
+    drift.push(`rules[${want.type}]\n    file: present\n    live: MISSING`);
+    continue;
+  }
+  liveByType.delete(want.type);
+  // Compare only the parameters the file declares. GitHub echoes back extra
+  // defaults (e.g. required_reviewers: []) that are not policy decisions.
+  for (const [k, v] of Object.entries(want.parameters ?? {})) {
+    cmp(`rules[${want.type}].${k}`, v, (got.parameters ?? {})[k]);
+  }
+}
+for (const type of liveByType.keys()) {
+  drift.push(
+    `rules[${type}]\n    file: absent\n    live: PRESENT (not declared in the file)`,
+  );
+}
+
+if (process.env.CLASSIC === "1") {
+  drift.push(
+    [
+      "classic branch protection on 'main'",
+      "    file: rulesets only (single source of truth)",
+      "    live: PRESENT - GitHub enforces the union of classic protection and",
+      "          rulesets, so this silently overrides the file. Remove it.",
+    ].join("\n"),
+  );
+}
+
+if (drift.length > 0) {
+  console.error(
+    "FAIL: live branch protection has drifted from .github/rulesets/main.json\n",
+  );
+  for (const d of drift) console.error(`  - ${d}\n`);
+  console.error("Reconcile with: scripts/branch-protection.sh apply");
+  process.exit(1);
+}
+
+console.log(
+  `OK: live ruleset "${spec.name}" matches .github/rulesets/main.json`,
+);
+console.log(
+  "OK: no classic branch protection on 'main' (rulesets are the only layer)",
+);

--- a/scripts/branch-protection-diff.mjs
+++ b/scripts/branch-protection-diff.mjs
@@ -21,6 +21,26 @@ const spec = JSON.parse(fs.readFileSync(specPath, "utf8"));
 const live = JSON.parse(fs.readFileSync(0, "utf8"));
 const drift = [];
 
+// A token without repo-admin rights can still GET a ruleset, but receives a
+// *redacted* view: the rules come back while admin-only fields are omitted
+// entirely. Diffing that against the file reports drift on every withheld
+// field — a false alarm that would train everyone to ignore this check.
+//
+// `bypass_actors` is the reliable discriminator: an admin read always includes
+// it, as `[]` when there are none. `undefined` means redacted, not empty.
+if (live.bypass_actors === undefined) {
+  console.error(
+    [
+      "SKIP: the ruleset came back redacted — this token lacks repo-admin rights.",
+      "      Rules were returned but admin-only fields (bypass_actors) were withheld,",
+      "      so drift cannot be determined without reporting false positives.",
+      "      In CI, set BRANCH_PROTECTION_TOKEN to a fine-grained PAT with",
+      "      'Administration: read'. Locally, authenticate as the repo owner.",
+    ].join("\n"),
+  );
+  process.exit(3);
+}
+
 /**
  * Order-insensitive canonical form. The API echoes object keys in its own
  * order, and none of the arrays in a ruleset are order-significant

--- a/scripts/branch-protection-diff.mjs
+++ b/scripts/branch-protection-diff.mjs
@@ -2,52 +2,44 @@
 /**
  * Compare live GitHub branch protection against `.github/rulesets/main.json`.
  *
- * Driven by `scripts/branch-protection.sh check`, which supplies the live
- * ruleset on stdin and signals classic-protection presence via CLASSIC=1.
+ * Driven by `scripts/branch-protection.sh check`, which supplies on stdin:
  *
- * Exits 0 when they match, 1 on drift (with a per-field report).
+ *   { effective: [...],        // GET /repos/{o}/{r}/rules/branches/{branch}
+ *     ruleset:   {...}|null,   // GET /repos/{o}/{r}/rulesets/{id}  (admin only)
+ *     classic:   true|false|null }  // classic protection present / absent / unknown
+ *
+ * `effective` needs no special permission and carries full rule parameters, so
+ * the core policy is verifiable with any token. `ruleset` and `classic` require
+ * repo admin; when they are unavailable the checks that depend on them are
+ * reported as UNVERIFIED rather than silently passed.
+ *
+ * Exits 0 when everything checked matches, 1 on drift, 3 when nothing could be
+ * verified at all.
  */
 import fs from "node:fs";
 
 const specPath = process.argv[2];
 if (!specPath) {
   console.error(
-    "usage: branch-protection-diff.mjs <spec.json>  (live ruleset JSON on stdin)",
+    "usage: branch-protection-diff.mjs <spec.json>  (payload JSON on stdin)",
   );
   process.exit(2);
 }
 
 const spec = JSON.parse(fs.readFileSync(specPath, "utf8"));
-const live = JSON.parse(fs.readFileSync(0, "utf8"));
-const drift = [];
+const { effective, ruleset, classic } = JSON.parse(fs.readFileSync(0, "utf8"));
+const branch = process.env.BRANCH || "the default branch";
 
-// A token without repo-admin rights can still GET a ruleset, but receives a
-// *redacted* view: the rules come back while admin-only fields are omitted
-// entirely. Diffing that against the file reports drift on every withheld
-// field — a false alarm that would train everyone to ignore this check.
-//
-// `bypass_actors` is the reliable discriminator: an admin read always includes
-// it, as `[]` when there are none. `undefined` means redacted, not empty.
-if (live.bypass_actors === undefined) {
-  console.error(
-    [
-      "SKIP: the ruleset came back redacted — this token lacks repo-admin rights.",
-      "      Rules were returned but admin-only fields (bypass_actors) were withheld,",
-      "      so drift cannot be determined without reporting false positives.",
-      "      In CI, set BRANCH_PROTECTION_TOKEN to a fine-grained PAT with",
-      "      'Administration: read'. Locally, authenticate as the repo owner.",
-    ].join("\n"),
-  );
-  process.exit(3);
-}
+const drift = [];
+const unverified = [];
 
 /**
  * Order-insensitive canonical form. The API echoes object keys in its own
  * order, and none of the arrays in a ruleset are order-significant
  * (`bypass_actors`, `required_status_checks`, `allowed_merge_methods`,
- * `include`/`exclude`), so both are normalized before comparison. Without this
- * the check reports drift every run and gets ignored — the failure mode a
- * drift check exists to prevent.
+ * `include`/`exclude`), so both sides are normalized before comparison.
+ * Without this the check would report drift on every run and get ignored —
+ * the failure mode a drift check exists to prevent.
  */
 const canon = (v) => {
   if (Array.isArray(v)) {
@@ -72,21 +64,15 @@ const cmp = (path, want, got) => {
   }
 };
 
-for (const key of [
-  "name",
-  "target",
-  "enforcement",
-  "conditions",
-  "bypass_actors",
-]) {
-  if (key in spec) cmp(key, spec[key], live[key]);
-}
+// --- Rules and their parameters (no special permission required) -------------
 
-const liveByType = new Map((live.rules ?? []).map((r) => [r.type, r]));
+const liveByType = new Map((effective ?? []).map((r) => [r.type, r]));
 for (const want of spec.rules ?? []) {
   const got = liveByType.get(want.type);
   if (!got) {
-    drift.push(`rules[${want.type}]\n    file: present\n    live: MISSING`);
+    drift.push(
+      `rules[${want.type}]\n    file: present\n    live: NOT IN EFFECT on '${branch}'`,
+    );
     continue;
   }
   liveByType.delete(want.type);
@@ -98,20 +84,55 @@ for (const want of spec.rules ?? []) {
 }
 for (const type of liveByType.keys()) {
   drift.push(
-    `rules[${type}]\n    file: absent\n    live: PRESENT (not declared in the file)`,
+    `rules[${type}]\n    file: absent\n    live: IN EFFECT on '${branch}' (not declared in the file)`,
   );
 }
 
-if (process.env.CLASSIC === "1") {
-  drift.push(
-    [
-      "classic branch protection on 'main'",
-      "    file: rulesets only (single source of truth)",
-      "    live: PRESENT - GitHub enforces the union of classic protection and",
-      "          rulesets, so this silently overrides the file. Remove it.",
-    ].join("\n"),
+// --- Ruleset-object fields (admin only) --------------------------------------
+
+if (ruleset && ruleset.bypass_actors !== undefined) {
+  for (const key of [
+    "name",
+    "target",
+    "enforcement",
+    "conditions",
+    "bypass_actors",
+  ]) {
+    if (key in spec) cmp(key, spec[key], ruleset[key]);
+  }
+} else {
+  unverified.push(
+    "enforcement / conditions / bypass_actors — the ruleset object is readable\n" +
+      "    only with repo-admin rights, and a non-admin token receives a redacted\n" +
+      "    copy with those fields withheld.",
   );
 }
+
+// --- Classic branch protection (admin only) ----------------------------------
+//
+// Classic protection is enforced as a union with rulesets but does NOT appear
+// in the effective-rules endpoint (verified empirically), so this is the only
+// way to see it. That makes it the one gap a non-admin token cannot close.
+
+if (classic === true) {
+  drift.push(
+    [
+      `classic branch protection on '${branch}'`,
+      "    file: rulesets only (single source of truth)",
+      "    live: PRESENT - GitHub enforces the union of classic protection and",
+      "          rulesets, and classic rules are invisible from the Rulesets UI,",
+      "          so this can silently override the file. Remove it.",
+    ].join("\n"),
+  );
+} else if (classic === null) {
+  unverified.push(
+    "classic branch protection — probing it requires repo-admin rights, and it\n" +
+      "    does not surface in the effective-rules endpoint. If it were re-added,\n" +
+      "    this run could not tell.",
+  );
+}
+
+// --- Report ------------------------------------------------------------------
 
 if (drift.length > 0) {
   console.error(
@@ -122,9 +143,24 @@ if (drift.length > 0) {
   process.exit(1);
 }
 
+const checkedRules = (spec.rules ?? []).length;
+if (checkedRules === 0 && unverified.length > 0) {
+  console.error("SKIP: nothing could be verified.");
+  process.exit(3);
+}
+
 console.log(
-  `OK: live ruleset "${spec.name}" matches .github/rulesets/main.json`,
+  `OK: ${checkedRules} rule(s) in effect on '${branch}' match .github/rulesets/main.json`,
 );
+if (unverified.length > 0) {
+  console.log("\nNOT VERIFIED by this run:");
+  for (const u of unverified) console.log(`  - ${u}`);
+  console.log(
+    "\n  Set BRANCH_PROTECTION_TOKEN (fine-grained PAT, 'Administration: read')\n" +
+      "  in CI, or run this locally as the repo owner, to cover them.",
+  );
+  process.exit(0);
+}
 console.log(
-  "OK: no classic branch protection on 'main' (rulesets are the only layer)",
+  `OK: no classic branch protection on '${branch}' (rulesets are the only layer)`,
 );

--- a/scripts/branch-protection.sh
+++ b/scripts/branch-protection.sh
@@ -35,12 +35,31 @@ NAME="$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(proc
 
 # Resolve the ruleset by name, not by a hardcoded id, so the script survives a
 # delete-and-recreate in the GitHub UI.
+#
+# Listing rulesets requires repo-admin rights. An under-permissioned token gets
+# a 403, which must not be mistaken for "the ruleset does not exist" — that
+# would report drift where there is none. Sets RULESET_ID (possibly empty) and
+# returns 3 when the API itself is unreadable.
 ruleset_id() {
-  gh api "repos/$REPO/rulesets" --jq ".[] | select(.name==\"$NAME\") | .id" 2>/dev/null | head -1
+  local list
+  if ! list="$(gh api "repos/$REPO/rulesets" 2>/dev/null)"; then
+    return 3
+  fi
+  RULESET_ID="$(printf %s "$list" | NAME="$NAME" node -e '
+    const rs = JSON.parse(require("fs").readFileSync(0, "utf8"));
+    const hit = rs.find((r) => r.name === process.env.NAME);
+    process.stdout.write(hit ? String(hit.id) : "");
+  ')"
 }
 
 cmd_apply() {
-  local id; id="$(ruleset_id)"
+  local id rc=0
+  ruleset_id || rc=$?
+  if [ "$rc" -eq 3 ]; then
+    echo "FAIL: cannot list rulesets on $REPO — this needs a token with repo-admin rights." >&2
+    exit 3
+  fi
+  id="$RULESET_ID"
   if [ -n "$id" ]; then
     echo "Updating ruleset '$NAME' (id=$id) on $REPO"
     gh api -X PUT "repos/$REPO/rulesets/$id" --input "$SPEC" >/dev/null
@@ -59,15 +78,25 @@ cmd_apply() {
 }
 
 cmd_check() {
-  local id live
-  id="$(ruleset_id)"
+  local id live rc=0
+  ruleset_id || rc=$?
+  if [ "$rc" -eq 3 ]; then
+    echo "SKIP: cannot read rulesets on $REPO." >&2
+    echo "      Reading them requires repo-admin rights, which GITHUB_TOKEN cannot" >&2
+    echo "      be granted ('administration' is not a grantable workflow scope)." >&2
+    echo "      In CI, set the BRANCH_PROTECTION_TOKEN secret to a fine-grained PAT" >&2
+    echo "      with 'Administration: read'." >&2
+    exit 3
+  fi
+
+  id="$RULESET_ID"
   if [ -z "$id" ]; then
     echo "FAIL: no ruleset named '$NAME' on $REPO — run: scripts/branch-protection.sh apply" >&2
     exit 1
   fi
 
   if ! live="$(gh api "repos/$REPO/rulesets/$id" 2>/dev/null)"; then
-    echo "SKIP: cannot read rulesets on $REPO (token lacks 'administration: read')." >&2
+    echo "SKIP: cannot read ruleset $id on $REPO (insufficient permissions)." >&2
     exit 3
   fi
 

--- a/scripts/branch-protection.sh
+++ b/scripts/branch-protection.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Branch protection as code — apply it, and detect drift from it.
+#
+# `.github/rulesets/main.json` is the single source of truth for `main`'s
+# protection. GitHub cannot read that file from the repo contents, so it has to
+# be pushed to the API. This script pushes it (`apply`) and verifies the live
+# settings still match it (`check`).
+#
+# `check` also fails when *classic* branch protection exists on `main`. Classic
+# protection and rulesets are independent systems and GitHub enforces the union
+# of both, so a leftover classic rule silently overrides anything relaxed here.
+# That is not hypothetical: this repo spent a week requiring stale bot review
+# threads to be resolved (classic) while not requiring CI to pass (neither
+# layer), because the ruleset in this file had never actually been applied.
+#
+# Usage:
+#   scripts/branch-protection.sh check    # compare live settings to the file
+#   scripts/branch-protection.sh apply    # push the file to GitHub
+#
+# Requires: gh (authenticated with repo admin), node.
+# Exit codes: 0 ok · 1 drift · 2 usage/dependency error · 3 cannot read (no admin)
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SPEC="$ROOT/.github/rulesets/main.json"
+
+command -v gh   >/dev/null 2>&1 || { echo "FAIL: gh is not installed"   >&2; exit 2; }
+command -v node >/dev/null 2>&1 || { echo "FAIL: node is not installed" >&2; exit 2; }
+[ -f "$SPEC" ]                  || { echo "FAIL: missing $SPEC"         >&2; exit 2; }
+
+REPO="${REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+NAME="$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")).name)' "$SPEC")"
+
+# Resolve the ruleset by name, not by a hardcoded id, so the script survives a
+# delete-and-recreate in the GitHub UI.
+ruleset_id() {
+  gh api "repos/$REPO/rulesets" --jq ".[] | select(.name==\"$NAME\") | .id" 2>/dev/null | head -1
+}
+
+cmd_apply() {
+  local id; id="$(ruleset_id)"
+  if [ -n "$id" ]; then
+    echo "Updating ruleset '$NAME' (id=$id) on $REPO"
+    gh api -X PUT "repos/$REPO/rulesets/$id" --input "$SPEC" >/dev/null
+  else
+    echo "Creating ruleset '$NAME' on $REPO"
+    gh api -X POST "repos/$REPO/rulesets" --input "$SPEC" >/dev/null
+  fi
+  echo "OK: applied $SPEC"
+
+  if gh api "repos/$REPO/branches/main/protection" >/dev/null 2>&1; then
+    echo "WARN: classic branch protection is also present on 'main'." >&2
+    echo "      GitHub enforces the union of classic protection and rulesets," >&2
+    echo "      so it can silently override this file. Remove it with:" >&2
+    echo "      gh api -X DELETE repos/$REPO/branches/main/protection" >&2
+  fi
+}
+
+cmd_check() {
+  local id live
+  id="$(ruleset_id)"
+  if [ -z "$id" ]; then
+    echo "FAIL: no ruleset named '$NAME' on $REPO — run: scripts/branch-protection.sh apply" >&2
+    exit 1
+  fi
+
+  if ! live="$(gh api "repos/$REPO/rulesets/$id" 2>/dev/null)"; then
+    echo "SKIP: cannot read rulesets on $REPO (token lacks 'administration: read')." >&2
+    exit 3
+  fi
+
+  # Classic protection is the failure mode this check exists to catch: it is
+  # invisible in the ruleset UI but unioned into the effective policy.
+  local classic=0
+  if gh api "repos/$REPO/branches/main/protection" >/dev/null 2>&1; then
+    classic=1
+  fi
+
+  printf %s "$live" | CLASSIC="$classic" node "$ROOT/scripts/branch-protection-diff.mjs" "$SPEC"
+  # node exits non-zero on drift; `set -e` propagates it.
+}
+
+case "${1:-}" in
+  check) cmd_check ;;
+  apply) cmd_apply ;;
+  *) echo "usage: $(basename "$0") {check|apply}" >&2; exit 2 ;;
+esac

--- a/scripts/branch-protection.sh
+++ b/scripts/branch-protection.sh
@@ -2,25 +2,25 @@
 #
 # Branch protection as code — apply it, and detect drift from it.
 #
-# `.github/rulesets/main.json` is the single source of truth for `main`'s
-# protection. GitHub cannot read that file from the repo contents, so it has to
+# `.github/rulesets/main.json` is the single source of truth for the default
+# branch's protection. GitHub cannot read that file from the repo, so it has to
 # be pushed to the API. This script pushes it (`apply`) and verifies the live
 # settings still match it (`check`).
 #
-# `check` also fails when *classic* branch protection exists on `main`. Classic
-# protection and rulesets are independent systems and GitHub enforces the union
-# of both, so a leftover classic rule silently overrides anything relaxed here.
-# That is not hypothetical: this repo spent a week requiring stale bot review
-# threads to be resolved (classic) while not requiring CI to pass (neither
-# layer), because the ruleset in this file had never actually been applied.
+# Why this exists: this repo spent a week enforcing the inverse of its stated
+# policy. The ruleset file required status checks but had never been applied,
+# while a separate classic branch-protection rule required conversation
+# resolution. GitHub enforces the *union* of the two systems and classic
+# protection is invisible from the Rulesets UI, so the effective policy was
+# "stale bot threads block merges, but CI need not pass" — and nothing detected
+# the divergence.
 #
 # Usage:
 #   scripts/branch-protection.sh check    # compare live settings to the file
 #   scripts/branch-protection.sh apply    # push the file to GitHub
 #
-# Requires: gh (authenticated with repo admin), node.
-# Exit codes: 0 ok · 1 drift · 2 usage/dependency error · 3 cannot read (no admin)
-
+# Requires: gh, node. `check` works with any token; `apply` needs repo admin.
+# Exit codes: 0 ok · 1 drift · 2 usage/dependency error · 3 cannot read
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -31,15 +31,14 @@ command -v node >/dev/null 2>&1 || { echo "FAIL: node is not installed" >&2; exi
 [ -f "$SPEC" ]                  || { echo "FAIL: missing $SPEC"         >&2; exit 2; }
 
 REPO="${REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+BRANCH="${BRANCH:-$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)}"
 NAME="$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")).name)' "$SPEC")"
 
-# Resolve the ruleset by name, not by a hardcoded id, so the script survives a
-# delete-and-recreate in the GitHub UI.
-#
-# Listing rulesets requires repo-admin rights. An under-permissioned token gets
-# a 403, which must not be mistaken for "the ruleset does not exist" — that
-# would report drift where there is none. Sets RULESET_ID (possibly empty) and
-# returns 3 when the API itself is unreadable.
+# Resolve the ruleset by name rather than a hardcoded id, so the script survives
+# a delete-and-recreate in the UI. Listing rulesets needs repo admin; a 403 must
+# not be read as "the ruleset does not exist", which would report false drift.
+# Sets RULESET_ID (possibly empty); returns 3 when the list itself is unreadable.
+RULESET_ID=""
 ruleset_id() {
   local list
   if ! list="$(gh api "repos/$REPO/rulesets" 2>/dev/null)"; then
@@ -52,62 +51,68 @@ ruleset_id() {
   ')"
 }
 
+# true / false / null(unknown). A 404 "Branch not protected" is a definitive
+# absence; a 403 only means this token cannot tell, which is not the same thing.
+probe_classic() {
+  local out rc=0
+  out="$(gh api "repos/$REPO/branches/$BRANCH/protection" 2>&1)" || rc=$?
+  if [ "$rc" -eq 0 ]; then echo true; return; fi
+  case "$out" in
+    *"Branch not protected"*) echo false ;;
+    *) echo null ;;
+  esac
+}
+
 cmd_apply() {
-  local id rc=0
+  local rc=0
   ruleset_id || rc=$?
   if [ "$rc" -eq 3 ]; then
-    echo "FAIL: cannot list rulesets on $REPO — this needs a token with repo-admin rights." >&2
+    echo "FAIL: cannot list rulesets on $REPO — apply needs a token with repo-admin rights." >&2
     exit 3
   fi
-  id="$RULESET_ID"
-  if [ -n "$id" ]; then
-    echo "Updating ruleset '$NAME' (id=$id) on $REPO"
-    gh api -X PUT "repos/$REPO/rulesets/$id" --input "$SPEC" >/dev/null
+
+  if [ -n "$RULESET_ID" ]; then
+    echo "Updating ruleset '$NAME' (id=$RULESET_ID) on $REPO"
+    gh api -X PUT "repos/$REPO/rulesets/$RULESET_ID" --input "$SPEC" >/dev/null
   else
     echo "Creating ruleset '$NAME' on $REPO"
     gh api -X POST "repos/$REPO/rulesets" --input "$SPEC" >/dev/null
   fi
   echo "OK: applied $SPEC"
 
-  if gh api "repos/$REPO/branches/main/protection" >/dev/null 2>&1; then
-    echo "WARN: classic branch protection is also present on 'main'." >&2
+  if [ "$(probe_classic)" = "true" ]; then
+    echo "WARN: classic branch protection is also present on '$BRANCH'." >&2
     echo "      GitHub enforces the union of classic protection and rulesets," >&2
     echo "      so it can silently override this file. Remove it with:" >&2
-    echo "      gh api -X DELETE repos/$REPO/branches/main/protection" >&2
+    echo "      gh api -X DELETE repos/$REPO/branches/$BRANCH/protection" >&2
   fi
 }
 
 cmd_check() {
-  local id live rc=0
+  local effective ruleset="null" classic rc=0
+
+  # Effective ruleset-sourced rules for the branch, with full parameters. This
+  # endpoint needs no special permissions, so the core policy is always
+  # verifiable — including in CI with the default GITHUB_TOKEN.
+  if ! effective="$(gh api "repos/$REPO/rules/branches/$BRANCH" 2>/dev/null)"; then
+    echo "FAIL: cannot read effective branch rules for '$BRANCH' on $REPO." >&2
+    exit 3
+  fi
+
+  # Admin-only enrichments: bypass_actors and enforcement live on the ruleset
+  # object, and classic protection is only visible through its own endpoint.
+  # Note: classic protection does NOT appear in the effective-rules endpoint
+  # above (verified empirically), so without admin it cannot be detected at all.
+  # Both are reported as *unverified* rather than silently assumed fine.
   ruleset_id || rc=$?
-  if [ "$rc" -eq 3 ]; then
-    echo "SKIP: cannot read rulesets on $REPO." >&2
-    echo "      Reading them requires repo-admin rights, which GITHUB_TOKEN cannot" >&2
-    echo "      be granted ('administration' is not a grantable workflow scope)." >&2
-    echo "      In CI, set the BRANCH_PROTECTION_TOKEN secret to a fine-grained PAT" >&2
-    echo "      with 'Administration: read'." >&2
-    exit 3
+  if [ "$rc" -eq 0 ] && [ -n "$RULESET_ID" ]; then
+    ruleset="$(gh api "repos/$REPO/rulesets/$RULESET_ID" 2>/dev/null || echo null)"
   fi
+  classic="$(probe_classic)"
 
-  id="$RULESET_ID"
-  if [ -z "$id" ]; then
-    echo "FAIL: no ruleset named '$NAME' on $REPO — run: scripts/branch-protection.sh apply" >&2
-    exit 1
-  fi
-
-  if ! live="$(gh api "repos/$REPO/rulesets/$id" 2>/dev/null)"; then
-    echo "SKIP: cannot read ruleset $id on $REPO (insufficient permissions)." >&2
-    exit 3
-  fi
-
-  # Classic protection is the failure mode this check exists to catch: it is
-  # invisible in the ruleset UI but unioned into the effective policy.
-  local classic=0
-  if gh api "repos/$REPO/branches/main/protection" >/dev/null 2>&1; then
-    classic=1
-  fi
-
-  printf %s "$live" | CLASSIC="$classic" node "$ROOT/scripts/branch-protection-diff.mjs" "$SPEC"
+  BRANCH="$BRANCH" node "$ROOT/scripts/branch-protection-diff.mjs" "$SPEC" <<JSON
+{ "effective": $effective, "ruleset": $ruleset, "classic": $classic }
+JSON
   # node exits non-zero on drift; `set -e` propagates it.
 }
 


### PR DESCRIPTION
## The problem

`main` had **two independent protection systems** stacked, and GitHub enforces the **union** of both:

| Layer | Thread resolution | Status checks | Applied? |
|---|---|---|---|
| `.github/rulesets/main.json` | required | **3 required** | **never** — the live ruleset was a stripped copy |
| Live ruleset `main-protection` | not required | **none** | yes |
| Classic branch protection | **required** | **none** | yes |

Net effective policy: **stale bot review threads block merges, but CI does not have to pass.**

That is the inverse of the intent. It is why `main` could sit red from 2026-07-23 for a week while PRs stayed unmergeable on Codex threads already marked `outdated` — and why #847 needed three manual "Resolve conversation" clicks despite 13/13 checks green.

Classic protection is invisible from the Rulesets UI, so relaxing the ruleset appeared to do nothing.

## Changes

**Collapse to one layer.** Classic branch protection removed. The versioned file is now the whole policy, not half of it.

**Require what actually gates correctness** — `build_and_test`, `Analyze (javascript-typescript)`, `Secret Pattern Detection`. All three verified to report on both `main` and a PR before being required; a required context that never reports blocks merges forever.

**Drop the team controls** — conversation resolution, stale-review dismissal, strict (up-to-date-branch) checks. On a single-committer repo three review bots open threads automatically and keep blocking after they go stale, GitHub forbids self-approval, and strict checks force every open PR to rebase on each merge. Documented as reversible, with the trigger stated: a second regular committer.

**Admins can bypass.** The ruleset reported `current_user_can_bypass: never` with no bypass actors — the owner could be locked out of their own repo.

**Kept:** no direct pushes, no force-push, no deletion, linear history, squash-only.

## Keeping it fixed

The file and the live settings disagreed for a week and nothing noticed. `scripts/branch-protection.sh` now has `apply` and `check`; `.github/workflows/branch-protection.yml` runs `check` on ruleset changes, on pushes to `main`, and weekly.

`check` compares live settings field-by-field against the file (order-insensitively, so it does not cry wolf) and fails if classic protection reappears. Deliberately **not** a required check — it reports on repo configuration, not on the code in the PR, so it must never block a code change.

### Verification

Mutation-tested, all three drift paths:

| Mutation | Result |
|---|---|
| flip `required_review_thread_resolution` in the file | FAIL, names the exact field |
| drop a required status check from the file | FAIL, diffs both lists |
| classic protection present | FAIL, explains the union trap |
| unmodified | PASS |

The policy change is already live and proven end-to-end: #847 merged cleanly under it (`e0bfb84`), no `--admin`, no thread clicks.

## Docs

`.github/rulesets/README.md` rewritten — it claimed approvals, CODEOWNERS review, conversation resolution, and a merge queue, **none** of which were ever configured, and carried a wrong `OWNER` in the apply snippet. Also updated `docs/architecture/branching-and-release-strategy.md` §3–4 and `.github/CONTRIBUTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxSMvLhpVcxMJmQBPSKpB9

## Summary by Sourcery

Define branch protection for main as a single ruleset source of truth and add automation to detect and prevent drift between the repo configuration and the versioned ruleset file.

New Features:
- Introduce scripts to apply the main branch ruleset via API and to compare live protection settings against the versioned ruleset JSON.
- Add a scheduled GitHub Actions workflow that runs drift checks for branch protection and reports discrepancies without blocking merges.

Enhancements:
- Clarify and realign documented branch protection policy to match a single-maintainer workflow, emphasizing required status checks and admin bypass.
- Document the decision to rely on rulesets only (no classic protection) and to treat certain review and merge-queue controls as optional team-level settings.

CI:
- Add a branch protection drift GitHub Actions workflow triggered on relevant file changes, pushes to main, manual dispatch, and a weekly schedule to monitor configuration drift.

Documentation:
- Rewrite ruleset and branching strategy docs to accurately describe the enforced protection model, required checks, and non-required review/queue settings, and update CONTRIBUTING to reflect the simplified merge requirements and non-blocking review threads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution and release guidance to reflect streamlined merge requirements.
  * Clarified branch protection, required checks, administrator bypasses, and ruleset behavior.
  * Added instructions for verifying and applying protection settings.

* **New Features**
  * Added commands to check and apply branch protection configuration.
  * Added automated detection of configuration drift.

* **Configuration**
  * Relaxed review-related merge requirements while retaining required status checks.
  * Enabled controlled administrator bypasses and squash-only merges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->