### PR TITLE
fix(ci): don't hand an admin PAT to PR-controlled code

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -47,7 +47,7 @@ Two things need repo-admin rights, which `GITHUB_TOKEN` **cannot** be granted
    rulesets but does **not** appear in the effective-rules endpoint, so without
    admin rights its return is undetectable.
 
-To cover both, add a repository secret:
+To cover both, add a secret:
 
 | Secret                    | Value                                                              |
 | ------------------------- | ------------------------------------------------------------------ |
@@ -57,6 +57,31 @@ Without it the job still verifies the rules and prints an explicit
 `NOT VERIFIED` list rather than implying full coverage. The job is deliberately
 **not** a required status check: it reports on repository configuration, not on
 the code in the PR, so it must never block a code change.
+
+#### Read this before creating that secret
+
+The drift step executes the **checked-out** `scripts/branch-protection.sh`. Any
+run whose ref an untrusted party controls must therefore not have the PAT in
+scope. The workflow selects it on `push` and `schedule` only — `push` is filtered
+to `main`, and `schedule` always runs from the default branch. `workflow_dispatch`
+is excluded because the dispatcher chooses the ref, and `pull_request` is excluded
+because it runs the PR head's script.
+
+**That expression is not a security boundary against a same-repository PR.** A
+`pull_request` run uses the PR's copy of the workflow file, so its author can edit
+the condition or add a step that names `secrets.BRANCH_PROTECTION_TOKEN` outright.
+Same-repo branch PRs receive repository secrets; only fork PRs are withheld.
+
+So:
+
+- **Solo repo, or every write-access account trusted** — a plain repository secret
+  is fine. That is the situation today, and the PAT is not currently set.
+- **The moment anyone else gets write access** — move it to a **protected
+  environment** secret (Settings → Environments → required reviewers) and add
+  `environment:` to the job. Deployment protection rules gate secret release even
+  when a PR rewrites the workflow, which is the only mechanism here that actually
+  holds. Alternatively, drop the PAT entirely and accept the two `NOT VERIFIED`
+  lines — the rules themselves are still fully checked without it.
 
 ## What it enforces
 

--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -18,9 +18,12 @@ scripts/branch-protection.sh check   # does live match this file?
 scripts/branch-protection.sh apply   # push this file to GitHub
 ```
 
-Both need a token with **repo-admin** rights; `gh auth login` as the repo owner
-covers it. `check` resolves the ruleset by **name**, so deleting and recreating
-it in the UI does not break the script.
+`apply` needs a token with **repo-admin** rights; `gh auth login` as the repo
+owner covers it. `check` verifies every rule and parameter with **any** token —
+admin rights only widen it to cover ruleset metadata and classic branch
+protection (see [Running `check` in CI](#running-check-in-ci)), and without them
+it says so rather than implying full coverage. `check` resolves the ruleset by
+**name**, so deleting and recreating it in the UI does not break the script.
 
 To import through the UI instead: Settings → **Rules** → **Rulesets** →
 **New ruleset** → **Import a ruleset** → upload `main.json`.

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -55,16 +55,28 @@ jobs:
 
       - name: Compare live protection to .github/rulesets/main.json
         env:
-          # On `pull_request` this job runs the PR head's copy of
-          # scripts/branch-protection.sh — code the PR author controls. Handing that
-          # an admin-scoped PAT would let anyone with write access exfiltrate it by
-          # editing the script in a branch. (Fork PRs never receive secrets on
-          # `pull_request`; same-repo branch PRs do.) So PR runs get the scoped,
-          # ephemeral GITHUB_TOKEN, which still verifies every rule and parameter —
-          # it just reports the ruleset metadata and classic-protection checks as
-          # NOT VERIFIED. The PAT is reserved for push / schedule / dispatch, where
-          # the script comes from the branch it is protecting.
-          GH_TOKEN: ${{ github.event_name == 'pull_request' && secrets.GITHUB_TOKEN || secrets.BRANCH_PROTECTION_TOKEN || secrets.GITHUB_TOKEN }}
+          # This step executes the CHECKED-OUT scripts/branch-protection.sh, so the
+          # PAT must only be in scope when that script came from a trusted ref.
+          #
+          #   push      — trigger is filtered to `main`; the script is post-merge.
+          #   schedule  — always runs from the default branch.
+          #   dispatch  — THE RUNNER PICKS THE REF. A collaborator can dispatch this
+          #               against a feature branch carrying a modified script.
+          #   pull_request — runs the PR head's script (fork PRs get no secrets;
+          #               same-repo branch PRs do).
+          #
+          # So the PAT is selected for push and schedule only. The other two get the
+          # scoped, ephemeral GITHUB_TOKEN, which still verifies every rule and
+          # parameter in main.json and simply reports the ruleset metadata and
+          # classic-protection checks as NOT VERIFIED.
+          #
+          # This expression closes the dispatch hole. It is NOT, on its own, a
+          # boundary against a same-repo pull_request: that run uses the PR's copy of
+          # THIS FILE, so its author could edit the expression or add a step naming
+          # the secret directly. Read `.github/rulesets/README.md` before creating
+          # BRANCH_PROTECTION_TOKEN — as a plain repository secret it is only safe
+          # while every account with write access is trusted.
+          GH_TOKEN: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && secrets.BRANCH_PROTECTION_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set +e
           ./scripts/branch-protection.sh check

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -55,7 +55,16 @@ jobs:
 
       - name: Compare live protection to .github/rulesets/main.json
         env:
-          GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_TOKEN || secrets.GITHUB_TOKEN }}
+          # On `pull_request` this job runs the PR head's copy of
+          # scripts/branch-protection.sh — code the PR author controls. Handing that
+          # an admin-scoped PAT would let anyone with write access exfiltrate it by
+          # editing the script in a branch. (Fork PRs never receive secrets on
+          # `pull_request`; same-repo branch PRs do.) So PR runs get the scoped,
+          # ephemeral GITHUB_TOKEN, which still verifies every rule and parameter —
+          # it just reports the ruleset metadata and classic-protection checks as
+          # NOT VERIFIED. The PAT is reserved for push / schedule / dispatch, where
+          # the script comes from the branch it is protecting.
+          GH_TOKEN: ${{ github.event_name == 'pull_request' && secrets.GITHUB_TOKEN || secrets.BRANCH_PROTECTION_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set +e
           ./scripts/branch-protection.sh check


### PR DESCRIPTION
## The problem

The `branch_protection_drift` job runs on `pull_request`. On that event it checks out the **PR head** and executes that head's copy of `scripts/branch-protection.sh` — code the PR author controls — with:

```yaml
GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_TOKEN || secrets.GITHUB_TOKEN }}
```

`BRANCH_PROTECTION_TOKEN` is documented as a fine-grained PAT with **Administration: read**. Anyone with write access could open a branch PR that edits the script to print or POST the token.

Fork PRs never receive secrets on `pull_request`, so this is not remotely exploitable — but **same-repo branch PRs do**, and the secret isn't set yet, which makes this a trap primed to fire the moment it is. It was introduced yesterday in #851.

## The fix

```yaml
GH_TOKEN: ${{ github.event_name == 'pull_request' && secrets.GITHUB_TOKEN || secrets.BRANCH_PROTECTION_TOKEN || secrets.GITHUB_TOKEN }}
```

PR runs get the scoped, ephemeral `GITHUB_TOKEN`. The PAT is reserved for `push` / `schedule` / `workflow_dispatch`, where the script being executed comes from the branch it is protecting.

**Coverage is barely affected.** Every rule and parameter in `main.json` is read from `GET /repos/{o}/{r}/rules/branches/{branch}`, which needs no special permission — that works on a PR either way. Only two things degrade to `NOT VERIFIED` on PRs: the ruleset's own metadata (`enforcement` / `conditions` / `bypass_actors`) and the presence of classic branch protection. Both are still fully checked on every push to `main` and on the weekly run, which is where drift would actually appear — nobody changes repo settings from inside a PR.

The job is not a required check, so nothing about merge gating changes.

## Also

`.github/rulesets/README.md` claimed *"Both need a token with repo-admin rights"*, contradicting its own CI section two paragraphs later. Only `apply` needs admin; `check` verifies the full rule set with any token and says explicitly what it could not cover.

Both found by CodeRabbit reviewing #853.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxSMvLhpVcxMJmQBPSKpB9

## Summary by Sourcery

Prevent CI branch protection checks from exposing an admin-scoped token to pull request-controlled code and clarify token requirements in ruleset documentation.

Bug Fixes:
- Ensure pull_request runs of the branch_protection workflow use the scoped GITHUB_TOKEN instead of the admin PAT to avoid secret exfiltration.

Enhancements:
- Adjust branch_protection workflow token selection so admin PAT is only used on trusted events (push, schedule, workflow_dispatch).

Documentation:
- Update rulesets README to state that only the apply operation requires repo-admin rights and document the actual coverage of check with non-admin tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified token requirements for applying and checking repository rules.
  * Documented permission errors and ruleset resolution by name.

* **Security**
  * Pull request checks now use a restricted token, while admin-scoped access is reserved for trusted workflow runs.
  * Verification reports admin-only checks that cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->