### PR TITLE
fix(auth): refresh cookie path '/' at both issue sites — silent refresh survives the /api rewrite

### DIFF
--- a/src/api/src/modules/auth/auth.controller.spec.ts
+++ b/src/api/src/modules/auth/auth.controller.spec.ts
@@ -9,6 +9,7 @@ const mockAuthService = {
   login: jest.fn(),
   exchangeEnterpriseToken: jest.fn(),
   generateRefreshToken: jest.fn().mockResolvedValue('mock-refresh-token'), // allow-secret
+  refreshAccessToken: jest.fn(),
   revokeRefreshTokensForUser: jest.fn().mockResolvedValue(undefined),
   verifyToken: jest.fn(),
   verifyTokenIgnoringExpiry: jest.fn(),
@@ -117,6 +118,51 @@ describe('AuthController', () => {
       const dto = plainToInstance(LoginDto, { email: 'test@styx.protocol', password: 'short' }); // allow-secret
       const errors = await validate(dto);
       expect(errors.some((e) => e.property === 'password')).toBe(false);
+    });
+
+    it('sets the refresh cookie on path "/" so it survives the web /api rewrite', async () => {
+      // Browsers reach this API only through the web app's /api rewrite, so the
+      // path they see for refresh is /api/auth/refresh. A cookie scoped to
+      // '/auth/refresh' is never sent back, every silent refresh 401s, and the
+      // user is hard-logged-out when the 15-minute access token expires.
+      (mockAuthService.login as jest.Mock).mockResolvedValue({
+        userId: 'user-id',
+        token: 'jwt-token', // allow-secret
+      });
+
+      await controller.login(
+        plainToInstance(LoginDto, {
+          email: 'test@styx.protocol',
+          password: 'secure123', // allow-secret
+        }),
+        mockResponse,
+      );
+
+      const refreshCall = (mockResponse.cookie as jest.Mock).mock.calls.find(
+        ([name]: [string]) => name === 'styx_refresh_token',
+      );
+      expect(refreshCall).toBeDefined();
+      expect(refreshCall[2].path).toBe('/');
+    });
+
+    it('re-issues the ROTATED refresh cookie on path "/" as well', async () => {
+      // Fixing only the login site would make the first silent refresh succeed
+      // and the second fail: rotation issues a fresh cookie, and if that copy
+      // reverts to a scoped path the hard logout just moves 15 minutes later.
+      (mockAuthService as any).refreshAccessToken.mockResolvedValue({
+        userId: 'user-id',
+        token: 'rotated-jwt', // allow-secret
+        refreshToken: 'rotated-refresh', // allow-secret
+      });
+      const req = { headers: { cookie: 'styx_refresh_token=old-refresh' } } as any;
+
+      await controller.refresh(req, mockResponse);
+
+      const rotatedCall = (mockResponse.cookie as jest.Mock).mock.calls.find(
+        ([name]: [string]) => name === 'styx_refresh_token',
+      );
+      expect(rotatedCall).toBeDefined();
+      expect(rotatedCall[2].path).toBe('/');
     });
   });
 

--- a/src/api/src/modules/auth/auth.controller.ts
+++ b/src/api/src/modules/auth/auth.controller.ts
@@ -42,13 +42,17 @@ export class AuthController {
       maxAge: ACCESS_TOKEN_MAX_AGE_MS,
     });
 
-    // Refresh token — long-lived (7 days), restricted to /auth/refresh path
+    // Refresh token — long-lived (7 days). Path must be '/': the browser only
+    // ever reaches this API through the web app's /api rewrite, so the path it
+    // sees for refresh is /api/auth/refresh — a path-scoped '/auth/refresh'
+    // cookie is never sent and every silent refresh 401s, hard-logging users
+    // out when the 15-minute access token expires.
     const refreshToken = await this.authService.generateRefreshToken(userId); // allow-secret
     res.cookie('styx_refresh_token', refreshToken, {
       httpOnly: true,
       secure,
       sameSite,
-      path: '/auth/refresh',
+      path: '/',
       maxAge: REFRESH_TOKEN_MAX_AGE_MS,
     });
 
@@ -65,6 +69,9 @@ export class AuthController {
     const secure = process.env.NODE_ENV === 'production';
     const sameSite = 'lax' as const;
     res.clearCookie('styx_auth_token', { path: '/', secure, sameSite });
+    res.clearCookie('styx_refresh_token', { path: '/', secure, sameSite });
+    // Also clear any legacy path-scoped copy from before the path fix, so a
+    // stale cookie cannot shadow future sessions on direct-origin clients.
     res.clearCookie('styx_refresh_token', { path: '/auth/refresh', secure, sameSite });
     res.clearCookie('styx_csrf_token', { path: '/', secure, sameSite });
   }
@@ -124,11 +131,14 @@ export class AuthController {
       maxAge: ACCESS_TOKEN_MAX_AGE_MS,
     });
 
+    // Rotation must keep path '/' too — fixing only the login site would make
+    // the FIRST silent refresh succeed and the second (which carries the
+    // rotated cookie issued here) fail with the same hard logout.
     res.cookie('styx_refresh_token', result.refreshToken, {
       httpOnly: true,
       secure,
       sameSite,
-      path: '/auth/refresh',
+      path: '/',
       maxAge: REFRESH_TOKEN_MAX_AGE_MS,
     });
 


### PR DESCRIPTION
**Every browser session hard-logs-out 15 minutes after login.** The refresh cookie is scoped to `path: '/auth/refresh'`, but browsers only reach this API through the web app's `/api` rewrite — the path they request is `/api/auth/refresh`, which the scoped cookie never matches. So the cookie is never sent, every silent refresh 401s (`api-client.ts` auto-refresh), and the user is dumped to login when the 15-minute access token expires. Broken locally too; invisible in short rehearsals, fatal for a 30-minute user test — found while preparing the Render beta for remote testers.

**Two issue sites, both fixed to `path: '/'`:**
1. `issueBrowserSessionCookies` (login / register / enterprise)
2. the rotation in `POST /auth/refresh` — fixing only site 1 makes the *first* refresh succeed and the *second* fail, moving the hard logout from minute 15 to minute 30

Logout additionally clears the legacy path-scoped copy so a stale cookie can't shadow future sessions on direct-origin clients.

**Proof:** both new regression tests fail against the pre-fix controller (verified by extracting it from origin/main and running the spec: 1 failed at the path assertion), pass with the fix. Full API suite: 1946/1946; `tsc --noEmit` clean.

## Summary by Sourcery

Ensure auth refresh cookies use a root path so silent token refresh works through the web /api rewrite and does not hard-log-out users after access token expiry.

Bug Fixes:
- Set the login-issued refresh cookie path to '/' so browsers send it when calling /api/auth/refresh.
- Set the rotated refresh cookie path in the refresh endpoint to '/' to prevent hard logout on subsequent silent refreshes.
- Clear both root-path and legacy path-scoped refresh cookies on logout to avoid stale tokens shadowing new sessions.

Tests:
- Add controller tests verifying login and refresh endpoints issue the styx_refresh_token cookie on path '/' so it survives the /api rewrite.