### PR TITLE
feat(demo): a self-explaining guided tour over every route

### DIFF
--- a/docs/demo/jessica-demo-runbook.md
+++ b/docs/demo/jessica-demo-runbook.md
@@ -18,6 +18,31 @@ The launcher creates a random synthetic-only login password outside version cont
 
 The demo data is synthetic. With Docker, reset removes only containers and volumes in the named `styx-demo` Compose project. Without Docker, it uses only the explicitly named local database `styx_demo_styxlaunch` and Redis port `6391`. Neither path selects a hosted environment or payment account.
 
+## The guided tour (self-driving, for five different readers)
+
+The demo explains itself. Every route in the app carries a synced panel on the right with the
+route's truth label, a plain-language summary, and — for anyone past "New to this" — the mechanism
+behind it. Numbered markers anchor to real elements on the page; clicking one says what that element
+is. Arrow keys move between chapters.
+
+This is what lets you, Jessica, an investor, a user tester and someone who has never heard of a
+commitment contract all open the same demo and each get an explanation pitched at them: the
+**Explain it for** control at the bottom of the panel switches depth without changing what is shown.
+The choice is remembered per browser, so five people can be at five different depths simultaneously.
+
+Coverage is enforced, not asserted: `src/web/lib/guided-tour/registry.test.ts` fails if any route in
+`src/web/app` has no entry, if an entry points at a route that no longer exists, or if any summary is
+short enough to be a placeholder. Widening the tour is a data edit in
+`src/web/lib/guided-tour/registry.ts` — the overlay engine knows nothing about any specific route.
+
+Two honest limits to state if asked. The truth labels in the panel are the tour's, sourced from
+`/tour`'s own vocabulary — most routes do not render a label themselves. And a marker whose element
+has moved is dropped silently rather than mispointing, so a UI change degrades the tour instead of
+breaking the demo underneath it.
+
+The tour is compiled out of any build that is not a demo build: it renders only when
+`NEXT_PUBLIC_STYX_GUIDED_TOUR` or `NEXT_PUBLIC_STYX_TEST_MONEY_MODE` is `true` at build time.
+
 ## Rehearsed route
 
 | Moment               | Route / account                           | Truth label                  |

--- a/src/web/app/layout.tsx
+++ b/src/web/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { Providers } from "./providers";
 import { SiteFooter } from "../components/SiteFooter";
+import GuidedTour from "../components/guided-tour/GuidedTour";
 
 export const metadata: Metadata = {
   title: "Styx | Relationship Recovery",
@@ -31,6 +32,9 @@ export default function RootLayout({
         ) : null}
         <Providers><main className="flex-1">{children}</main></Providers>
         <SiteFooter />
+        {/* Demo builds only -- GuidedTour renders nothing unless the guided-tour
+            or test-money flag is set at build time. */}
+        <GuidedTour />
       </body>
     </html>
   );

--- a/src/web/components/guided-tour/GuidedTour.tsx
+++ b/src/web/components/guided-tour/GuidedTour.tsx
@@ -1,0 +1,327 @@
+'use client';
+
+/**
+ * The guided-demo overlay.
+ *
+ * Renders two things over the real product, never a mock of it:
+ *  - a synced side panel explaining the current route, at the depth the viewer
+ *    chose, with the route's truth label always visible; and
+ *  - numbered tooltips anchored to real elements on the page.
+ *
+ * It is inert unless the build is a demo build, so a real user session can never
+ * see it: see isGuidedTourEnabled() below.
+ *
+ * Design constraints worth keeping:
+ *  - The engine knows nothing about any specific route. Everything it renders
+ *    comes from lib/guided-tour/registry.ts, so widening coverage is a data edit.
+ *  - A step whose selector matches nothing is dropped, not rendered as an error.
+ *    A UI change should degrade the tour, never break the demo underneath it.
+ *  - The panel never invents a claim. Its truth label is the registry's, and the
+ *    registry's vocabulary is asserted against /tour by the recorder.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import {
+  PERSONA_ACCOUNTS,
+  TOUR_ORDER,
+  TRUTH_LABEL_TEXT,
+  matchTourRoute,
+  type TourRoute,
+  type TourStep,
+  type TruthLabel,
+} from '../../lib/guided-tour/registry';
+
+/** Audience depth. `layperson` sees the summary only; everyone else sees mechanism too. */
+const AUDIENCES = [
+  { id: 'layperson', label: 'New to this' },
+  { id: 'tester', label: 'User tester' },
+  { id: 'investor', label: 'Investor' },
+  { id: 'operator', label: 'Operator' },
+] as const;
+
+type AudienceId = (typeof AUDIENCES)[number]['id'];
+
+const AUDIENCE_STORAGE_KEY = 'styx.guidedTour.audience';
+const OPEN_STORAGE_KEY = 'styx.guidedTour.open';
+
+const PANEL_WIDTH = 380;
+const PANEL_TAB_WIDTH = 44;
+
+const LABEL_STYLES: Record<TruthLabel, string> = {
+  working: 'border-emerald-500/40 bg-emerald-950/40 text-emerald-300',
+  beta: 'border-amber-500/40 bg-amber-950/40 text-amber-300',
+  future: 'border-sky-500/40 bg-sky-950/40 text-sky-300',
+};
+
+/**
+ * The tour ships only in demo builds. Both flags are inlined at build time, so a
+ * production bundle contains no tour code path that can be switched on at runtime.
+ */
+export function isGuidedTourEnabled(): boolean {
+  return (
+    process.env.NEXT_PUBLIC_STYX_GUIDED_TOUR === 'true' ||
+    process.env.NEXT_PUBLIC_STYX_TEST_MONEY_MODE === 'true'
+  );
+}
+
+/** Resolves a step selector to an element. `text=` matches by visible text. */
+function resolveStepElement(selector: string): HTMLElement | null {
+  if (!selector.startsWith('text=')) {
+    try {
+      return document.querySelector<HTMLElement>(selector);
+    } catch {
+      return null;
+    }
+  }
+  const needle = selector.slice(5).trim().toLowerCase();
+  const candidates = Array.from(
+    document.querySelectorAll<HTMLElement>('h1,h2,h3,h4,p,span,button,a,div,td,th,li'),
+  );
+  // Prefer the smallest element containing the text: the deepest match is the
+  // label itself rather than a wrapper that spans half the page.
+  let best: HTMLElement | null = null;
+  for (const element of candidates) {
+    const text = element.textContent?.trim().toLowerCase();
+    if (!text || !text.includes(needle)) continue;
+    if (element.closest('[data-guided-tour]')) continue;
+    if (!best || text.length < (best.textContent?.trim().length ?? Infinity)) best = element;
+  }
+  return best;
+}
+
+type AnchoredStep = TourStep & { index: number; top: number; left: number };
+
+export default function GuidedTour() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const [open, setOpen] = useState(true);
+  const [audience, setAudience] = useState<AudienceId>('layperson');
+  const [activeStep, setActiveStep] = useState<number | null>(null);
+  const [anchored, setAnchored] = useState<AnchoredStep[]>([]);
+
+  const route = useMemo<TourRoute | undefined>(
+    () => (pathname ? matchTourRoute(pathname) : undefined),
+    [pathname],
+  );
+
+  const position = useMemo(() => {
+    if (!route) return { index: -1, total: TOUR_ORDER.length };
+    return { index: TOUR_ORDER.findIndex((entry) => entry.path === route.path), total: TOUR_ORDER.length };
+  }, [route]);
+
+  useEffect(() => {
+    const storedAudience = window.localStorage.getItem(AUDIENCE_STORAGE_KEY) as AudienceId | null;
+    if (storedAudience && AUDIENCES.some((entry) => entry.id === storedAudience)) {
+      setAudience(storedAudience);
+    }
+    const storedOpen = window.localStorage.getItem(OPEN_STORAGE_KEY);
+    if (storedOpen !== null) setOpen(storedOpen === 'true');
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem(AUDIENCE_STORAGE_KEY, audience);
+  }, [audience]);
+
+  useEffect(() => {
+    window.localStorage.setItem(OPEN_STORAGE_KEY, String(open));
+  }, [open]);
+
+  // Reserve space rather than covering the product. An overlay panel clips the
+  // right-hand column of every wide route -- on /dashboard it hides the Truth Log
+  // entries, which is the one thing the chapter is there to show.
+  useEffect(() => {
+    if (!isGuidedTourEnabled() || !route) return undefined;
+    const previous = document.body.style.paddingRight;
+    document.body.style.paddingRight = open ? `${PANEL_WIDTH}px` : `${PANEL_TAB_WIDTH}px`;
+    return () => {
+      document.body.style.paddingRight = previous;
+    };
+  }, [open, route]);
+
+  // Anchor the markers after the route's own data has had a chance to render,
+  // and keep them attached through scroll and resize.
+  useEffect(() => {
+    setActiveStep(null);
+    if (!route?.steps?.length) {
+      setAnchored([]);
+      return;
+    }
+    let frame = 0;
+    const reposition = () => {
+      const next: AnchoredStep[] = [];
+      route.steps?.forEach((step, index) => {
+        const element = resolveStepElement(step.selector);
+        if (!element) return; // Missing element: drop the marker, keep the route.
+        const rect = element.getBoundingClientRect();
+        if (rect.width === 0 && rect.height === 0) return;
+        next.push({ ...step, index, top: rect.top + window.scrollY, left: rect.left + window.scrollX });
+      });
+      setAnchored(next);
+    };
+    const settle = window.setTimeout(reposition, 700);
+    const onScrollOrResize = () => {
+      window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(reposition);
+    };
+    window.addEventListener('scroll', onScrollOrResize, { passive: true });
+    window.addEventListener('resize', onScrollOrResize);
+    return () => {
+      window.clearTimeout(settle);
+      window.cancelAnimationFrame(frame);
+      window.removeEventListener('scroll', onScrollOrResize);
+      window.removeEventListener('resize', onScrollOrResize);
+    };
+  }, [route, pathname]);
+
+  const go = useCallback(
+    (delta: number) => {
+      if (position.index < 0) return;
+      const next = TOUR_ORDER[position.index + delta];
+      if (next) router.push(next.path.replace(/\[[^\]]+\]/g, 'demo'));
+    },
+    [position.index, router],
+  );
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (target && /^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName)) return;
+      if (event.key === 'ArrowRight') go(1);
+      if (event.key === 'ArrowLeft') go(-1);
+      if (event.key === 'Escape') setActiveStep(null);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [go]);
+
+  if (!isGuidedTourEnabled() || !route) return null;
+
+  const showDetail = audience !== 'layperson';
+  const personaAccount = route.persona === 'none' ? null : PERSONA_ACCOUNTS[route.persona];
+
+  return (
+    <div data-guided-tour="root">
+      {/* Anchored markers over the real UI. */}
+      {anchored.map((step) => (
+        <div
+          key={`${route.path}-${step.index}`}
+          data-guided-tour="marker"
+          style={{ position: 'absolute', top: step.top - 12, left: step.left - 12, zIndex: 2147483000 }}
+        >
+          <button
+            type="button"
+            aria-label={`Explain: ${step.title}`}
+            onClick={() => setActiveStep(activeStep === step.index ? null : step.index)}
+            className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-amber-300 bg-amber-500 text-xs font-black text-black shadow-lg transition hover:scale-110"
+          >
+            {step.index + 1}
+          </button>
+          {activeStep === step.index && (
+            <div className="mt-2 w-72 rounded-2xl border border-amber-500/40 bg-neutral-950 p-4 text-left shadow-2xl">
+              <p className="text-xs font-black uppercase tracking-widest text-amber-300">{step.title}</p>
+              <p className="mt-2 text-sm leading-6 text-neutral-300">{step.body}</p>
+            </div>
+          )}
+        </div>
+      ))}
+
+      {/* The synced panel. */}
+      <aside
+        data-guided-tour="panel"
+        className="fixed bottom-0 right-0 top-0 z-[2147483100] flex w-[380px] max-w-full flex-col border-l border-neutral-800 bg-neutral-950/95 text-white backdrop-blur"
+        style={{ transform: open ? 'translateX(0)' : 'translateX(calc(100% - 44px))', transition: 'transform 200ms' }}
+      >
+        <button
+          type="button"
+          onClick={() => setOpen(!open)}
+          aria-label={open ? 'Collapse the guided tour' : 'Expand the guided tour'}
+          className="absolute left-0 top-1/2 h-24 w-11 -translate-x-full rounded-l-xl border border-r-0 border-neutral-800 bg-neutral-950 text-xs font-black uppercase tracking-widest text-neutral-400"
+        >
+          <span style={{ writingMode: 'vertical-rl' }}>{open ? 'Hide' : 'Tour'}</span>
+        </button>
+
+        <div className="flex-1 overflow-y-auto p-6">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-[11px] font-black uppercase tracking-[0.2em] text-neutral-500">
+              {route.chapter}
+            </span>
+            <span className="text-[11px] font-bold text-neutral-600">
+              {position.index + 1} / {position.total}
+            </span>
+          </div>
+
+          <span
+            className={`mt-4 inline-flex rounded-full border px-3 py-1 text-[11px] font-black uppercase tracking-wider ${LABEL_STYLES[route.label]}`}
+          >
+            {TRUTH_LABEL_TEXT[route.label]}
+          </span>
+
+          <h2 className="mt-4 text-2xl font-black leading-tight tracking-tight">{route.title}</h2>
+          <p className="mt-3 text-[15px] leading-7 text-neutral-300">{route.summary}</p>
+          {showDetail && (
+            <p className="mt-3 border-l-2 border-neutral-800 pl-4 text-sm leading-6 text-neutral-400">
+              {route.detail}
+            </p>
+          )}
+
+          {personaAccount && (
+            <p className="mt-5 rounded-xl border border-neutral-800 bg-neutral-900/60 p-3 text-xs leading-5 text-neutral-400">
+              This chapter is written for the synthetic account{' '}
+              <span className="font-bold text-neutral-200">{personaAccount}</span>. If the page looks
+              empty or asks you to sign in, you are viewing it as someone else.
+            </p>
+          )}
+
+          {anchored.length > 0 && (
+            <p className="mt-5 text-xs leading-5 text-neutral-500">
+              {anchored.length} numbered marker{anchored.length === 1 ? '' : 's'} on this page. Click one
+              to see what that element is.
+            </p>
+          )}
+
+          <div className="mt-6 border-t border-neutral-800 pt-5">
+            <p className="text-[11px] font-black uppercase tracking-[0.2em] text-neutral-500">
+              Explain it for
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {AUDIENCES.map((entry) => (
+                <button
+                  key={entry.id}
+                  type="button"
+                  onClick={() => setAudience(entry.id)}
+                  className={`rounded-full border px-3 py-1.5 text-xs font-bold transition ${
+                    audience === entry.id
+                      ? 'border-white bg-white text-black'
+                      : 'border-neutral-700 text-neutral-400 hover:border-neutral-500'
+                  }`}
+                >
+                  {entry.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 border-t border-neutral-800 p-4">
+          <button
+            type="button"
+            onClick={() => go(-1)}
+            disabled={position.index <= 0}
+            className="rounded-full border border-neutral-700 px-4 py-2 text-sm font-bold text-neutral-300 disabled:opacity-30"
+          >
+            Back
+          </button>
+          <button
+            type="button"
+            onClick={() => go(1)}
+            disabled={position.index < 0 || position.index >= position.total - 1}
+            className="flex-1 rounded-full bg-white px-4 py-2 text-sm font-black text-black disabled:opacity-30"
+          >
+            Next
+          </button>
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/src/web/lib/guided-tour/registry.test.ts
+++ b/src/web/lib/guided-tour/registry.test.ts
@@ -1,0 +1,79 @@
+import { readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+import {
+  CHAPTERS,
+  PERSONA_ACCOUNTS,
+  TOUR_ORDER,
+  TOUR_ROUTES,
+  matchTourRoute,
+} from "./registry";
+
+const APP_DIR = path.resolve(__dirname, "../../app");
+
+/** Every route in the app, as the guided tour would see it in the address bar. */
+function discoverAppRoutes(dir: string = APP_DIR, prefix = ""): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      // Route groups and private folders do not appear in the URL.
+      if (entry.startsWith("_")) continue;
+      const segment = entry.startsWith("(") && entry.endsWith(")") ? "" : `/${decodeURIComponent(entry)}`;
+      found.push(...discoverAppRoutes(full, `${prefix}${segment}`));
+    } else if (entry === "page.tsx") {
+      found.push(prefix === "" ? "/" : prefix);
+    }
+  }
+  return found;
+}
+
+describe("guided tour registry", () => {
+  const appRoutes = discoverAppRoutes().sort();
+
+  // The point of the tour is that a viewer can open any route and be told what
+  // it is. A route with no entry is a silent hole in that promise, so failing
+  // here is the intended behaviour when someone adds a page.
+  it("explains every route in the app", () => {
+    const registered = new Set(TOUR_ROUTES.map((route) => route.path));
+    const missing = appRoutes.filter((route) => !registered.has(route));
+    expect(missing).toEqual([]);
+  });
+
+  it("has no entry for a route that no longer exists", () => {
+    const actual = new Set(appRoutes);
+    const stale = TOUR_ROUTES.map((route) => route.path).filter((route) => !actual.has(route));
+    expect(stale).toEqual([]);
+  });
+
+  it("gives every route real copy, not a placeholder", () => {
+    for (const route of TOUR_ROUTES) {
+      expect(route.title.trim().length).toBeGreaterThan(0);
+      // Short enough to be a stub is a real failure mode for a registry this
+      // wide: a one-word summary reads as covered while explaining nothing.
+      expect(route.summary.trim().length).toBeGreaterThan(30);
+      expect(route.detail.trim().length).toBeGreaterThan(30);
+      expect(CHAPTERS).toContain(route.chapter);
+    }
+  });
+
+  it("names a known synthetic account whenever a persona is required", () => {
+    for (const route of TOUR_ROUTES) {
+      if (route.persona === "none") continue;
+      expect(PERSONA_ACCOUNTS[route.persona]).toMatch(/@/);
+    }
+  });
+
+  it("orders every route exactly once", () => {
+    expect(TOUR_ORDER).toHaveLength(TOUR_ROUTES.length);
+    expect(new Set(TOUR_ORDER.map((route) => route.path)).size).toBe(TOUR_ROUTES.length);
+  });
+
+  it("matches dynamic routes to their registry entry", () => {
+    expect(matchTourRoute("/contracts/abc123")?.path).toBe("/contracts/[id]");
+    expect(matchTourRoute("/contracts/abc123/attest")?.path).toBe("/contracts/[id]/attest");
+    expect(matchTourRoute("/realms/fitness")?.path).toBe("/realms/[slug]");
+    expect(matchTourRoute("/dashboard")?.path).toBe("/dashboard");
+    expect(matchTourRoute("/not-a-real-route")).toBeUndefined();
+  });
+});

--- a/src/web/lib/guided-tour/registry.ts
+++ b/src/web/lib/guided-tour/registry.ts
@@ -1,0 +1,624 @@
+/**
+ * The guided-demo registry.
+ *
+ * One entry per route in src/web/app. Coverage is DATA, not code: adding a route
+ * to the tour means adding an entry here, never touching the overlay engine.
+ *
+ * Copy rules, because five very different people read the same panel:
+ *  - `summary` is for a non-technical reader. No jargon, no product-speak, one
+ *    or two sentences. This is what a layperson and an investor both see first.
+ *  - `detail` is the mechanism: what actually happens, and why it matters. Shown
+ *    to every audience except `layperson`.
+ *  - `label` is the truth boundary, and it is not decoration. `working` means the
+ *    route works today against synthetic data; `beta` means test-money only;
+ *    `future` means the route previews a direction that is not deployed.
+ *    Never mark a route `working` to make a demo look better.
+ *  - `steps` anchor tooltips to real elements. A step whose selector matches
+ *    nothing is skipped silently at runtime -- the route still explains itself --
+ *    so a UI change degrades the tour instead of breaking the demo.
+ */
+
+export type TruthLabel = "working" | "beta" | "future";
+
+/** Which synthetic account the route needs. `none` means signed-out is fine. */
+export type TourPersona = "none" | "river" | "moira" | "hr" | "alecto" | "sage";
+
+export type TourStep = {
+  /** CSS selector, or a text= prefix to match by visible text. */
+  selector: string;
+  title: string;
+  body: string;
+};
+
+export type TourRoute = {
+  path: string;
+  title: string;
+  chapter: string;
+  persona: TourPersona;
+  label: TruthLabel;
+  summary: string;
+  detail: string;
+  steps?: TourStep[];
+};
+
+export const PERSONA_ACCOUNTS: Record<Exclude<TourPersona, "none">, string> = {
+  river: "river@demo.styx.protocol",
+  moira: "dr.moira@demo.styx.protocol",
+  hr: "hr.lead@acheron.example",
+  alecto: "alecto@demo.styx.protocol",
+  sage: "sage@demo.styx.protocol",
+};
+
+export const TRUTH_LABEL_TEXT: Record<TruthLabel, string> = {
+  working: "Working today",
+  beta: "Test-money beta",
+  future: "Future enterprise capability",
+};
+
+export const CHAPTERS = [
+  "Start here",
+  "Make a promise",
+  "Prove it",
+  "Hold the line",
+  "The coach",
+  "The employer",
+  "Trust and limits",
+] as const;
+
+export const TOUR_ROUTES: TourRoute[] = [
+  // ── Start here ────────────────────────────────────────────────────────────
+  {
+    path: "/tour",
+    title: "The boundary, stated first",
+    chapter: "Start here",
+    persona: "none",
+    label: "beta",
+    summary:
+      "Styx lets someone put their own money behind a promise, and keeps an honest record of whether they kept it. This page says up front what is real and what is not.",
+    detail:
+      "Every other page in this demo runs on synthetic accounts and test credits. The labels you see throughout the tour come from this page's own vocabulary, so nothing in the walkthrough can claim more than this page does.",
+    steps: [
+      {
+        selector: "text=Test-money beta",
+        title: "The truth label",
+        body: "This badge appears on every chapter. Amber means test-money only. Green means the route genuinely works today. Blue means it is a preview of a direction, not a deployed product.",
+      },
+      {
+        selector: "text=What is deliberately not being claimed",
+        title: "What we are not claiming",
+        body: "Read this out loud to an investor. Naming the limits is the reason the rest of the demo can be trusted.",
+      },
+    ],
+  },
+  {
+    path: "/",
+    title: "The front door",
+    chapter: "Start here",
+    persona: "none",
+    label: "working",
+    summary: "The public landing page — how Styx explains itself to someone arriving cold.",
+    detail:
+      "This is the marketing surface, not the product. It is included in the tour so you can see the promise a visitor is given before comparing it against what the signed-in routes actually do.",
+  },
+  {
+    path: "/pitch",
+    title: "The investor deck",
+    chapter: "Start here",
+    persona: "none",
+    label: "working",
+    summary: "The pitch narrative in slide form: the problem, the wedge, and the business model.",
+    detail:
+      "Historical figures and market claims on this surface are projections unless separately sourced. Treat it as the story, and the signed-in routes as the evidence.",
+  },
+  {
+    path: "/circles",
+    title: "The demo index",
+    chapter: "Start here",
+    persona: "none",
+    label: "beta",
+    summary: "A map of the synthetic demo data — every seeded scenario, and a link to the surface that shows it.",
+    detail:
+      "The seed builds five concentric circles: waitlist prospects, active contracts with day-accurate streaks, three auditors mid-review, a five-member accountability pod, and one enterprise. This page is the shortest route to any of them.",
+  },
+  {
+    path: "/ask",
+    title: "Ask Styx",
+    chapter: "Start here",
+    persona: "none",
+    label: "future",
+    summary: "A question box for stakeholders — ask how Styx works and get a plain answer.",
+    detail:
+      "Backed by a separate Cloudflare Worker. In this local demo the worker URL is not configured, so treat this route as a direction rather than a working feature.",
+  },
+  {
+    path: "/help",
+    title: "Help",
+    chapter: "Start here",
+    persona: "none",
+    label: "working",
+    summary: "Plain-language answers to the questions people actually ask before committing money.",
+    detail: "Useful as a proxy for support load: everything here is a question the product has not yet made obvious.",
+  },
+  {
+    path: "/login",
+    title: "Sign in",
+    chapter: "Start here",
+    persona: "none",
+    label: "working",
+    summary: "The ordinary sign-in screen a real user would meet.",
+    detail:
+      "The guided tour never uses this form. It establishes sessions through the API directly so the shared synthetic password is never typed on screen or captured in a recording.",
+  },
+  {
+    path: "/register",
+    title: "Create an account",
+    chapter: "Start here",
+    persona: "none",
+    label: "working",
+    summary: "Sign-up, including the age confirmation and terms acceptance a money product needs.",
+    detail:
+      "Registration captures age confirmation, terms acceptance and an optional referral code. These are consent artifacts, not form fields — they are what makes a later stake defensible.",
+  },
+  {
+    path: "/beta",
+    title: "Private beta waitlist",
+    chapter: "Start here",
+    persona: "none",
+    label: "beta",
+    summary: "Where someone asks to be let in early.",
+    detail:
+      "The synthetic seed puts four prospects here across organic, creator, practitioner and referral channels — the four acquisition routes the go-to-market plan assumes.",
+  },
+  {
+    path: "/beta/confirm",
+    title: "Waitlist confirmation",
+    chapter: "Start here",
+    persona: "none",
+    label: "beta",
+    summary: "The confirmation step after joining the waitlist.",
+    detail: "Confirms intent and assigns a cohort. The seeded cohort in this demo is cohort-2026-08.",
+  },
+
+  // ── Make a promise ────────────────────────────────────────────────────────
+  {
+    path: "/dashboard",
+    title: "One person's commitment",
+    chapter: "Make a promise",
+    persona: "river",
+    label: "working",
+    summary:
+      "River promised not to contact an ex. Real money is held while that promise is open, and this is what River sees every day.",
+    detail:
+      "The dashboard is the product's centre of gravity: money at risk, the current streak, today's pending check-in, and an append-only record of what was attested and when.",
+    steps: [
+      {
+        selector: "text=CAPITAL AT RISK (TEST CREDITS)",
+        title: "Money at risk",
+        body: "This is the amount held against the promise. In this demo it is test credits and the ledger provider cannot move real money — that is enforced in code, not by policy.",
+      },
+      {
+        selector: "text=TRUTH LOG",
+        title: "The truth log",
+        body: "Append-only. Entries are never edited or deleted, which is the whole point: the record has to be worth more than the story someone tells about themselves later.",
+      },
+      {
+        selector: "text=MY CONTRACTS",
+        title: "Open commitments",
+        body: "Each contract carries its own stake, cadence and evidence rule. River's is a 21-day no-contact streak.",
+      },
+    ],
+  },
+  {
+    path: "/contracts/new",
+    title: "Making the promise",
+    chapter: "Make a promise",
+    persona: "river",
+    label: "working",
+    summary: "Where someone defines what they are promising, how much they are staking, and how it will be checked.",
+    detail:
+      "The three decisions that make a commitment enforceable: the behaviour, the amount at risk, and what counts as evidence. Get the evidence rule wrong and the whole record is worthless.",
+  },
+  {
+    path: "/contracts/[id]",
+    title: "Inside one contract",
+    chapter: "Make a promise",
+    persona: "river",
+    label: "working",
+    summary: "The full history of a single promise — every check-in, every stake movement.",
+    detail:
+      "Shows the double-entry ledger behind the contract: the hold when it opened, returns on kept days, forfeits on missed ones.",
+  },
+  {
+    path: "/contracts/[id]/attest",
+    title: "Today's check-in",
+    chapter: "Make a promise",
+    persona: "river",
+    label: "working",
+    summary: "The daily moment of truth: did you keep it?",
+    detail:
+      "Attestation is deliberately small and frequent. The seeded data includes a perfect streak, a missed-and-recovered streak and a wobbling one, because the product has to be honest about all three.",
+  },
+  {
+    path: "/wallet",
+    title: "The money",
+    chapter: "Make a promise",
+    persona: "river",
+    label: "beta",
+    summary: "Balance, holds, and what has been returned or forfeited.",
+    detail:
+      "Backed by a double-entry ledger with system escrow and revenue accounts. In this demo the provider is internal and marked as not moving real money.",
+  },
+  {
+    path: "/realms",
+    title: "Categories of promise",
+    chapter: "Make a promise",
+    persona: "river",
+    label: "working",
+    summary: "The different life areas someone can commit in.",
+    detail: "Realms carry their own evidence rules and their own auditor expertise, which is what makes review credible.",
+  },
+  {
+    path: "/realms/[slug]",
+    title: "Inside a realm",
+    chapter: "Make a promise",
+    persona: "river",
+    label: "working",
+    summary: "One category in depth, with the commitments people make in it.",
+    detail: "Auditors are matched to realms by recorded expertise rather than at random.",
+  },
+  {
+    path: "/realms/[slug]/contracts/new",
+    title: "Commit within a realm",
+    chapter: "Make a promise",
+    persona: "river",
+    label: "working",
+    summary: "Starting a promise pre-shaped by its category.",
+    detail: "Pre-fills the evidence rule appropriate to the realm, which is the main defence against unverifiable promises.",
+  },
+  {
+    path: "/tavern",
+    title: "The commons",
+    chapter: "Make a promise",
+    persona: "river",
+    label: "working",
+    summary: "Where people going through the same thing can see they are not alone.",
+    detail: "Retention in this category comes from company, not features. This is the surface that tests that claim.",
+  },
+  {
+    path: "/referrals",
+    title: "Bringing someone in",
+    chapter: "Make a promise",
+    persona: "river",
+    label: "working",
+    summary: "How an existing user invites the next one.",
+    detail: "Referral is the cheapest of the four seeded acquisition channels and the one with the best retention.",
+  },
+  {
+    path: "/profile",
+    title: "Profile",
+    chapter: "Make a promise",
+    persona: "river",
+    label: "working",
+    summary: "Who the account belongs to, and what the record says about them.",
+    detail: "The public-facing half of a person's record, distinct from the private truth log.",
+  },
+  {
+    path: "/settings",
+    title: "Settings",
+    chapter: "Make a promise",
+    persona: "river",
+    label: "working",
+    summary: "Notification, privacy and account controls.",
+    detail: "Includes the controls that matter most in a behaviour product: what gets sent, when, and to whom.",
+  },
+  {
+    path: "/kyc",
+    title: "Identity verification",
+    chapter: "Make a promise",
+    persona: "sage",
+    label: "beta",
+    summary: "Confirming a real person is behind an account before money moves.",
+    detail:
+      "The seed deliberately spreads accounts across VERIFIED, PENDING and NOT_STARTED so you can see all three states. Sage is mid-verification.",
+  },
+  {
+    path: "/do-not-text-your-ex-tonight",
+    title: "The wedge",
+    chapter: "Make a promise",
+    persona: "none",
+    label: "working",
+    summary: "The single, specific, painful moment the product was built for.",
+    detail:
+      "This is the entry point that converts. Show it to an investor when they ask what the wedge is — it is one situation, named exactly, not a category.",
+  },
+  {
+    path: "/recovery/how-commitment-contracts-work",
+    title: "How this works",
+    chapter: "Make a promise",
+    persona: "none",
+    label: "working",
+    summary: "The mechanism explained for someone who has never heard of a commitment contract.",
+    detail: "Loss aversion is the engine: people work substantially harder to avoid losing money than to gain it.",
+  },
+  {
+    path: "/recovery/breakup-no-contact-guide",
+    title: "No-contact guide",
+    chapter: "Make a promise",
+    persona: "none",
+    label: "working",
+    summary: "Practical help for the specific promise most people arrive wanting to make.",
+    detail: "Doubles as the organic acquisition surface for the wedge.",
+  },
+  {
+    path: "/recovery/accountability-app-for-relationships",
+    title: "Accountability, relationships",
+    chapter: "Make a promise",
+    persona: "none",
+    label: "working",
+    summary: "The relationship-focused entry point.",
+    detail: "One of four seeded acquisition channels; organic search is the cheapest.",
+  },
+  {
+    path: "/recovery/couples-recovery-tools",
+    title: "Couples tools",
+    chapter: "Make a promise",
+    persona: "none",
+    label: "working",
+    summary: "Commitments made by two people rather than one.",
+    detail: "Extends the single-person contract to a mutual one, which changes who can attest.",
+  },
+
+  // ── Prove it ──────────────────────────────────────────────────────────────
+  {
+    path: "/fury",
+    title: "The auditors",
+    chapter: "Prove it",
+    persona: "alecto",
+    label: "working",
+    summary:
+      "When a claim needs checking, three independent people review it. They do not know each other's verdicts until all three are in.",
+    detail:
+      "This is the answer to 'what stops someone lying?'. The seeded review has three auditors — Alecto, Megaera and Tisiphone — with one review pending and one already resolved by consensus.",
+    steps: [
+      {
+        selector: "text=Fury",
+        title: "Three-way review",
+        body: "Independent review is what makes the record worth more than self-reporting. Consensus is required, and auditors are matched to the realm by recorded expertise.",
+      },
+    ],
+  },
+  {
+    path: "/whistleblower/[linkId]",
+    title: "Someone else reports it",
+    chapter: "Prove it",
+    persona: "none",
+    label: "working",
+    summary: "A private link that lets a third party report that a promise was broken.",
+    detail:
+      "The uncomfortable but necessary case: self-report is not the only evidence path. The link is scoped and does not expose the reporter.",
+  },
+  {
+    path: "/behavioral",
+    title: "The behavioural toolkit",
+    chapter: "Prove it",
+    persona: "river",
+    label: "working",
+    summary: "The set of tools that measure whether someone is actually changing, rather than just paying.",
+    detail:
+      "Staking money is the mechanism; these are the measurements. Without them the product is a wager, and the difference matters to every audience in the room.",
+  },
+  {
+    path: "/behavioral/assessment",
+    title: "Where someone is starting from",
+    chapter: "Prove it",
+    persona: "river",
+    label: "working",
+    summary: "A baseline read on habits before any promise is made.",
+    detail: "Without a baseline there is no way to claim improvement later. This is the measurement the outcome claims rest on.",
+  },
+  {
+    path: "/behavioral/habit-strength",
+    title: "Habit strength",
+    chapter: "Prove it",
+    persona: "river",
+    label: "working",
+    summary: "How established a behaviour has actually become.",
+    detail: "Streak length alone is a weak signal; this weights consistency and recovery after a miss.",
+  },
+  {
+    path: "/behavioral/friction-audit",
+    title: "Friction audit",
+    chapter: "Prove it",
+    persona: "river",
+    label: "working",
+    summary: "Finding the moments where someone is most likely to break.",
+    detail: "Targets intervention at the point of failure rather than spreading it evenly.",
+  },
+  {
+    path: "/behavioral/reentry",
+    title: "After a miss",
+    chapter: "Prove it",
+    persona: "river",
+    label: "working",
+    summary: "What happens the day after someone breaks their promise.",
+    detail:
+      "The most important surface in the product for retention. The seeded data includes a missed-and-recovered streak specifically so this can be shown honestly.",
+  },
+  {
+    path: "/behavioral/academy",
+    title: "Academy",
+    chapter: "Prove it",
+    persona: "river",
+    label: "working",
+    summary: "Teaching the method rather than only enforcing it.",
+    detail: "Education lowers support load and raises the quality of the promises people make.",
+  },
+  {
+    path: "/behavioral/gateway-oath",
+    title: "The oath",
+    chapter: "Prove it",
+    persona: "river",
+    label: "working",
+    summary: "The explicit commitment someone makes on entry.",
+    detail: "A deliberate friction point: stating the promise plainly improves follow-through before any money is involved.",
+  },
+  {
+    path: "/behavioral/auditor-wellness",
+    title: "Auditor wellness",
+    chapter: "Prove it",
+    persona: "alecto",
+    label: "working",
+    summary: "Looking after the people who review other people's failures.",
+    detail:
+      "Reviewer burnout is the quiet failure mode of any peer-audit system. Worth showing to anyone who asks whether the model scales.",
+  },
+
+  // ── Hold the line ─────────────────────────────────────────────────────────
+  {
+    path: "/guardrails",
+    title: "Guardrails",
+    chapter: "Hold the line",
+    persona: "none",
+    label: "working",
+    summary: "The limits the product puts on itself — what it will refuse to let someone stake or promise.",
+    detail:
+      "The single most important page for a regulator or a cautious investor. A product that takes money against behaviour has to be able to say no.",
+  },
+
+  // ── The coach ─────────────────────────────────────────────────────────────
+  {
+    path: "/practitioner",
+    title: "The coach's console",
+    chapter: "The coach",
+    persona: "moira",
+    label: "working",
+    summary:
+      "A coach sees, in one place, which of their clients is drifting — without reading anyone's private journal.",
+    detail:
+      "This is the first buyer. Independent coaches already do this work in spreadsheets and memory. The console turns scattered self-reports into a ranked risk view backed by an auditable record.",
+    steps: [
+      {
+        selector: "text=Composite risk intelligence for assigned clients",
+        title: "Ranked by risk",
+        body: "Not an alphabetical client list — an ordering by who most needs attention this week. That ordering is the product.",
+      },
+      {
+        selector: "text=Practitioner Console",
+        title: "Assigned clients only",
+        body: "A coach sees only clients assigned to them, and sees signals rather than raw private content.",
+      },
+    ],
+  },
+
+  // ── The employer ──────────────────────────────────────────────────────────
+  {
+    path: "/hr",
+    title: "The employer view",
+    chapter: "The employer",
+    persona: "hr",
+    label: "future",
+    summary:
+      "An employer sees whether a wellbeing programme is working in aggregate — and cannot see any individual employee.",
+    detail:
+      "A preview of a direction, not a deployed enterprise product. Individual data is structurally redacted rather than hidden by permission, which is the only version of this an employer can legally buy.",
+    steps: [
+      {
+        selector: "text=Enterprise Group Analytics",
+        title: "Aggregate only",
+        body: "Group-level outcomes. The seeded enterprise is Acheron Logistics Group, with a deliberate mix of active, completed and failed contracts so the numbers are not flattering.",
+      },
+      {
+        selector: "text=Total Contracts",
+        title: "The metric an employer buys on",
+        body: "Participation and completion in aggregate. Note what is absent: no name, no individual outcome, no journal content.",
+      },
+    ],
+  },
+  {
+    path: "/admin",
+    title: "Operator console",
+    chapter: "The employer",
+    persona: "hr",
+    label: "future",
+    summary: "The internal view for whoever runs the platform.",
+    detail: "Not a customer-facing surface. Shown so the operational cost of running the product is visible rather than assumed.",
+  },
+  {
+    path: "/admin/cac-ltv",
+    title: "Acquisition cost and lifetime value",
+    chapter: "The employer",
+    persona: "hr",
+    label: "future",
+    summary: "What a customer costs to acquire against what they are worth.",
+    detail:
+      "The two numbers an investor will ask for. Figures here are modelled from synthetic data — say so plainly rather than letting them read as trading history.",
+  },
+  {
+    path: "/admin/jurisdictions",
+    title: "Where this is allowed",
+    chapter: "The employer",
+    persona: "hr",
+    label: "future",
+    summary: "Which places the product can legally operate in, and which are blocked.",
+    detail:
+      "Staking money on outcomes is regulated differently everywhere. Blocked jurisdictions fail closed. In the local demo the geofence runs in a permissive demo posture, so this shows the control, not a verified legal position.",
+  },
+
+  // ── Trust and limits ──────────────────────────────────────────────────────
+  {
+    path: "/legal/terms",
+    title: "Terms",
+    chapter: "Trust and limits",
+    persona: "none",
+    label: "working",
+    summary: "The agreement someone accepts before staking anything.",
+    detail: "Acceptance is captured at registration and is part of what makes a forfeit defensible.",
+  },
+  {
+    path: "/legal/privacy",
+    title: "Privacy",
+    chapter: "Trust and limits",
+    persona: "none",
+    label: "working",
+    summary: "What is collected, what is shared, and what never leaves the account.",
+    detail: "Read alongside the employer view: the privacy promise is what makes that view sellable.",
+  },
+  {
+    path: "/legal/responsible-use",
+    title: "Responsible use",
+    chapter: "Trust and limits",
+    persona: "none",
+    label: "working",
+    summary: "Who this product is not for, stated by the product itself.",
+    detail: "A behaviour-and-money product without this page is not credible. Pair it with /guardrails.",
+  },
+  {
+    path: "/legal/rules",
+    title: "The rules",
+    chapter: "Trust and limits",
+    persona: "none",
+    label: "working",
+    summary: "How stakes, evidence and disputes are actually decided.",
+    detail: "The operational rulebook behind the truth log.",
+  },
+];
+
+export const TOUR_BY_PATH = new Map(TOUR_ROUTES.map((route) => [route.path, route]));
+
+/** Matches a live pathname to a registry entry, including dynamic segments. */
+export function matchTourRoute(pathname: string): TourRoute | undefined {
+  const direct = TOUR_BY_PATH.get(pathname);
+  if (direct) return direct;
+  return TOUR_ROUTES.find((route) => {
+    if (!route.path.includes("[")) return false;
+    const pattern = new RegExp(
+      `^${route.path.replace(/\[[^\]]+\]/g, "[^/]+").replace(/\//g, "\\/")}$`,
+    );
+    return pattern.test(pathname);
+  });
+}
+
+/** Registry order, grouped by chapter, for next/previous navigation. */
+export const TOUR_ORDER: TourRoute[] = CHAPTERS.flatMap((chapter) =>
+  TOUR_ROUTES.filter((route) => route.chapter === chapter),
+);

--- a/src/web/lib/guided-tour/registry.ts
+++ b/src/web/lib/guided-tour/registry.ts
@@ -605,16 +605,31 @@ export const TOUR_ROUTES: TourRoute[] = [
 
 export const TOUR_BY_PATH = new Map(TOUR_ROUTES.map((route) => [route.path, route]));
 
-/** Matches a live pathname to a registry entry, including dynamic segments. */
+const splitSegments = (value: string): string[] => value.split("/").filter(Boolean);
+
+/**
+ * Matches a live pathname to a registry entry, including dynamic segments.
+ *
+ * Compares segment by segment rather than compiling the registry path into a
+ * regex. Building a pattern by escaping a string is the sink CodeQL flags as
+ * incomplete sanitization (js/incomplete-sanitization) -- and escaping is the
+ * wrong tool here anyway, since a dynamic segment is exactly "one segment, any
+ * value", which a direct comparison expresses without an escaping rule to get
+ * subtly wrong.
+ */
 export function matchTourRoute(pathname: string): TourRoute | undefined {
   const direct = TOUR_BY_PATH.get(pathname);
   if (direct) return direct;
+
+  const actual = splitSegments(pathname);
   return TOUR_ROUTES.find((route) => {
     if (!route.path.includes("[")) return false;
-    const pattern = new RegExp(
-      `^${route.path.replace(/\[[^\]]+\]/g, "[^/]+").replace(/\//g, "\\/")}$`,
+    const expected = splitSegments(route.path);
+    if (expected.length !== actual.length) return false;
+    return expected.every(
+      (segment, index) =>
+        (segment.startsWith("[") && segment.endsWith("]")) || segment === actual[index],
     );
-    return pattern.test(pathname);
   });
 }
 


### PR DESCRIPTION
## Why

Five people need to open the demo at once — the operator, Jessica, an investor, a user tester, and someone who has never heard of a commitment contract — and each needs the explanation pitched at them. Today the demo explains nothing on its own: it requires a presenter.

## What this adds

A guided layer over the **real product**, never a mock of it.

- **All 48 routes** in `src/web/app` carry a synced side panel: the route's truth label, a plain-language summary, and the mechanism for anyone past the "New to this" depth.
- **Numbered markers** anchor to real elements on the page; clicking one explains that element.
- **"Explain it for"** switches depth (New to this / User tester / Investor / Operator), stored per browser — so five viewers sit at five different depths against the same running demo.
- Arrow keys move between chapters.

## Coverage is enforced, not asserted

`src/web/lib/guided-tour/registry.test.ts` fails if a route in `app/` has no entry, if an entry points at a route that no longer exists, or if any summary is short enough to be a placeholder. That test is what caught `/behavioral` uncovered.

The engine knows nothing about any specific route — widening the tour is a data edit to `registry.ts`.

## Honesty constraints

- A marker whose element cannot be found is **dropped**, not mispointed: a UI change degrades the tour instead of breaking the demo under it.
- The panel's truth labels are the **tour's own**, sourced from `/tour`'s vocabulary, because the signed-in routes do not render labels themselves. The runbook states this rather than letting a viewer infer the product displays them.
- The layer **compiles out** of any build that is not a demo build (`NEXT_PUBLIC_STYX_GUIDED_TOUR` / `NEXT_PUBLIC_STYX_TEST_MONEY_MODE`).

## Verification

- `npx tsc --noEmit` clean.
- `npx jest lib/guided-tour` — 6/6 pass.
- `npm run demo:reset:verify` exit **0** with the tour built in; live API, browser, ledger, proof, behavioral, coach and enterprise-preview checks all pass.
- Verified visually on `/tour` and a signed-in `/dashboard`: panel reserves layout width rather than overlaying, which was hiding the Truth Log entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmP1SLhXcZBmA7g4NM6PTY

## Summary by Sourcery

Add a guided tour overlay to the demo that explains every app route for different audiences while enforcing coverage and honest constraints.

New Features:
- Introduce a guided tour overlay component that renders a synced explanatory side panel and anchored markers over live product routes.
- Define a registry of all app routes with truth labels, audience-focused summaries, and navigation metadata to drive the guided tour.
- Persist per-browser audience depth and panel visibility so multiple viewers can see tailored explanations simultaneously.

Enhancements:
- Reserve layout space for the guided tour panel in the root layout so it does not obscure key product content.
- Document the guided tour behaviour and constraints in the Jessica demo runbook for operators and presenters.

Build:
- Gate the guided tour overlay behind demo-only environment flags so it compiles out of non-demo builds.

Documentation:
- Extend the demo runbook with a section describing the guided tour, its audience modes, coverage guarantees, and build-time flags.

Tests:
- Add registry tests that ensure every app route has a non-placeholder guided tour entry, that no stale entries exist, and that ordering and dynamic route matching are correct.