### PR TITLE
fix: the snapshot's 8 broken routes, and the two live API bugs that surfaced

### DIFF
--- a/docs/demo/jessica-demo-runbook.md
+++ b/docs/demo/jessica-demo-runbook.md
@@ -79,6 +79,12 @@ opens, explanation depth, and notes. What is not: no IP addresses, no user agent
 identity, no page content. Everyone shares the same synthetic accounts, so account identity would be
 noise — the self-entered name is the only attribution, and the panel says so on screen.
 
+**Automation is excluded.** Every script that drives the demo in a browser — the fixture capture,
+the snapshot sweep, both recorders — sets `styx.guidedTour.telemetry = off` in localStorage and is
+therefore absent from the report. Before that existed, the report showed "8 viewer(s)" for a demo
+no human had ever opened: a confident wrong answer to the only question the report exists to
+answer. Set the same key by hand on a device you do not want counted.
+
 ## Showing it to people who are NOT in the room
 
 The LAN demo needs everyone on the same Wi-Fi. For an investor or a remote reviewer there is a
@@ -88,9 +94,24 @@ no Redis** behind it.
 ```bash
 npm run snapshot:capture   # fixtures, recorded off the running demo
 npm run snapshot:build     # static export into src/web/out
+npm run snapshot:verify    # drives all 48 routes; exit 0 ⟺ shippable
 npm run snapshot:serve     # preview on http://127.0.0.1:4315
-npm run snapshot:deploy    # wrangler pages deploy
+npm run snapshot:deploy    # runs verify first, then wrangler pages deploy
 ```
+
+`snapshot:verify` is the gate, and `snapshot:deploy` runs it for you — you cannot publish
+a snapshot that fails it. It exists because none of the cheaper checks can see the failure
+that matters: a broken route still builds, still exports an HTML file, and still answers
+`200`, because the error is *text inside the page*. It fails on three things — a route that
+reaches for `/api`, a route that calls anything off-origin, and a route the snapshot layer
+had no fixture for.
+
+That last one is the valuable one, and it is worth reading as a product signal rather than
+a packaging problem: the capture only records successful responses, so **a missing fixture
+usually means that endpoint is broken on the live demo.** It found two, both invisible
+until then because the pages caught their own errors and rendered a plausible empty state —
+`/admin/cac-ltv` reported "$0 revenue, 0 users" for a permanently-403 endpoint, and
+`/behavioral/habit-strength` was returning a 500 from an ambiguous SQL column.
 
 Reads are answered from fixtures captured by driving the real demo as each persona and recording
 what the app actually requests — not hand-written, because a hand-written fixture drifts and renders
@@ -109,6 +130,15 @@ Two operational traps, both of which cost real time:
 - Preview with `snapshot:serve`, never `serve -s`. SPA mode rewrites every unmatched path to
   `index.html`, so each route returns the landing page with a `200` while the URL bar still looks
   right — a preview that looks fine and tests nothing.
+
+Two things to say honestly if someone asks:
+
+- The snapshot sends **no telemetry**. The note/interaction collector is a machine on the
+  presenter's LAN and does not exist behind a public host, so notes are a live-demo feature only.
+  Ask a remote reviewer for comments directly.
+- `/admin/cac-ltv` now shows real synthetic user, paying-user and revenue counts, but **CAC, LTV,
+  payback and burn are still hard-coded zeros in the API** — the product does not compute them
+  yet. That is a real gap, not a snapshot artifact; do not present those four tiles as measured.
 
 ## The guided tour (self-driving, for five different readers)
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "snapshot:capture": "bash scripts/demo/snapshot.sh capture",
     "snapshot:build": "bash scripts/demo/snapshot.sh build",
     "snapshot:serve": "bash scripts/demo/snapshot.sh serve",
+    "snapshot:verify": "bash scripts/demo/snapshot.sh verify",
     "snapshot:deploy": "bash scripts/demo/snapshot.sh deploy",
     "demo:feedback": "bash scripts/demo/feedback.sh start",
     "demo:feedback:stop": "bash scripts/demo/feedback.sh stop",

--- a/scripts/demo/capture-signed-in-rehearsal.mjs
+++ b/scripts/demo/capture-signed-in-rehearsal.mjs
@@ -119,6 +119,11 @@ try {
     viewport: { width: 1280, height: 720 },
     recordVideo: { dir: recordingDir, size: { width: 1280, height: 720 } },
   });
+  // A recorder is not an attendee; keep it out of the feedback report.
+  await context.addInitScript(
+    ([key, value]) => window.localStorage.setItem(key, value),
+    ["styx.guidedTour.telemetry", "off"],
+  );
 
   // The captions must quote the product's own labels. If someone edits the
   // truthLabels map in tour/page.tsx, fail here rather than overlay stale text.

--- a/scripts/demo/capture-snapshot.mjs
+++ b/scripts/demo/capture-snapshot.mjs
@@ -67,6 +67,13 @@ const written = [];
 
 for (const [persona, email] of Object.entries(PERSONAS)) {
   const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  // This run drives all five personas across every route. Without the opt-out it
+  // lands in the feedback report as five attentive viewers, and the report's whole
+  // job is to say who actually came.
+  await context.addInitScript(
+    ([key, value]) => window.localStorage.setItem(key, value),
+    ["styx.guidedTour.telemetry", "off"],
+  );
 
   // POST /auth/login is throttled at 5 per 60s per IP; five personas is right at the
   // edge, so pace them rather than tripping it half way through a capture.

--- a/scripts/demo/capture-tour-fallback.mjs
+++ b/scripts/demo/capture-tour-fallback.mjs
@@ -41,6 +41,11 @@ try {
     viewport: { width: 1280, height: 720 },
     recordVideo: { dir: recordingDir, size: { width: 1280, height: 720 } },
   });
+  // A recorder is not an attendee; keep it out of the feedback report.
+  await context.addInitScript(
+    ([key, value]) => window.localStorage.setItem(key, value),
+    ["styx.guidedTour.telemetry", "off"],
+  );
   const page = await context.newPage();
   await page.goto(tourUrl, { waitUntil: "networkidle" });
   const video = page.video();

--- a/scripts/demo/snapshot.sh
+++ b/scripts/demo/snapshot.sh
@@ -80,9 +80,45 @@ serve() {
   node24 npx --yes serve "$out_dir" -l 4315
 }
 
+# Sweeps every registry route on the built export and fails if any of them still
+# reaches for a backend. Serves on its own port so it never collides with a preview
+# someone left running, and always takes its server back down.
+verify() {
+  [ -f "$out_dir/index.html" ] || die "nothing built. Run: npm run snapshot:build"
+  local port="${STYX_SNAPSHOT_VERIFY_PORT:-4316}"
+
+  # verify_pid is deliberately NOT local: the EXIT trap fires after this function
+  # has returned, so a local would already be out of scope and `set -u` would abort
+  # the cleanup with "pid: unbound variable" -- masking the real exit code.
+  verify_pid=""
+  cleanup() { [ -n "${verify_pid:-}" ] && kill "$verify_pid" 2>/dev/null || true; }
+  trap cleanup EXIT
+
+  info "Serving the export on 127.0.0.1:${port} for verification ..."
+  node24 npx --yes serve "$out_dir" -l "$port" >/dev/null 2>&1 &
+  verify_pid=$!
+
+  # -q --http1.1: an --http2 line in the operator's curlrc makes this request an h2c
+  # upgrade that the server answers by closing the connection. Cost a full session once.
+  local ready=0 i
+  for i in $(seq 1 40); do
+    if curl -q -fsS --http1.1 --max-time 5 -o /dev/null "http://127.0.0.1:${port}/tour/" 2>/dev/null; then
+      ready=1
+      break
+    fi
+    sleep 1
+  done
+  [ "$ready" -eq 1 ] || die "the verification server never became ready on port ${port}."
+
+  node24 node "$repo_root/scripts/demo/verify-snapshot.mjs" "http://127.0.0.1:${port}"
+}
+
 deploy() {
   [ -f "$out_dir/index.html" ] || die "nothing built. Run: npm run snapshot:build"
   command -v npx >/dev/null 2>&1 || die "npx is required to run wrangler."
+  # Publishing is the one irreversible step here, so the predicate runs first. A
+  # snapshot that renders "API 404" to an investor is worse than no snapshot.
+  verify
   info "Deploying to Cloudflare Pages project '${project}' ..."
   npx --yes wrangler pages deploy "$out_dir" --project-name "$project"
 }
@@ -91,6 +127,7 @@ case "${1:-}" in
   capture) capture ;;
   build) build ;;
   serve) serve ;;
+  verify) verify ;;
   deploy) deploy ;;
-  *) die "usage: bash scripts/demo/snapshot.sh {capture|build|serve|deploy}" ;;
+  *) die "usage: bash scripts/demo/snapshot.sh {capture|build|serve|verify|deploy}" ;;
 esac

--- a/scripts/demo/verify-snapshot.mjs
+++ b/scripts/demo/verify-snapshot.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * The snapshot's executable predicate. Exit 0 <=> every route in the guided-tour
+ * registry renders from captured fixtures with no backend behind it.
+ *
+ * WHY A SWEEP AND NOT A BUILD CHECK.
+ *
+ * The snapshot's failure mode is invisible to everything cheaper. A broken route
+ * still builds, still exports an HTML file, and still answers HTTP 200 -- the
+ * error is text *inside* the page. Verifying that the export exists, or that
+ * `/tour` looks right, proves nothing about the other 47 routes.
+ *
+ * That is not hypothetical: shipping interception in `api-client.ts` alone left
+ * 8 of 48 routes issuing real `/api` calls (they use hand-rolled `fetch`), so a
+ * remote viewer opening `/practitioner` or `/realms` got "API 404" while every
+ * gate stayed green.
+ *
+ * Two things fail this predicate:
+ *   1. Any same-origin `/api/*` request. On a static host it can only 404.
+ *   2. Any cross-origin request. The static snapshot must be self-contained; the
+ *      LAN feedback collector in particular does not exist behind a pages.dev
+ *      origin, and aiming viewers at it is mixed-content noise at best.
+ *
+ * Usage: node scripts/demo/verify-snapshot.mjs <base-url>
+ */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "../..");
+const registryPath = path.join(repoRoot, "src/web/lib/guided-tour/registry.ts");
+
+const BASE = (process.argv[2] || "http://127.0.0.1:4316").replace(/\/$/, "");
+
+// Concrete ids for dynamic segments -- the same ones the export pre-renders, so
+// the sweep visits pages that actually exist rather than reporting phantom holes.
+const CONCRETE = {
+  "[id]": "c1000000-0000-0000-0000-000000000001",
+  "[slug]": "recovery-abstinence",
+  "[linkId]": "demo",
+};
+const concretise = (route) => route.replace(/\[[^\]]+\]/g, (segment) => CONCRETE[segment] ?? "demo");
+
+/**
+ * Off-origin hosts that are a deliberate part of the app, not a backend.
+ *
+ * Kept as a narrow allow-list rather than relaxing the rule, because the whole
+ * point of the off-origin check is to catch things like the LAN feedback
+ * collector -- a host that exists on the presenter's machine and nowhere else.
+ *
+ * cdnjs: /pitch loads a decorative font for its p5 sketches
+ * (components/PitchDeck/ui/slides/p5Sketches.ts). Pre-existing app behaviour,
+ * and it degrades to a default font rather than breaking the slide -- but it does
+ * mean /pitch is the one route that is not fully offline-capable.
+ */
+const ALLOWED_OFF_ORIGIN = new Set(["https://cdnjs.cloudflare.com"]);
+
+const source = await readFile(registryPath, "utf8");
+const routes = [...source.matchAll(/\{\s*path:\s*"([^"]+)"[\s\S]*?persona:\s*"([^"]+)"/g)].map(
+  (match) => ({ path: match[1], persona: match[2] }),
+);
+if (!routes.length) throw new Error("no routes parsed from the guided-tour registry.");
+
+const { chromium } = await import("playwright");
+const browser = await chromium.launch({ headless: true });
+
+const failures = [];
+let swept = 0;
+
+for (const route of routes) {
+  // A "none" route is public, but it still renders inside a persona's session;
+  // river is the persona with the widest fixture set.
+  const persona = route.persona === "none" ? "river" : route.persona;
+  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  await context.addInitScript(
+    ([personaKey, personaValue, optOutKey]) => {
+      window.localStorage.setItem(personaKey, personaValue);
+      // Belt and braces: a snapshot build already suppresses telemetry, and this
+      // sweep asserts that. Setting the opt-out too means the sweep cannot pollute
+      // the presenter's report even if it is ever pointed at a live demo.
+      window.localStorage.setItem(optOutKey, "off");
+    },
+    ["styx.snapshot.persona", persona, "styx.guidedTour.telemetry"],
+  );
+  const page = await context.newPage();
+
+  const apiCalls = new Set();
+  const offOrigin = new Set();
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.origin !== BASE) {
+      if (!ALLOWED_OFF_ORIGIN.has(url.origin)) offOrigin.add(url.origin);
+      return;
+    }
+    if (url.pathname.startsWith("/api/")) apiCalls.add(url.pathname);
+  });
+
+  let target = `${BASE}${concretise(route.path)}`;
+  if (!target.endsWith("/")) target += "/"; // the export builds with trailingSlash
+
+  let settled = true;
+  try {
+    await page.goto(target, { waitUntil: "networkidle", timeout: 25000 });
+    await page.waitForTimeout(400);
+  } catch {
+    settled = false;
+  }
+
+  // Strip the tour panel before measuring: it describes every route, so a page
+  // that rendered nothing still carries plenty of the panel's text.
+  const chars = await page.evaluate(() => {
+    const clone = document.body.cloneNode(true);
+    clone.querySelectorAll("[data-guided-tour]").forEach((node) => node.remove());
+    return (clone.textContent || "").replace(/\s+/g, " ").trim().length;
+  });
+
+  // Endpoints the snapshot layer was asked for and had no fixture for. Checking
+  // the screen instead would miss these: a page that catches its own error and
+  // renders zeros looks completely healthy.
+  const misses = await page.evaluate(() => window.__STYX_SNAPSHOT_MISSES__ || []);
+
+  const problems = [];
+  if (apiCalls.size) problems.push(`hit the API: ${[...apiCalls].join(", ")}`);
+  if (offOrigin.size) problems.push(`called off-origin: ${[...offOrigin].join(", ")}`);
+  if (!settled) problems.push("never reached networkidle");
+  if (chars < 200) problems.push(`rendered almost nothing (${chars} chars outside the tour panel)`);
+  if (misses.length) problems.push(`no fixture captured for: ${[...new Set(misses)].join(", ")}`);
+
+  if (problems.length) failures.push({ route: route.path, persona, problems });
+  swept += 1;
+
+  await page.close();
+  await context.close();
+}
+
+await browser.close();
+
+console.log(`Swept ${swept} route(s) against ${BASE}.`);
+if (failures.length) {
+  console.log(`FAIL: ${failures.length} route(s) are not self-contained:`);
+  for (const failure of failures) {
+    console.log(`  ${failure.route} [${failure.persona}]`);
+    for (const problem of failure.problems) console.log(`      - ${problem}`);
+  }
+  console.log("");
+  console.log("A route that reaches for /api needs its client routed through the snapshot");
+  console.log("layer (src/web/services/snapshot-fetch.ts patches fetch for exactly this).");
+  console.log("");
+  console.log("A route with NO FIXTURE is the more interesting failure: the capture only");
+  console.log("records 2xx responses, so a missing fixture usually means that endpoint is");
+  console.log("broken on the live demo. Probe it directly before re-capturing -- this check");
+  console.log("is how a permanently-403 admin route and a 500-ing behavioral query were found.");
+  console.log("  npm run demo:reset:verify && npm run snapshot:capture");
+  process.exit(1);
+}
+console.log(`PASS: all ${swept} routes render from fixtures with no backend and no off-origin calls.`);

--- a/src/api/src/common/guards/role.guard.spec.ts
+++ b/src/api/src/common/guards/role.guard.spec.ts
@@ -1,7 +1,17 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
 import { RoleGuard } from './role.guard';
 import { Reflector } from '@nestjs/core';
 import { ForbiddenException } from '@nestjs/common';
 import { Pool } from 'pg';
+
+/**
+ * The roles a user row can actually hold. RoleGuard compares the DB value against
+ * the decorator's strings with plain `includes`, so anything outside this set can
+ * never match -- it does not throw, it silently 403s every caller forever.
+ */
+const CANONICAL_ROLES = ['USER', 'ADMIN', 'FURY', 'PRACTITIONER'];
 
 describe('RoleGuard', () => {
   let guard: RoleGuard;
@@ -118,5 +128,62 @@ describe('RoleGuard', () => {
     await expect(guard.canActivate(createContext({ id: 'u-null-role' }))).rejects.toThrow(
       /Role USER is not authorized/,
     );
+  });
+
+  it('rejects a requirement whose case does not match the stored role', async () => {
+    // The bug this guards against, in miniature: @Roles('admin') on a handler
+    // overrode the controller's @Roles('ADMIN') via getAllAndOverride, and a real
+    // ADMIN was refused. Nothing warned -- it looked exactly like a permissions
+    // decision.
+    (mockReflector.getAllAndOverride as jest.Mock).mockReturnValue(['admin']);
+    (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [{ role: 'ADMIN', status: 'ACTIVE' }] });
+
+    await expect(guard.canActivate(createContext({ id: 'u-admin', role: 'ADMIN' }))).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+});
+
+/**
+ * Static sweep, not a unit test of the guard.
+ *
+ * A @Roles value outside CANONICAL_ROLES is unreachable code that fails silently
+ * as a 403 -- there is no startup error and no log line, so the endpoint simply
+ * never works and looks like it is merely locked down. `/admin/financial-metrics`
+ * carried `@Roles('admin')` and 403'd every administrator for its entire life; it
+ * surfaced only when a demo snapshot rendered "$0 revenue, 0 users" and that number
+ * was checked against the API.
+ */
+describe('@Roles decorators across the API', () => {
+  function collectSources(dir: string): string[] {
+    const found: string[] = [];
+    for (const entry of readdirSync(dir)) {
+      const full = path.join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        if (entry === 'node_modules' || entry === 'dist') continue;
+        found.push(...collectSources(full));
+      } else if (entry.endsWith('.ts') && !entry.endsWith('.spec.ts')) {
+        found.push(full);
+      }
+    }
+    return found;
+  }
+
+  it('only ever require a role a user row can actually hold', () => {
+    const apiSrc = path.resolve(__dirname, '../..');
+    const offenders: string[] = [];
+
+    for (const file of collectSources(apiSrc)) {
+      const source = readFileSync(file, 'utf8');
+      for (const match of source.matchAll(/@Roles\(([^)]*)\)/g)) {
+        for (const raw of match[1].matchAll(/['"]([^'"]+)['"]/g)) {
+          if (!CANONICAL_ROLES.includes(raw[1])) {
+            offenders.push(`${path.relative(apiSrc, file)}: @Roles(${JSON.stringify(raw[1])})`);
+          }
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
   });
 });

--- a/src/api/src/modules/admin/admin.controller.ts
+++ b/src/api/src/modules/admin/admin.controller.ts
@@ -647,7 +647,11 @@ export class AdminController {
   }
 
   @Get("financial-metrics")
-  @Roles("admin")
+  // "ADMIN", not "admin": RoleGuard compares against the role stored in the DB and
+  // getAllAndOverride lets a handler-level @Roles replace the class-level one, so the
+  // lowercase form silently overrode @Roles("ADMIN") with a value no user can hold.
+  // The endpoint 403'd every caller -- including real admins -- for its whole life.
+  @Roles("ADMIN")
   async financialMetrics() {
     const result = await this.pool.query(`
       SELECT

--- a/src/api/src/modules/behavioral/behavioral-enrichment.service.ts
+++ b/src/api/src/modules/behavioral/behavioral-enrichment.service.ts
@@ -62,7 +62,11 @@ export class BehavioralEnrichmentService {
   async getHabitStrength(userId: string) {
     const { rows } = await this.pool.query(
       `SELECT
-        COUNT(*) FILTER (WHERE status IN ('ATTESTED','COSIGNED'))::int AS completed,
+        -- a.status, not status: contracts also has a status column, so the bare
+        -- reference made this whole endpoint 500 with "column reference \"status\"
+        -- is ambiguous". The states below ('ATTESTED','COSIGNED') are attestation
+        -- states, so the attestation is the one that was always meant.
+        COUNT(*) FILTER (WHERE a.status IN ('ATTESTED','COSIGNED'))::int AS completed,
         COUNT(*)::int AS total
        FROM attestations a
        JOIN contracts c ON c.id = a.contract_id

--- a/src/web/app/providers.tsx
+++ b/src/web/app/providers.tsx
@@ -1,6 +1,13 @@
 'use client';
 
 import { AuthProvider } from '../contexts/AuthContext';
+import { installSnapshotFetch } from '../services/snapshot-fetch';
+
+// At module scope, not in an effect: this module is evaluated when the client
+// bundle loads, which is before any page's data-fetching effect runs. Installed
+// from the one component every route mounts, so a page cannot be added that
+// forgets it. A no-op outside snapshot builds.
+installSnapshotFetch();
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return <AuthProvider>{children}</AuthProvider>;

--- a/src/web/lib/guided-tour/feedback.ts
+++ b/src/web/lib/guided-tour/feedback.ts
@@ -13,10 +13,31 @@
  *     identical to "nobody interacted".
  *  3. It sends only what the viewer can see themselves: a random id, a name they
  *     typed, the route, and their own note. No identity, no page content.
+ *  4. It is OFF in the hosted snapshot. The collector is a machine on the
+ *     presenter's LAN; from a pages.dev origin, rule 2 would aim every viewer at
+ *     `https://<pages-host>:4312`, which cannot exist. That request is not merely
+ *     futile -- over HTTPS the browser blocks it as mixed content and logs an
+ *     error on every page, and any remote viewer's traffic would be attributed to
+ *     nothing. Measured while verifying the snapshot: a headless sweep of the
+ *     static export wrote 54 phantom sessions into the presenter's real
+ *     collector.
  */
+import { isSnapshotMode } from '../../services/snapshot';
 
 const SESSION_KEY = 'styx.guidedTour.sessionId';
 const NAME_KEY = 'styx.guidedTour.name';
+
+/**
+ * Opt-out, set by anything driving the demo in a browser that is not a person.
+ *
+ * Automation reaches these pages constantly -- the fixture capture drives all five
+ * personas, the snapshot verifier sweeps 48 routes -- and each of those runs was
+ * landing in the report as an attendee. Before this existed the report showed
+ * "8 viewer(s)" for a demo no human had ever opened, which is worse than showing
+ * nothing: it is a confident, wrong answer to the only question the report exists
+ * to answer.
+ */
+const OPT_OUT_KEY = 'styx.guidedTour.telemetry';
 
 export type FeedbackEvent = {
   type: 'route_view' | 'tooltip_open' | 'audience_change' | 'nav';
@@ -30,6 +51,13 @@ const collectorPort = process.env.NEXT_PUBLIC_STYX_FEEDBACK_PORT || '4312';
 /** Same hostname the viewer used, so every device reports to the presenter's machine. */
 function collectorBase(): string | null {
   if (typeof window === 'undefined') return null;
+  if (isSnapshotMode()) return null; // rule 4: no collector exists behind a static host
+  try {
+    if (window.localStorage.getItem(OPT_OUT_KEY) === 'off') return null;
+  } catch {
+    // localStorage can throw in a locked-down context; that is not a reason to
+    // break the demo, and telemetry is the layer that must yield (rule 1).
+  }
   return `${window.location.protocol}//${window.location.hostname}:${collectorPort}`;
 }
 

--- a/src/web/public/demo-snapshot/alecto.json
+++ b/src/web/public/demo-snapshot/alecto.json
@@ -8,16 +8,16 @@
     "total_staked": 0,
     "role": "FURY",
     "status": "ACTIVE",
-    "created_at": "2026-08-13T09:36:48.432Z",
+    "created_at": "2026-08-14T14:18:50.287Z",
     "compliance": {
       "kyc_status": "VERIFIED",
       "age_verification_status": "VERIFIED",
       "identity_provider": "MOCK",
       "identity_verification_id": "ivs_mock_demo_alecto",
-      "identity_verified_at": "2026-06-14T09:36:48.432Z",
+      "identity_verified_at": "2026-06-15T14:18:50.287Z",
       "is_kyc_verified": true,
       "is_age_verified": true,
-      "terms_accepted_at": "2026-06-13T09:36:48.432Z",
+      "terms_accepted_at": "2026-06-14T14:18:50.287Z",
       "terms_version": "2026-04"
     }
   }

--- a/src/web/public/demo-snapshot/hr.json
+++ b/src/web/public/demo-snapshot/hr.json
@@ -8,21 +8,21 @@
     "total_staked": 0,
     "role": "ADMIN",
     "status": "ACTIVE",
-    "created_at": "2026-08-13T09:36:48.432Z",
+    "created_at": "2026-08-14T14:18:50.287Z",
     "compliance": {
       "kyc_status": "VERIFIED",
       "age_verification_status": "VERIFIED",
       "identity_provider": "MOCK",
       "identity_verification_id": "ivs_mock_demo_hrlead",
-      "identity_verified_at": "2026-07-14T09:36:48.432Z",
+      "identity_verified_at": "2026-07-15T14:18:50.287Z",
       "is_kyc_verified": true,
       "is_age_verified": true,
-      "terms_accepted_at": "2026-07-13T09:36:48.432Z",
+      "terms_accepted_at": "2026-07-14T14:18:50.287Z",
       "terms_version": "2026-05"
     }
   },
   "GET /auth/csrf": {
-    "csrfToken": "3e0b510549e1bc6638f44d1a0f8afd28b1eb1ee135acd229d9b244d7533f0aac"
+    "csrfToken": "80c9d6f3e1647d4b88d2d820aae55459fe5ab1d616bc92642508f998ba647d80"
   },
   "GET /b2b/metrics/e0000000-0000-0000-0000-000000000001": {
     "enterpriseId": "e0000000-0000-0000-0000-000000000001",
@@ -42,6 +42,42 @@
     "pendingDisputes": 0
   },
   "GET /admin/disputes": [],
+  "GET /admin/financial-metrics": {
+    "cac": {
+      "current": 0,
+      "previous": 0,
+      "trend": 0
+    },
+    "ltv": {
+      "current": 0,
+      "previous": 0,
+      "trend": 0
+    },
+    "ltvCacRatio": {
+      "current": 0,
+      "trend": 0
+    },
+    "paybackDays": {
+      "current": 0,
+      "trend": 0
+    },
+    "monthlyBurn": {
+      "current": 0,
+      "previous": 0
+    },
+    "totalUsers": {
+      "current": 15,
+      "newThisMonth": 15
+    },
+    "payingUsers": {
+      "current": 8,
+      "pct": 0
+    },
+    "monthlyRevenue": {
+      "current": 445,
+      "recurringPct": 0
+    }
+  },
   "GET /admin/kill-switch": {
     "refundOnlyMode": false
   },
@@ -52,357 +88,357 @@
         "name": "Alaska",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "AL",
         "name": "Alabama",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "AR",
         "name": "Arkansas",
         "tier": "HARD_BLOCK",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "AZ",
         "name": "Arizona",
         "tier": "HARD_BLOCK",
         "disposition_mode": "REFUND_ONLY",
-        "updated_at": "2026-08-13T09:36:48.371Z"
+        "updated_at": "2026-08-14T14:18:50.230Z"
       },
       {
         "code": "CA",
         "name": "California",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "CO",
         "name": "Colorado",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "CT",
         "name": "Connecticut",
         "tier": "REFUND_ONLY",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "DC",
         "name": "District of Columbia",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "DE",
         "name": "Delaware",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "FL",
         "name": "Florida",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "GA",
         "name": "Georgia",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "HI",
         "name": "Hawaii",
         "tier": "HARD_BLOCK",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "IA",
         "name": "Iowa",
         "tier": "REFUND_ONLY",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "ID",
         "name": "Idaho",
         "tier": "HARD_BLOCK",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "IL",
         "name": "Illinois",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "IN",
         "name": "Indiana",
         "tier": "REFUND_ONLY",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "KS",
         "name": "Kansas",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "KY",
         "name": "Kentucky",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "LA",
         "name": "Louisiana",
         "tier": "REFUND_ONLY",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "MA",
         "name": "Massachusetts",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "MD",
         "name": "Maryland",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "ME",
         "name": "Maine",
         "tier": "REFUND_ONLY",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "MI",
         "name": "Michigan",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "MN",
         "name": "Minnesota",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "MO",
         "name": "Missouri",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "MS",
         "name": "Mississippi",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "MT",
         "name": "Montana",
         "tier": "HARD_BLOCK",
         "disposition_mode": "REFUND_ONLY",
-        "updated_at": "2026-08-13T09:36:48.371Z"
+        "updated_at": "2026-08-14T14:18:50.230Z"
       },
       {
         "code": "NC",
         "name": "North Carolina",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "ND",
         "name": "North Dakota",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "NE",
         "name": "Nebraska",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "NH",
         "name": "New Hampshire",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "NJ",
         "name": "New Jersey",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "NM",
         "name": "New Mexico",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "NV",
         "name": "Nevada",
         "tier": "HARD_BLOCK",
         "disposition_mode": "REFUND_ONLY",
-        "updated_at": "2026-08-13T09:36:48.371Z"
+        "updated_at": "2026-08-14T14:18:50.230Z"
       },
       {
         "code": "NY",
         "name": "New York",
         "tier": "REFUND_ONLY",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "OH",
         "name": "Ohio",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "OK",
         "name": "Oklahoma",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "OR",
         "name": "Oregon",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "PA",
         "name": "Pennsylvania",
         "tier": "REFUND_ONLY",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "RI",
         "name": "Rhode Island",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "SC",
         "name": "South Carolina",
         "tier": "HARD_BLOCK",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "SD",
         "name": "South Dakota",
         "tier": "HARD_BLOCK",
         "disposition_mode": "REFUND_ONLY",
-        "updated_at": "2026-08-13T09:36:48.371Z"
+        "updated_at": "2026-08-14T14:18:50.230Z"
       },
       {
         "code": "TN",
         "name": "Tennessee",
         "tier": "REFUND_ONLY",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "TX",
         "name": "Texas",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "UT",
         "name": "Utah",
         "tier": "HARD_BLOCK",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "VA",
         "name": "Virginia",
         "tier": "REFUND_ONLY",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "VT",
         "name": "Vermont",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "WA",
         "name": "Washington",
         "tier": "HARD_BLOCK",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "WI",
         "name": "Wisconsin",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "WV",
         "name": "West Virginia",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       },
       {
         "code": "WY",
         "name": "Wyoming",
         "tier": "FULL_ACCESS",
         "disposition_mode": "HOUSE_RETAINED",
-        "updated_at": "2026-08-13T09:36:48.182Z"
+        "updated_at": "2026-08-14T14:18:50.058Z"
       }
     ]
   }

--- a/src/web/public/demo-snapshot/moira.json
+++ b/src/web/public/demo-snapshot/moira.json
@@ -8,21 +8,18 @@
     "total_staked": 0,
     "role": "PRACTITIONER",
     "status": "ACTIVE",
-    "created_at": "2026-08-13T09:36:48.432Z",
+    "created_at": "2026-08-14T14:18:50.287Z",
     "compliance": {
       "kyc_status": "VERIFIED",
       "age_verification_status": "VERIFIED",
       "identity_provider": "MOCK",
       "identity_verification_id": "ivs_mock_demo_moira",
-      "identity_verified_at": "2026-05-15T09:36:48.432Z",
+      "identity_verified_at": "2026-05-16T14:18:50.287Z",
       "is_kyc_verified": true,
       "is_age_verified": true,
-      "terms_accepted_at": "2026-05-13T09:36:48.432Z",
+      "terms_accepted_at": "2026-05-14T14:18:50.287Z",
       "terms_version": "2026-04"
     }
-  },
-  "GET /auth/csrf": {
-    "csrfToken": "72c8e490b4883f2ca1c5641a58151d36d1463a9035ed37e4eca725208494ba91"
   },
   "GET /practitioner/dashboard": [
     {
@@ -71,21 +68,21 @@
           }
         ],
         "trend": "STABLE",
-        "lastUpdated": "2026-08-13T09:38:23.784Z"
+        "lastUpdated": "2026-08-14T14:20:32.258Z"
       },
       "recentAlerts": [
         {
-          "id": "83e39f6c-9adc-4b82-a7a6-5ba0dac4a50e",
+          "id": "e5ac8af2-836a-4325-ba76-79b5883cdf55",
           "userId": "d1000000-0000-0000-0000-000000000002",
           "alertType": "RATIONALIZATION",
           "excerpt": "just one more time",
           "severity": "MEDIUM",
-          "createdAt": "2026-08-11T09:36:48.447Z"
+          "createdAt": "2026-08-12T14:18:50.306Z"
         }
       ],
       "adherenceRate": 87,
       "streakDays": 13,
-      "nextCheckIn": "2026-08-13T03:00:00.000Z"
+      "nextCheckIn": "2026-08-14T03:00:00.000Z"
     },
     {
       "clientId": "d1000000-0000-0000-0000-000000000001",
@@ -133,19 +130,19 @@
           }
         ],
         "trend": "DECLINING",
-        "lastUpdated": "2026-08-13T09:38:23.786Z"
+        "lastUpdated": "2026-08-14T14:20:32.261Z"
       },
       "recentAlerts": [],
       "adherenceRate": 95,
       "streakDays": 21,
-      "nextCheckIn": "2026-08-13T03:00:00.000Z"
+      "nextCheckIn": "2026-08-14T03:00:00.000Z"
     },
     {
       "clientId": "d1000000-0000-0000-0000-000000000005",
       "clientAlias": "Sage Ellis",
       "riskProfile": {
         "userId": "d1000000-0000-0000-0000-000000000005",
-        "riskScore": 3,
+        "riskScore": 8,
         "riskLevel": "GREEN",
         "factors": [
           {
@@ -175,8 +172,8 @@
           {
             "type": "WEEKEND_COMPLIANCE",
             "weight": 0.1,
-            "value": 0.33333333333333337,
-            "description": "33% lower compliance on weekends"
+            "value": 0.75,
+            "description": "75% lower compliance on weekends"
           },
           {
             "type": "PREVIOUS_VIOLATIONS",
@@ -186,29 +183,29 @@
           }
         ],
         "trend": "STABLE",
-        "lastUpdated": "2026-08-13T09:38:23.788Z"
+        "lastUpdated": "2026-08-14T14:20:32.264Z"
       },
       "recentAlerts": [
         {
-          "id": "2fcafddd-e1d5-4425-b24f-824ef4c3b600",
+          "id": "791681df-e722-4058-b514-2be679abcd04",
           "userId": "d1000000-0000-0000-0000-000000000005",
           "alertType": "TRIGGER_MENTION",
           "excerpt": "saw them at the cafe near work",
           "severity": "LOW",
-          "createdAt": "2026-08-10T09:36:48.447Z"
+          "createdAt": "2026-08-11T14:18:50.306Z"
         }
       ],
       "adherenceRate": 83,
       "streakDays": 5,
-      "nextCheckIn": "2026-08-13T03:00:00.000Z"
+      "nextCheckIn": "2026-08-14T03:00:00.000Z"
     },
     {
       "clientId": "d1000000-0000-0000-0000-000000000006",
       "clientAlias": "Indigo Park",
       "riskProfile": {
         "userId": "d1000000-0000-0000-0000-000000000006",
-        "riskScore": 28,
-        "riskLevel": "GREEN",
+        "riskScore": 31,
+        "riskLevel": "YELLOW",
         "factors": [
           {
             "type": "ATTESTATION_CONSISTENCY",
@@ -237,8 +234,8 @@
           {
             "type": "WEEKEND_COMPLIANCE",
             "weight": 0.1,
-            "value": 0.33333333333333337,
-            "description": "33% lower compliance on weekends"
+            "value": 0.5714285714285714,
+            "description": "57% lower compliance on weekends"
           },
           {
             "type": "PREVIOUS_VIOLATIONS",
@@ -248,21 +245,21 @@
           }
         ],
         "trend": "DECLINING",
-        "lastUpdated": "2026-08-13T09:38:23.789Z"
+        "lastUpdated": "2026-08-14T14:20:32.266Z"
       },
       "recentAlerts": [
         {
-          "id": "c5f367ef-daee-4c6d-8ec6-58097a700bda",
+          "id": "781cf344-41a5-4199-8f07-bc4453ca76b0",
           "userId": "d1000000-0000-0000-0000-000000000006",
           "alertType": "DISTRESS_ESCALATION",
           "excerpt": "falling apart",
           "severity": "HIGH",
-          "createdAt": "2026-08-12T09:36:48.447Z"
+          "createdAt": "2026-08-13T14:18:50.306Z"
         }
       ],
       "adherenceRate": 77,
       "streakDays": 10,
-      "nextCheckIn": "2026-08-13T03:00:00.000Z"
+      "nextCheckIn": "2026-08-14T03:00:00.000Z"
     }
   ]
 }

--- a/src/web/public/demo-snapshot/river.json
+++ b/src/web/public/demo-snapshot/river.json
@@ -8,32 +8,21 @@
     "total_staked": 55,
     "role": "USER",
     "status": "ACTIVE",
-    "created_at": "2026-08-13T09:36:48.432Z",
+    "created_at": "2026-08-14T14:18:50.287Z",
     "compliance": {
       "kyc_status": "VERIFIED",
       "age_verification_status": "VERIFIED",
       "identity_provider": "MOCK",
       "identity_verification_id": "ivs_mock_demo_river",
-      "identity_verified_at": "2026-07-19T09:36:48.432Z",
+      "identity_verified_at": "2026-07-20T14:18:50.287Z",
       "is_kyc_verified": true,
       "is_age_verified": true,
-      "terms_accepted_at": "2026-07-18T09:36:48.432Z",
+      "terms_accepted_at": "2026-07-19T14:18:50.287Z",
       "terms_version": "2026-05"
     }
   },
   "GET /auth/csrf": {
-    "csrfToken": "2795eea5ea84602d44c43dabd6628a13235122c6550e4ad80e307337db55f4f3"
-  },
-  "GET /wallet/balance": {
-    "id": "d1000000-0000-0000-0000-000000000001",
-    "email": "river@demo.styx.protocol",
-    "integrity_score": 82,
-    "allowed_tiers": [
-      "TIER_1_MICRO_STAKES",
-      "TIER_2_STANDARD"
-    ],
-    "ledger_balance": -55,
-    "status": "ACTIVE"
+    "csrfToken": "9e31ed9608f1a63e1377d2010e8c508e68ca3477b3b9a7bf1f3f71ee4601c0d2"
   },
   "GET /contracts": [
     {
@@ -47,10 +36,10 @@
       "status": "ACTIVE",
       "grace_days_used": 0,
       "strikes": 0,
-      "started_at": "2026-07-23T09:36:48.437Z",
-      "ends_at": "2026-09-21T09:36:48.437Z",
-      "created_at": "2026-08-13T09:36:48.437Z",
-      "updated_at": "2026-08-13T09:36:48.437Z",
+      "started_at": "2026-07-24T14:18:50.292Z",
+      "ends_at": "2026-09-22T14:18:50.292Z",
+      "created_at": "2026-08-14T14:18:50.292Z",
+      "updated_at": "2026-08-14T14:18:50.292Z",
       "bounty_link_id": null,
       "realm_id": "RECOVERY_ABSTINENCE",
       "grace_period_month": null,
@@ -80,10 +69,10 @@
       "status": "ACTIVE",
       "grace_days_used": 0,
       "strikes": 0,
-      "started_at": "2026-08-07T09:36:48.437Z",
-      "ends_at": "2026-08-21T09:36:48.437Z",
-      "created_at": "2026-08-13T09:36:48.437Z",
-      "updated_at": "2026-08-13T09:36:48.437Z",
+      "started_at": "2026-08-08T14:18:50.292Z",
+      "ends_at": "2026-08-22T14:18:50.292Z",
+      "created_at": "2026-08-14T14:18:50.292Z",
+      "updated_at": "2026-08-14T14:18:50.292Z",
       "bounty_link_id": null,
       "realm_id": "COGNITIVE_DEVICE",
       "grace_period_month": null,
@@ -96,55 +85,13 @@
       "proof_count": 2
     }
   ],
-  "GET /wallet/history?limit=10": {
-    "transactions": [
-      {
-        "id": "ee100000-0000-0000-0000-000000000001",
-        "type": "STAKE_HOLD",
-        "amount": -40,
-        "timestamp": "2026-08-13T09:36:48.444Z",
-        "description": "STAKE_HOLD"
-      },
-      {
-        "id": "ee100000-0000-0000-0000-000000000008",
-        "type": "STAKE_HOLD",
-        "amount": -15,
-        "timestamp": "2026-08-13T09:36:48.444Z",
-        "description": "STAKE_HOLD"
-      }
-    ]
-  },
-  "GET /wallet/history": {
-    "transactions": [
-      {
-        "id": "ee100000-0000-0000-0000-000000000001",
-        "type": "STAKE_HOLD",
-        "amount": -40,
-        "timestamp": "2026-08-13T09:36:48.444Z",
-        "description": "STAKE_HOLD"
-      },
-      {
-        "id": "ee100000-0000-0000-0000-000000000008",
-        "type": "STAKE_HOLD",
-        "amount": -15,
-        "timestamp": "2026-08-13T09:36:48.444Z",
-        "description": "STAKE_HOLD"
-      }
-    ]
-  },
   "GET /dashboard/streak": {
     "days": [
-      {
-        "date": "2026-07-15",
-        "attested": false,
-        "graceUsed": false,
-        "chainBroken": false
-      },
       {
         "date": "2026-07-16",
         "attested": false,
         "graceUsed": false,
-        "chainBroken": true
+        "chainBroken": false
       },
       {
         "date": "2026-07-17",
@@ -184,9 +131,9 @@
       },
       {
         "date": "2026-07-23",
-        "attested": true,
+        "attested": false,
         "graceUsed": false,
-        "chainBroken": false
+        "chainBroken": true
       },
       {
         "date": "2026-07-24",
@@ -310,6 +257,12 @@
       },
       {
         "date": "2026-08-13",
+        "attested": true,
+        "graceUsed": false,
+        "chainBroken": false
+      },
+      {
+        "date": "2026-08-14",
         "attested": false,
         "graceUsed": false,
         "chainBroken": false
@@ -319,6 +272,53 @@
     "longestStreak": 21,
     "neverMissTwiceActive": false,
     "penaltyMultiplier": 2
+  },
+  "GET /wallet/balance": {
+    "id": "d1000000-0000-0000-0000-000000000001",
+    "email": "river@demo.styx.protocol",
+    "integrity_score": 82,
+    "allowed_tiers": [
+      "TIER_1_MICRO_STAKES",
+      "TIER_2_STANDARD"
+    ],
+    "ledger_balance": -55,
+    "status": "ACTIVE"
+  },
+  "GET /wallet/history?limit=10": {
+    "transactions": [
+      {
+        "id": "ee100000-0000-0000-0000-000000000001",
+        "type": "STAKE_HOLD",
+        "amount": -40,
+        "timestamp": "2026-08-14T14:18:50.303Z",
+        "description": "STAKE_HOLD"
+      },
+      {
+        "id": "ee100000-0000-0000-0000-000000000008",
+        "type": "STAKE_HOLD",
+        "amount": -15,
+        "timestamp": "2026-08-14T14:18:50.303Z",
+        "description": "STAKE_HOLD"
+      }
+    ]
+  },
+  "GET /wallet/history": {
+    "transactions": [
+      {
+        "id": "ee100000-0000-0000-0000-000000000001",
+        "type": "STAKE_HOLD",
+        "amount": -40,
+        "timestamp": "2026-08-14T14:18:50.303Z",
+        "description": "STAKE_HOLD"
+      },
+      {
+        "id": "ee100000-0000-0000-0000-000000000008",
+        "type": "STAKE_HOLD",
+        "amount": -15,
+        "timestamp": "2026-08-14T14:18:50.303Z",
+        "description": "STAKE_HOLD"
+      }
+    ]
   },
   "GET /notifications": [
     {
@@ -332,7 +332,7 @@
         "streak": 21,
         "contractId": "c1000000-0000-0000-0000-000000000001"
       },
-      "created_at": "2026-08-13T09:36:48.446Z"
+      "created_at": "2026-08-14T14:18:50.305Z"
     }
   ],
   "GET /notifications/unread-count": {
@@ -349,10 +349,10 @@
     "status": "ACTIVE",
     "grace_days_used": 0,
     "strikes": 0,
-    "started_at": "2026-07-23T09:36:48.437Z",
-    "ends_at": "2026-09-21T09:36:48.437Z",
-    "created_at": "2026-08-13T09:36:48.437Z",
-    "updated_at": "2026-08-13T09:36:48.437Z",
+    "started_at": "2026-07-24T14:18:50.292Z",
+    "ends_at": "2026-09-22T14:18:50.292Z",
+    "created_at": "2026-08-14T14:18:50.292Z",
+    "updated_at": "2026-08-14T14:18:50.292Z",
     "bounty_link_id": null,
     "realm_id": "RECOVERY_ABSTINENCE",
     "grace_period_month": null,
@@ -390,14 +390,14 @@
         "id": "ee100000-0000-0000-0000-000000000001",
         "type": "STAKE_HOLD",
         "amount": -40,
-        "timestamp": "2026-08-13T09:36:48.444Z",
+        "timestamp": "2026-08-14T14:18:50.303Z",
         "description": "STAKE_HOLD"
       },
       {
         "id": "ee100000-0000-0000-0000-000000000008",
         "type": "STAKE_HOLD",
         "amount": -15,
-        "timestamp": "2026-08-13T09:36:48.444Z",
+        "timestamp": "2026-08-14T14:18:50.303Z",
         "description": "STAKE_HOLD"
       }
     ]
@@ -509,6 +509,23 @@
       }
     }
   ],
+  "GET /realms/recovery-abstinence/contracts": {
+    "realmId": "RECOVERY_ABSTINENCE",
+    "realmSlug": "recovery-abstinence",
+    "contracts": [
+      {
+        "id": "c1000000-0000-0000-0000-000000000001",
+        "oath_category": "RECOVERY_NO_CONTACT_TEXT",
+        "verification_method": "SELF_REPORT",
+        "stake_amount": "40.0000",
+        "status": "ACTIVE",
+        "duration_days": 60,
+        "started_at": "2026-07-24T14:18:50.292Z",
+        "ends_at": "2026-09-22T14:18:50.292Z",
+        "created_at": "2026-08-14T14:18:50.292Z"
+      }
+    ]
+  },
   "GET /realms/recovery-abstinence": {
     "id": "RECOVERY_ABSTINENCE",
     "displayName": "Recovery Abstinence",
@@ -548,48 +565,31 @@
       "totalStaked": 285
     }
   },
-  "GET /realms/recovery-abstinence/contracts": {
-    "realmId": "RECOVERY_ABSTINENCE",
-    "realmSlug": "recovery-abstinence",
-    "contracts": [
-      {
-        "id": "c1000000-0000-0000-0000-000000000001",
-        "oath_category": "RECOVERY_NO_CONTACT_TEXT",
-        "verification_method": "SELF_REPORT",
-        "stake_amount": "40.0000",
-        "status": "ACTIVE",
-        "duration_days": 60,
-        "started_at": "2026-07-23T09:36:48.437Z",
-        "ends_at": "2026-09-21T09:36:48.437Z",
-        "created_at": "2026-08-13T09:36:48.437Z"
-      }
-    ]
-  },
   "GET /feed?limit=50": {
     "events": [
       {
         "id": "e1100000-0000-0000-0000-000000000002",
         "type": "contract_created",
         "message": "Someone committed $40 to a  behavioral oath",
-        "timestamp": "2026-08-13T09:36:48.446Z"
+        "timestamp": "2026-08-14T14:18:50.306Z"
       },
       {
         "id": "e1100000-0000-0000-0000-000000000003",
         "type": "contract_created",
         "message": "System event recorded",
-        "timestamp": "2026-08-13T09:36:48.446Z"
+        "timestamp": "2026-08-14T14:18:50.306Z"
       },
       {
         "id": "e1000000-0000-0000-0000-000000000001",
         "type": "contract_created",
         "message": "Someone committed $50 to a  behavioral oath",
-        "timestamp": "2026-08-13T09:36:48.416Z"
+        "timestamp": "2026-08-14T14:18:50.270Z"
       },
       {
         "id": "e1000000-0000-0000-0000-000000000002",
         "type": "contract_created",
         "message": "System event recorded",
-        "timestamp": "2026-08-13T09:36:48.416Z"
+        "timestamp": "2026-08-14T14:18:50.270Z"
       }
     ]
   },
@@ -599,25 +599,25 @@
         "id": "e1100000-0000-0000-0000-000000000002",
         "type": "contract_created",
         "message": "Someone committed $40 to a  behavioral oath",
-        "timestamp": "2026-08-13T09:36:48.446Z"
+        "timestamp": "2026-08-14T14:18:50.306Z"
       },
       {
         "id": "e1100000-0000-0000-0000-000000000003",
         "type": "contract_created",
         "message": "System event recorded",
-        "timestamp": "2026-08-13T09:36:48.446Z"
+        "timestamp": "2026-08-14T14:18:50.306Z"
       },
       {
         "id": "e1000000-0000-0000-0000-000000000001",
         "type": "contract_created",
         "message": "Someone committed $50 to a  behavioral oath",
-        "timestamp": "2026-08-13T09:36:48.416Z"
+        "timestamp": "2026-08-14T14:18:50.270Z"
       },
       {
         "id": "e1000000-0000-0000-0000-000000000002",
         "type": "contract_created",
         "message": "System event recorded",
-        "timestamp": "2026-08-13T09:36:48.416Z"
+        "timestamp": "2026-08-14T14:18:50.270Z"
       }
     ]
   },
@@ -626,61 +626,61 @@
       "id": "d0000000-0000-0000-0000-000000000003",
       "email": "admin@styx.protocol",
       "integrity_score": 200,
-      "created_at": "2026-08-13T09:36:48.409Z"
+      "created_at": "2026-08-14T14:18:50.264Z"
     },
     {
       "id": "d1000000-0000-0000-0000-00000000000b",
       "email": "dr.moira@demo.styx.protocol",
       "integrity_score": 99,
-      "created_at": "2026-08-13T09:36:48.432Z"
+      "created_at": "2026-08-14T14:18:50.287Z"
     },
     {
       "id": "d1000000-0000-0000-0000-000000000008",
       "email": "alecto@demo.styx.protocol",
       "integrity_score": 95,
-      "created_at": "2026-08-13T09:36:48.432Z"
+      "created_at": "2026-08-14T14:18:50.287Z"
     },
     {
       "id": "d1000000-0000-0000-0000-000000000004",
       "email": "wren@demo.styx.protocol",
       "integrity_score": 93,
-      "created_at": "2026-08-13T09:36:48.432Z"
+      "created_at": "2026-08-14T14:18:50.287Z"
     },
     {
       "id": "d1000000-0000-0000-0000-000000000009",
       "email": "megaera@demo.styx.protocol",
       "integrity_score": 91,
-      "created_at": "2026-08-13T09:36:48.432Z"
+      "created_at": "2026-08-14T14:18:50.287Z"
     },
     {
       "id": "d0000000-0000-0000-0000-000000000002",
       "email": "fury@styx.protocol",
       "integrity_score": 90,
-      "created_at": "2026-08-13T09:36:48.409Z"
+      "created_at": "2026-08-14T14:18:50.264Z"
     },
     {
       "id": "d1000000-0000-0000-0000-00000000000a",
       "email": "tisiphone@demo.styx.protocol",
       "integrity_score": 88,
-      "created_at": "2026-08-13T09:36:48.432Z"
+      "created_at": "2026-08-14T14:18:50.287Z"
     },
     {
       "id": "d1000000-0000-0000-0000-00000000000c",
       "email": "hr.lead@acheron.example",
       "integrity_score": 85,
-      "created_at": "2026-08-13T09:36:48.432Z"
+      "created_at": "2026-08-14T14:18:50.287Z"
     },
     {
       "id": "d1000000-0000-0000-0000-000000000001",
       "email": "river@demo.styx.protocol",
       "integrity_score": 82,
-      "created_at": "2026-08-13T09:36:48.432Z"
+      "created_at": "2026-08-14T14:18:50.287Z"
     },
     {
       "id": "d0000000-0000-0000-0000-000000000001",
       "email": "demo@styx.protocol",
       "integrity_score": 75,
-      "created_at": "2026-08-13T09:36:48.409Z"
+      "created_at": "2026-08-14T14:18:50.264Z"
     }
   ],
   "GET /users/leaderboard": [
@@ -688,66 +688,66 @@
       "id": "d0000000-0000-0000-0000-000000000003",
       "email": "admin@styx.protocol",
       "integrity_score": 200,
-      "created_at": "2026-08-13T09:36:48.409Z"
+      "created_at": "2026-08-14T14:18:50.264Z"
     },
     {
       "id": "d1000000-0000-0000-0000-00000000000b",
       "email": "dr.moira@demo.styx.protocol",
       "integrity_score": 99,
-      "created_at": "2026-08-13T09:36:48.432Z"
+      "created_at": "2026-08-14T14:18:50.287Z"
     },
     {
       "id": "d1000000-0000-0000-0000-000000000008",
       "email": "alecto@demo.styx.protocol",
       "integrity_score": 95,
-      "created_at": "2026-08-13T09:36:48.432Z"
+      "created_at": "2026-08-14T14:18:50.287Z"
     },
     {
       "id": "d1000000-0000-0000-0000-000000000004",
       "email": "wren@demo.styx.protocol",
       "integrity_score": 93,
-      "created_at": "2026-08-13T09:36:48.432Z"
+      "created_at": "2026-08-14T14:18:50.287Z"
     },
     {
       "id": "d1000000-0000-0000-0000-000000000009",
       "email": "megaera@demo.styx.protocol",
       "integrity_score": 91,
-      "created_at": "2026-08-13T09:36:48.432Z"
+      "created_at": "2026-08-14T14:18:50.287Z"
     },
     {
       "id": "d0000000-0000-0000-0000-000000000002",
       "email": "fury@styx.protocol",
       "integrity_score": 90,
-      "created_at": "2026-08-13T09:36:48.409Z"
+      "created_at": "2026-08-14T14:18:50.264Z"
     },
     {
       "id": "d1000000-0000-0000-0000-00000000000a",
       "email": "tisiphone@demo.styx.protocol",
       "integrity_score": 88,
-      "created_at": "2026-08-13T09:36:48.432Z"
+      "created_at": "2026-08-14T14:18:50.287Z"
     },
     {
       "id": "d1000000-0000-0000-0000-00000000000c",
       "email": "hr.lead@acheron.example",
       "integrity_score": 85,
-      "created_at": "2026-08-13T09:36:48.432Z"
+      "created_at": "2026-08-14T14:18:50.287Z"
     },
     {
       "id": "d1000000-0000-0000-0000-000000000001",
       "email": "river@demo.styx.protocol",
       "integrity_score": 82,
-      "created_at": "2026-08-13T09:36:48.432Z"
+      "created_at": "2026-08-14T14:18:50.287Z"
     },
     {
       "id": "d0000000-0000-0000-0000-000000000001",
       "email": "demo@styx.protocol",
       "integrity_score": 75,
-      "created_at": "2026-08-13T09:36:48.409Z"
+      "created_at": "2026-08-14T14:18:50.264Z"
     }
   ],
   "GET /referrals/code": {
-    "code": "1D89FC0F",
-    "url": "https://styx.app/join/1D89FC0F"
+    "code": "10DBB17C",
+    "url": "https://styx.app/join/10DBB17C"
   },
   "GET /referrals/rewards": {
     "totalReferrals": 0,
@@ -755,6 +755,10 @@
     "pendingReferrals": 0,
     "totalRewardCents": 0,
     "rewards": []
+  },
+  "GET /behavioral/habit-strength": {
+    "strength": 0.04,
+    "label": "Fragile"
   },
   "GET /behavioral/reentry/eligibility": {
     "eligible": false,

--- a/src/web/services/snapshot-fetch.ts
+++ b/src/web/services/snapshot-fetch.ts
@@ -1,0 +1,94 @@
+/**
+ * Snapshot interception at the `fetch` boundary.
+ *
+ * WHY THIS EXISTS, and why intercepting in api-client was not enough.
+ *
+ * `services/api-client.ts` is *a* HTTP client, not *the* HTTP client. Eighteen
+ * call sites in `app/` and `components/` call `fetch('/api/...')` directly --
+ * `/realms`, `/kyc`, `/practitioner`, the `/behavioral/*` pages and
+ * `/admin/cac-ltv` among them. Hooking only api-client covered 40 of 48 routes
+ * and left 8 issuing a real network request on a static host, where it can only
+ * 404. Those pages then rendered "API 404" to the viewer.
+ *
+ * That is the exact failure `services/snapshot.ts` documents itself as existing
+ * to prevent -- a plausible, wrong screen -- and it was invisible to every gate:
+ * the export builds, all 77 pages render, and each route still answers HTTP 200
+ * because the error lives *inside* the page.
+ *
+ * So the interception belongs at the boundary every client necessarily crosses.
+ * A route added tomorrow with a hand-rolled `fetch` is covered without anyone
+ * remembering this file exists, which is the only property that makes the
+ * guarantee durable.
+ *
+ * It is inert outside snapshot mode: `isSnapshotMode()` is a build-time constant,
+ * so a normal build keeps its real network stack untouched.
+ */
+import { isSnapshotMode, snapshotRespond } from './snapshot';
+
+let installed = false;
+
+/** Resolves whatever fetch() accepts into an absolute URL, or null if unparseable. */
+function resolveUrl(input: RequestInfo | URL): URL | null {
+  try {
+    if (typeof input === 'string') return new URL(input, window.location.href);
+    if (input instanceof URL) return input;
+    return new URL(input.url, window.location.href);
+  } catch {
+    return null;
+  }
+}
+
+function resolveMethod(input: RequestInfo | URL, init?: RequestInit): string {
+  if (init?.method) return String(init.method).toUpperCase();
+  if (typeof input !== 'string' && !(input instanceof URL)) return input.method.toUpperCase();
+  return 'GET';
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+/**
+ * Patches window.fetch so same-origin /api/* requests are answered from the
+ * captured fixtures. Everything else -- including snapshot.ts's own fetch of
+ * /demo-snapshot/<persona>.json -- passes straight through to the real fetch,
+ * which is captured before the patch to make that unambiguous.
+ */
+export function installSnapshotFetch(): void {
+  if (!isSnapshotMode()) return;
+  if (installed || typeof window === 'undefined') return;
+  installed = true;
+
+  const nativeFetch = window.fetch.bind(window);
+
+  window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = resolveUrl(input);
+    if (!url || url.origin !== window.location.origin || !url.pathname.startsWith('/api/')) {
+      return nativeFetch(input as RequestInfo, init);
+    }
+
+    const path = url.pathname.slice('/api'.length) + (url.search || '');
+    const result = await snapshotRespond<unknown>(path, resolveMethod(input, init));
+    if (result.ok) return jsonResponse(result.data, 200);
+
+    // A 404 means no fixture was captured for this endpoint. Record it where a
+    // verifier can read it, because the on-screen result is NOT reliably visible:
+    // several pages swallow the error and render their zero state, which is how
+    // /admin/cac-ltv showed "$0 revenue, 0 users" -- a sentence about the business
+    // that no one wrote and that happened to be false. A page rendering nonsense
+    // silently is exactly what this snapshot must never do.
+    if (result.status === 404) {
+      const misses = (window as Window & { __STYX_SNAPSHOT_MISSES__?: string[] });
+      misses.__STYX_SNAPSHOT_MISSES__ = misses.__STYX_SNAPSHOT_MISSES__ || [];
+      misses.__STYX_SNAPSHOT_MISSES__.push(path);
+    }
+
+    // Callers read `message` off the error body (see practitionerFetch, kycFetch),
+    // so the honest explanation reaches the screen through code that already exists
+    // rather than needing every page to learn about snapshot mode.
+    return jsonResponse({ message: result.message, error: 'SNAPSHOT_READ_ONLY' }, result.status);
+  };
+}


### PR DESCRIPTION
## What this fixes

Verifying the Cloudflare snapshot's **behaviour** rather than its gates turned up four
defects, two in the demo packaging and two in the live product API.

### 1. 8 of 48 snapshot routes rendered "API 404"

Snapshot interception was installed in `services/api-client.ts` on the assumption that it
was *the* HTTP client. It is only *a* client — 18 call sites call `fetch('/api/…')`
directly. So `/realms`, `/realms/[slug]`, `/kyc`, `/practitioner`, `/admin/cac-ltv` and
three `/behavioral` pages issued real network requests to a static host.

Nothing caught it: the export builds, all 77 pages render, `/tour` is perfect, and every
broken route still answers `200` — the error is text *inside* the page.

Interception now sits on `window.fetch`, the boundary every client crosses.

### 2. Telemetry pointed at a host that cannot exist

From a `pages.dev` origin the guided tour aimed every viewer at
`https://<pages-host>:4312`, which HTTPS blocks as mixed content. Separately, every script
that drives a browser was being counted as an attendee — the feedback report read
**"8 viewer(s)"** for a demo no human had ever opened.

### 3. `/admin/financial-metrics` 403'd every administrator, always

The handler carried `@Roles("admin")`; `RoleGuard` compares case-sensitively against the DB
role, and `getAllAndOverride` let it replace the controller's `@Roles("ADMIN")`. The
dashboard caught the error and rendered zeros, so it reported **"$0 revenue, 0 users."**

### 4. `/behavioral/habit-strength` 500'd on an ambiguous column

`SELECT … WHERE status IN (…)` over a join of `attestations` and `contracts`, both of which
have `status`.

## The durable part

`npm run snapshot:verify` drives all 48 registry routes and exits 0 ⟺ the snapshot is
shippable. `snapshot:deploy` runs it first, so a snapshot that renders API errors cannot be
published. It fails on: a route that reaches for `/api`, a route that calls off-origin, a
route that renders nothing, and — the useful one — **a route with no fixture**, which
usually means that endpoint is broken on the live demo, because the capture only records
2xx. That check is what found bugs 3 and 4.

## Verification

Every check below was run bare and its own exit code read.

| Check | Result |
|---|---|
| `snapshot.sh verify` **before** the fix | exit **1** — 48 routes flagged, 8 with `/api` calls |
| `snapshot.sh verify` after | exit **0** — 48/48, no backend, no off-origin, no missing fixtures |
| Predicate with a fixture deleted | exit **1**, names the exact route and endpoint |
| `role.guard.spec.ts` with the lowercase decorator restored | exit **1** |
| `role.guard.spec.ts` | exit 0 — 12/12 |
| API `guards` + `behavioral` suites | exit 0 — 235/235, 20 suites |
| `guided-tour` registry suite | exit 0 — 7/7 |
| `tsc --noEmit` (web, api) | exit 0 |
| `demo:reset:verify` | exit 0 |
| Live probe of both endpoints | 403 → **200**, 500 → **200** |
| Capture run after the opt-out | **0** collector rows from 132 route-visits |

`/admin/cac-ltv` now renders Total Users 15, Paying Users 8, Monthly Revenue $445 instead of
all zeros. CAC/LTV/payback/burn remain zero — those are hard-coded in the API and the
product does not compute them yet; the runbook now says so rather than letting the tiles
imply measurement.

## Note on scope

Two concerns on one branch, deliberately: the snapshot fixtures cannot be captured until the
API bugs are fixed, so splitting would have stacked the PRs. They are separate commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmP1SLhXcZBmA7g4NM6PTY

## Summary by Sourcery

Strengthen demo snapshot verification so all guided-tour routes render from fixtures without backend calls, and fix two live API issues that were masking as empty states.

Bug Fixes:
- Correct admin financial metrics access control so administrators with role ADMIN can reach the endpoint instead of being 403ed.
- Fix habit-strength behavioral query by disambiguating status column to prevent server errors.
- Ensure snapshot interception covers all same-origin /api requests via a fetch-level shim, preventing 404s in the hosted snapshot.
- Disable guided-tour telemetry in snapshot mode and for automation/recorders to avoid mixed-content errors and phantom viewer sessions.

Enhancements:
- Add a Playwright-based snapshot verification sweep over all guided-tour routes that fails on backend usage, off-origin calls, thin renders, or missing fixtures.
- Introduce a static analysis check over @Roles decorators to ensure only canonical roles are used and catch unreachable, silently-failing endpoints.
- Document snapshot verification, telemetry opt-out, and the non-computed nature of CAC/LTV/payback/burn in the demo runbook to set correct expectations.

Build:
- Add npm script and shell support for snapshot:verify, integrating it as a gate before snapshot deployment.

Tests:
- Extend RoleGuard tests to cover case-sensitive role mismatches and add a static sweep asserting all @Roles decorators use canonical roles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Demo snapshots now work in read-only mode using captured data, including financial metrics and behavioral insights.
  * Added snapshot verification to detect missing data, failed pages, and unexpected network access before publishing.
* **Bug Fixes**
  * Corrected administrator access to financial metrics.
  * Fixed habit-strength reporting and refreshed demo dashboard, compliance, contract, and activity data.
* **Privacy**
  * Browser-recorded demos and static snapshots no longer send guided-tour telemetry.
* **Documentation**
  * Updated the demo runbook with verification, privacy, and metric details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->