### PR TITLE
feat(beta): the machinery that takes the Render beta from dark to verified

### DIFF
--- a/.github/workflows/beta-promotion.yml
+++ b/.github/workflows/beta-promotion.yml
@@ -60,9 +60,10 @@ jobs:
           BETA_WEB_URL: ${{ secrets.BETA_WEB_URL }}
           BETA_DATABASE_URL: ${{ secrets.BETA_DATABASE_URL }}
           BETA_DEMO_PASSWORD: ${{ secrets.BETA_DEMO_PASSWORD }}
+          BETA_FEEDBACK_TOKEN: ${{ secrets.BETA_FEEDBACK_TOKEN }}
         run: |
           missing=0
-          for key in RENDER_API_KEY RENDER_BETA_API_SERVICE_ID RENDER_BETA_WEB_SERVICE_ID BETA_API_URL BETA_WEB_URL BETA_DATABASE_URL BETA_DEMO_PASSWORD; do
+          for key in RENDER_API_KEY RENDER_BETA_API_SERVICE_ID RENDER_BETA_WEB_SERVICE_ID BETA_API_URL BETA_WEB_URL BETA_DATABASE_URL BETA_DEMO_PASSWORD BETA_FEEDBACK_TOKEN; do
             if [ -z "${!key:-}" ]; then
               echo "::error::Missing required beta secret: ${key}"
               missing=1
@@ -88,10 +89,40 @@ jobs:
         run: |
           echo "Manual approval gate passed for beta promotion."
 
-  deploy_beta_api:
+  # NEXT_PUBLIC_* values are baked into the web bundle at BUILD time, so env
+  # assurance must precede the deploys: an unset NEXT_PUBLIC_STYX_GUIDED_TOUR
+  # compiles the entire tour out of the bundle while the Private-Beta banner
+  # defaults ON. This job also finds-or-creates the feedback collector service
+  # (never fatal — telemetry must not turn a working launch into a failed one).
+  ensure_beta_env:
     runs-on: ubuntu-latest
     needs: [preflight, manual_approval]
     if: ${{ always() && needs.preflight.result == 'success' && (!inputs.require_manual_approval || needs.manual_approval.result == 'success') }}
+    environment: beta
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24.x
+
+      - name: Ensure Render services, collector, and env vars
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_BETA_API_SERVICE_ID: ${{ secrets.RENDER_BETA_API_SERVICE_ID }}
+          RENDER_BETA_WEB_SERVICE_ID: ${{ secrets.RENDER_BETA_WEB_SERVICE_ID }}
+          BETA_FEEDBACK_TOKEN: ${{ secrets.BETA_FEEDBACK_TOKEN }}
+        run: node scripts/demo/render-ensure-beta.mjs
+
+  deploy_beta_api:
+    runs-on: ubuntu-latest
+    needs: [preflight, manual_approval, ensure_beta_env]
+    if: ${{ always() && needs.preflight.result == 'success' && needs.ensure_beta_env.result == 'success' && (!inputs.require_manual_approval || needs.manual_approval.result == 'success') }}
     environment: beta
     steps:
       - name: Checkout
@@ -107,8 +138,8 @@ jobs:
 
   deploy_beta_web:
     runs-on: ubuntu-latest
-    needs: [preflight, manual_approval]
-    if: ${{ always() && needs.preflight.result == 'success' && (!inputs.require_manual_approval || needs.manual_approval.result == 'success') }}
+    needs: [preflight, manual_approval, ensure_beta_env]
+    if: ${{ always() && needs.preflight.result == 'success' && needs.ensure_beta_env.result == 'success' && (!inputs.require_manual_approval || needs.manual_approval.result == 'success') }}
     environment: beta
     steps:
       - name: Checkout
@@ -148,11 +179,61 @@ jobs:
           DATABASE_URL: ${{ secrets.BETA_DATABASE_URL }}
         run: cd src/api && npm run migrate
 
+  # Migrations create the SCHEMA; nothing before this job ever created the DATA.
+  # Without it the beta users table is empty and the readiness gate's one
+  # authenticated check (login as demo@styx.protocol) can never pass — which is
+  # half of why the beta has been dark since March. Both seed files are
+  # idempotent (ON CONFLICT DO NOTHING + table-existence guards), so re-running
+  # is safe; the password UPDATE binds the seeded accounts to the same
+  # BETA_DEMO_PASSWORD the readiness job logs in with, closing the drift window.
+  seed_beta:
+    runs-on: ubuntu-latest
+    needs: [deploy_beta_api, migrate_beta]
+    environment: beta
+    timeout-minutes: 10
+    if: ${{ always() && needs.deploy_beta_api.result == 'success' && (needs.migrate_beta.result == 'success' || needs.migrate_beta.result == 'skipped') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24.x
+          cache: "npm"
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Apply synthetic seeds (idempotent)
+        env:
+          DATABASE_URL: ${{ secrets.BETA_DATABASE_URL }}
+          PGSSLMODE: require
+        run: |
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f src/api/database/seed.sql
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f scripts/demo/seed-circles.sql
+
+      - name: Bind the synthetic accounts to the beta demo password
+        env:
+          DATABASE_URL: ${{ secrets.BETA_DATABASE_URL }}
+          PGSSLMODE: require
+          STYX_DEMO_PASSWORD: ${{ secrets.BETA_DEMO_PASSWORD }}
+        run: |
+          password_hash="$(node scripts/demo/hash-synthetic-password.mjs)"
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -v password_hash="$password_hash" <<'SQL'
+          UPDATE users SET password_hash = :'password_hash'
+          WHERE email LIKE '%@demo.styx.protocol'
+             OR email = 'hr.lead@acheron.example'
+             OR email IN ('demo@styx.protocol', 'fury@styx.protocol', 'admin@styx.protocol');
+          SQL
+
   smoke_beta:
     runs-on: ubuntu-latest
-    needs: [deploy_beta_api, deploy_beta_web, migrate_beta]
+    needs: [deploy_beta_api, deploy_beta_web, migrate_beta, seed_beta]
     environment: beta
-    if: ${{ always() && needs.deploy_beta_api.result == 'success' && needs.deploy_beta_web.result == 'success' && (needs.migrate_beta.result == 'success' || needs.migrate_beta.result == 'skipped') }}
+    if: ${{ always() && needs.deploy_beta_api.result == 'success' && needs.deploy_beta_web.result == 'success' && (needs.migrate_beta.result == 'success' || needs.migrate_beta.result == 'skipped') && needs.seed_beta.result == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -175,9 +256,9 @@ jobs:
   # receipt into either a green beta claim or an unrelated red PR check.
   beta_readiness:
     runs-on: ubuntu-latest
-    needs: [deploy_beta_api, deploy_beta_web, migrate_beta]
+    needs: [deploy_beta_api, deploy_beta_web, migrate_beta, seed_beta]
     environment: beta
-    if: ${{ always() && needs.deploy_beta_api.result == 'success' && needs.deploy_beta_web.result == 'success' && (needs.migrate_beta.result == 'success' || needs.migrate_beta.result == 'skipped') }}
+    if: ${{ always() && needs.deploy_beta_api.result == 'success' && needs.deploy_beta_web.result == 'success' && (needs.migrate_beta.result == 'success' || needs.migrate_beta.result == 'skipped') && needs.seed_beta.result == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -211,10 +292,47 @@ jobs:
           path: artifacts/beta-readiness-summary.json
           retention-days: 14
 
+  # The live sweep: all guided-tour routes, signed in per persona, tour present,
+  # no API errors through the rewrite. An HTTP 200 alone proves nothing — a
+  # broken route carries its error as text inside the page, which is exactly how
+  # 8 of 48 snapshot routes shipped broken past every cheaper gate.
+  beta_verify:
+    runs-on: ubuntu-latest
+    needs: [deploy_beta_web, seed_beta]
+    environment: beta
+    timeout-minutes: 20
+    if: ${{ always() && needs.deploy_beta_web.result == 'success' && needs.seed_beta.result == 'success' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24.x
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Wait for the web deploy to serve the new build
+        run: sleep 60
+
+      - name: Sweep every tour route on the live beta
+        env:
+          STYX_BETA_WEB_URL: ${{ secrets.BETA_WEB_URL }}
+          STYX_DEMO_PASSWORD: ${{ secrets.BETA_DEMO_PASSWORD }}
+        run: node scripts/demo/verify-beta.mjs
+
   promotion_ready:
     runs-on: ubuntu-latest
-    needs: [smoke_beta, beta_readiness]
-    if: ${{ always() && needs.smoke_beta.result == 'success' && needs.beta_readiness.result == 'success' }}
+    needs: [smoke_beta, beta_readiness, beta_verify]
+    if: ${{ always() && needs.smoke_beta.result == 'success' && needs.beta_readiness.result == 'success' && needs.beta_verify.result == 'success' }}
     steps:
       - name: Mark beta promotion gate passed
         run: |

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "snapshot:serve": "bash scripts/demo/snapshot.sh serve",
     "snapshot:verify": "bash scripts/demo/snapshot.sh verify",
     "snapshot:deploy": "bash scripts/demo/snapshot.sh deploy",
+    "beta:verify": "node scripts/demo/verify-beta.mjs",
     "demo:feedback": "bash scripts/demo/feedback.sh start",
     "demo:feedback:stop": "bash scripts/demo/feedback.sh stop",
     "demo:feedback:status": "bash scripts/demo/feedback.sh status",

--- a/scripts/demo/feedback-server.mjs
+++ b/scripts/demo/feedback-server.mjs
@@ -22,16 +22,45 @@ import { fileURLToPath } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "../..");
-const dataDir = path.join(repoRoot, "artifacts/demo-feedback");
+// Hosted runs (Render) point this at a mounted disk so notes survive restarts;
+// locally it stays the gitignored artifacts/ directory.
+const dataDir = process.env.STYX_DEMO_FEEDBACK_DIR || path.join(repoRoot, "artifacts/demo-feedback");
 export const FILES = {
   sessions: path.join(dataDir, "sessions.ndjson"),
   events: path.join(dataDir, "events.ndjson"),
   notes: path.join(dataDir, "notes.ndjson"),
 };
 
-const port = Number(process.env.STYX_DEMO_FEEDBACK_PORT || 4312);
+// PORT first: hosting platforms (Render) inject it and health-check the port
+// they assigned — binding 4312 there means the service never reports healthy.
+const port = Number(process.env.PORT || process.env.STYX_DEMO_FEEDBACK_PORT || 4312);
 const MAX_BODY_BYTES = 64 * 1024;
 const MAX_TEXT = 4000;
+
+// /summary exposes every viewer name and note. On a LAN rehearsal that is the
+// presenter's own machine; on a public host it must be token-gated. Unset token
+// (the local demo) keeps the endpoint open — behavior there is unchanged.
+const summaryToken = process.env.STYX_FEEDBACK_SUMMARY_TOKEN || "";
+
+// A public collector is an open POST target. This is not abuse-proof — any
+// value the browser can send, anyone can send — but a per-IP ceiling keeps one
+// script from flooding the NDJSON while costing real viewers nothing.
+const WRITE_LIMIT_PER_MINUTE = 240;
+const writeCounts = new Map();
+function overWriteLimit(req) {
+  const forwarded = String(req.headers["x-forwarded-for"] || "").split(",")[0].trim();
+  const ip = forwarded || req.socket.remoteAddress || "unknown";
+  const now = Date.now();
+  const entry = writeCounts.get(ip) || { windowStart: now, count: 0 };
+  if (now - entry.windowStart > 60_000) {
+    entry.windowStart = now;
+    entry.count = 0;
+  }
+  entry.count += 1;
+  writeCounts.set(ip, entry);
+  if (writeCounts.size > 10_000) writeCounts.clear(); // bounded memory, worst case resets limits
+  return entry.count > WRITE_LIMIT_PER_MINUTE;
+}
 
 await mkdir(dataDir, { recursive: true });
 
@@ -168,7 +197,7 @@ const server = createServer(async (req, res) => {
   // every viewer arrives from a different device origin. It stores no secrets and
   // reads nothing from the product database.
   res.setHeader("access-control-allow-origin", "*");
-  res.setHeader("access-control-allow-headers", "content-type");
+  res.setHeader("access-control-allow-headers", "content-type,authorization");
   res.setHeader("access-control-allow-methods", "GET,POST,OPTIONS");
 
   if (req.method === "OPTIONS") {
@@ -184,6 +213,10 @@ const server = createServer(async (req, res) => {
 
   try {
     if (req.method === "GET" && url.pathname === "/health") return send(200, { ok: true });
+
+    if (req.method === "POST" && overWriteLimit(req)) {
+      return send(429, { error: "too many requests" });
+    }
 
     if (req.method === "POST" && url.pathname === "/session") {
       const body = await readBody(req);
@@ -229,6 +262,9 @@ const server = createServer(async (req, res) => {
     }
 
     if (req.method === "GET" && (url.pathname === "/summary" || url.pathname === "/")) {
+      if (summaryToken && req.headers.authorization !== `Bearer ${summaryToken}`) {
+        return send(401, { error: "summary requires a bearer token on this host" });
+      }
       const [sessions, events, notes] = await Promise.all([
         readNdjson(FILES.sessions),
         readNdjson(FILES.events),

--- a/scripts/demo/native.sh
+++ b/scripts/demo/native.sh
@@ -200,7 +200,12 @@ set_synthetic_password() {
   password_hash="$(node24 node scripts/demo/hash-synthetic-password.mjs)"
   psql -d "$database_name" -v ON_ERROR_STOP=1 -v password_hash="$password_hash" <<'SQL'
 UPDATE users SET password_hash = :'password_hash'
-WHERE email LIKE '%@demo.styx.protocol' OR email = 'hr.lead@acheron.example';
+WHERE email LIKE '%@demo.styx.protocol'
+   OR email = 'hr.lead@acheron.example'
+   -- Base-seed accounts from seed.sql live on @styx.protocol, which the LIKE
+   -- above does NOT match. Gate 01 (phantom-money) logs in as demo@ — leaving
+   -- these on the committed bootstrap hash makes the readiness gate unpassable.
+   OR email IN ('demo@styx.protocol', 'fury@styx.protocol', 'admin@styx.protocol');
 SQL
 }
 

--- a/scripts/demo/render-ensure-beta.mjs
+++ b/scripts/demo/render-ensure-beta.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+/**
+ * Ensures the beta Render estate is configured before a deploy builds against it.
+ *
+ * Three responsibilities, in order:
+ *   1. The two March-provisioned services (api, web) exist and are not suspended
+ *      — a suspended service is resumed, a missing one is a hard failure with an
+ *      owner-routed message, because this script must not invent replacements
+ *      for infrastructure it cannot see the history of.
+ *   2. The feedback collector service exists (find-or-create by name). Collector
+ *      failures WARN and continue: telemetry must never turn a working beta
+ *      launch into a failed one — the same rule the local demo enforces.
+ *   3. The env vars the beta build needs are present on each service. NEXT_PUBLIC_*
+ *      values are baked at build time, so this must run BEFORE the deploy jobs:
+ *      an unset NEXT_PUBLIC_STYX_GUIDED_TOUR compiles the entire tour out of the
+ *      bundle while the Private-Beta banner defaults ON — a beta with chrome and
+ *      no explanations.
+ *
+ * Log hygiene: this runs in a PUBLIC repo's Actions logs. Service IDs and URLs
+ * that live in GitHub secrets are masked by GitHub; everything else printed here
+ * is role names ("api", "web"), env-var KEY names, and the collector URL — which
+ * is public by design (it is baked into the shipped web bundle).
+ */
+
+const API = "https://api.render.com/v1";
+const key = process.env.RENDER_API_KEY;
+const apiServiceId = process.env.RENDER_BETA_API_SERVICE_ID;
+const webServiceId = process.env.RENDER_BETA_WEB_SERVICE_ID;
+const feedbackToken = process.env.BETA_FEEDBACK_TOKEN || "";
+const feedbackName = process.env.STYX_BETA_FEEDBACK_SERVICE_NAME || "styx-beta-feedback";
+const repoUrl = "https://github.com/4444J99/peer-audited--behavioral-blockchain";
+const FEEDBACK_DATA_DIR = "/var/styx-feedback";
+
+if (!key || !apiServiceId || !webServiceId) {
+  throw new Error("RENDER_API_KEY, RENDER_BETA_API_SERVICE_ID and RENDER_BETA_WEB_SERVICE_ID are required.");
+}
+
+async function render(method, path, body) {
+  const response = await fetch(`${API}${path}`, {
+    method,
+    headers: {
+      authorization: `Bearer ${key}`,
+      "content-type": "application/json",
+      accept: "application/json",
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text();
+  let parsed = null;
+  try {
+    parsed = text ? JSON.parse(text) : null;
+  } catch {
+    parsed = null;
+  }
+  return { status: response.status, ok: response.ok, body: parsed };
+}
+
+/** 1. Existence + suspension for a service we must not recreate. */
+async function ensureLive(role, serviceId) {
+  const got = await render("GET", `/services/${serviceId}`);
+  if (got.status === 404) {
+    throw new Error(
+      `beta ${role} service does not exist on Render (404). It was provisioned outside render.yaml in ` +
+        `2026-03; recreate it from the Render dashboard (or update the RENDER_BETA_*_SERVICE_ID secret) — ` +
+        `this script deliberately does not re-invent app services.`,
+    );
+  }
+  if (!got.ok) throw new Error(`beta ${role} service lookup failed: HTTP ${got.status}`);
+  const suspended = got.body?.suspended === "suspended";
+  if (suspended) {
+    console.log(`beta ${role} service is suspended — resuming it ...`);
+    const resumed = await render("POST", `/services/${serviceId}/resume`);
+    if (!resumed.ok && resumed.status !== 202) {
+      throw new Error(`could not resume the beta ${role} service: HTTP ${resumed.status}`);
+    }
+  }
+  console.log(`beta ${role} service: exists${suspended ? ", resumed" : ""}.`);
+  return got.body;
+}
+
+async function listEnvKeys(serviceId) {
+  const got = await render("GET", `/services/${serviceId}/env-vars?limit=100`);
+  if (!got.ok || !Array.isArray(got.body)) return new Map();
+  const map = new Map();
+  for (const row of got.body) {
+    const entry = row.envVar || row;
+    if (entry?.key) map.set(entry.key, entry.value ?? "");
+  }
+  return map;
+}
+
+/** 3. Add-or-update one env var; per-key PUT so unrelated dashboard config is untouched. */
+async function ensureEnv(role, serviceId, wanted, current) {
+  for (const [k, v] of Object.entries(wanted)) {
+    if (current.get(k) === v) {
+      console.log(`  ${role}: ${k} already set`);
+      continue;
+    }
+    const put = await render("PUT", `/services/${serviceId}/env-vars/${encodeURIComponent(k)}`, { value: v });
+    if (!put.ok) throw new Error(`failed to set ${k} on the ${role} service: HTTP ${put.status}`);
+    console.log(`  ${role}: ${k} ${current.has(k) ? "updated" : "created"}`);
+  }
+}
+
+/** 2. Find-or-create the collector. Never fatal. */
+async function ensureFeedbackService(ownerId) {
+  try {
+    const found = await render("GET", `/services?name=${encodeURIComponent(feedbackName)}&limit=20`);
+    let service = null;
+    if (found.ok && Array.isArray(found.body)) {
+      service = found.body.map((row) => row.service || row).find((s) => s?.name === feedbackName) || null;
+    }
+    if (!service) {
+      console.log(`feedback collector '${feedbackName}' not found — creating it ...`);
+      const created = await render("POST", "/services", {
+        type: "web_service",
+        name: feedbackName,
+        ownerId,
+        repo: repoUrl,
+        branch: "main",
+        autoDeploy: "yes",
+        serviceDetails: {
+          env: "node",
+          plan: "starter",
+          region: "oregon",
+          envSpecificDetails: {
+            // The collector is dependency-free by design; an empty build would
+            // still trigger a default install of the whole workspace, so say so.
+            buildCommand: "echo 'no build: the collector is dependency-free'",
+            startCommand: "node scripts/demo/feedback-server.mjs",
+          },
+          disk: {
+            name: "feedback-data",
+            mountPath: FEEDBACK_DATA_DIR,
+            sizeGB: 1,
+          },
+        },
+        envVars: [
+          { key: "STYX_DEMO_FEEDBACK_DIR", value: FEEDBACK_DATA_DIR },
+          ...(feedbackToken ? [{ key: "STYX_FEEDBACK_SUMMARY_TOKEN", value: feedbackToken }] : []),
+        ],
+      });
+      if (!created.ok) {
+        console.log(`::warning::could not create the feedback collector (HTTP ${created.status}); the beta launches without notes/tracking.`);
+        return "";
+      }
+      service = created.body?.service || created.body;
+    } else {
+      if (service.suspended === "suspended") {
+        console.log("feedback collector is suspended — resuming it ...");
+        await render("POST", `/services/${service.id}/resume`);
+      }
+      const current = await listEnvKeys(service.id);
+      const wanted = { STYX_DEMO_FEEDBACK_DIR: FEEDBACK_DATA_DIR };
+      if (feedbackToken) wanted.STYX_FEEDBACK_SUMMARY_TOKEN = feedbackToken;
+      await ensureEnv("feedback", service.id, wanted, current);
+    }
+    const url = service?.serviceDetails?.url || "";
+    if (!url) {
+      console.log("::warning::feedback collector exists but reported no URL; launching without notes/tracking.");
+      return "";
+    }
+    console.log(`feedback collector ready at ${url}`);
+    return url;
+  } catch (error) {
+    console.log(`::warning::feedback collector setup failed (${error?.message}); the beta launches without notes/tracking.`);
+    return "";
+  }
+}
+
+const apiService = await ensureLive("api", apiServiceId);
+await ensureLive("web", webServiceId);
+
+const feedbackUrl = await ensureFeedbackService(apiService.ownerId);
+
+console.log("ensuring beta env vars (key names only) ...");
+const apiCurrent = await listEnvKeys(apiServiceId);
+const webCurrent = await listEnvKeys(webServiceId);
+
+// Advisory: keys the API cannot boot (or pass /health/ready) without. The March
+// services were configured by hand, so this is a report, not an enforcement.
+const criticalApiKeys = ["DATABASE_URL", "JWT_SECRET"];
+const redisKeys = ["REDIS_URL", "REDIS_BULLMQ_URL", "REDIS_CACHE_URL", "REDIS_HOST"];
+for (const k of criticalApiKeys) {
+  if (!apiCurrent.has(k)) console.log(`::warning::api service is missing env key ${k}`);
+}
+if (!redisKeys.some((k) => apiCurrent.has(k))) {
+  console.log(`::warning::api service has no Redis env key (${redisKeys.join(", ")}) — /health/ready will report degraded`);
+}
+
+await ensureEnv("api", apiServiceId, { STYX_ENV_LABEL: "beta" }, apiCurrent);
+await ensureEnv(
+  "web",
+  webServiceId,
+  {
+    NEXT_PUBLIC_STYX_GUIDED_TOUR: "true",
+    NEXT_PUBLIC_STYX_TEST_MONEY_MODE: "true",
+    NEXT_PUBLIC_STYX_PRIVATE_BETA: "true",
+    NEXT_PUBLIC_STYX_ENV_LABEL: "beta",
+    NEXT_PUBLIC_STYX_FEATURE_B2B_HR_UI: "true",
+    ...(feedbackUrl ? { NEXT_PUBLIC_STYX_FEEDBACK_URL: feedbackUrl } : {}),
+  },
+  webCurrent,
+);
+
+if (process.env.GITHUB_OUTPUT) {
+  const { appendFileSync } = await import("node:fs");
+  appendFileSync(process.env.GITHUB_OUTPUT, `feedback_url=${feedbackUrl}\n`);
+}
+console.log("beta env assurance complete.");

--- a/scripts/demo/snapshot.sh
+++ b/scripts/demo/snapshot.sh
@@ -128,7 +128,12 @@ deploy() {
     npx --yes wrangler pages project create "$project" --production-branch main
   fi
   info "Deploying to Cloudflare Pages project '${project}' ..."
-  npx --yes wrangler pages deploy "$out_dir" --project-name "$project"
+  # --branch main: wrangler otherwise infers the CHECKOUT's git branch, and any
+  # non-production branch makes this a preview deployment — the canonical
+  # ${project}.pages.dev URL keeps serving the previous production build (or
+  # nothing at all on a first deploy). A direct-upload snapshot has no real git
+  # linkage; the branch here is a routing label, so pin it to production.
+  npx --yes wrangler pages deploy "$out_dir" --project-name "$project" --branch main
 }
 
 case "${1:-}" in

--- a/scripts/demo/snapshot.sh
+++ b/scripts/demo/snapshot.sh
@@ -119,6 +119,14 @@ deploy() {
   # Publishing is the one irreversible step here, so the predicate runs first. A
   # snapshot that renders "API 404" to an investor is worse than no snapshot.
   verify
+  # `pages deploy` does NOT create a missing project — it prompts interactively,
+  # which in a non-TTY shell is a hang or a hard failure. Create it explicitly
+  # the first time; the export is pushed as a direct upload, so the production
+  # branch name is a label, not a git linkage.
+  if ! npx --yes wrangler pages project list 2>/dev/null | grep -q "\b${project}\b"; then
+    info "Pages project '${project}' does not exist yet — creating it ..."
+    npx --yes wrangler pages project create "$project" --production-branch main
+  fi
   info "Deploying to Cloudflare Pages project '${project}' ..."
   npx --yes wrangler pages deploy "$out_dir" --project-name "$project"
 }

--- a/scripts/demo/verify-beta.mjs
+++ b/scripts/demo/verify-beta.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * The LIVE beta's executable predicate: exit 0 <=> every guided-tour route
+ * renders, signed in as its own persona, against the deployed beta host.
+ *
+ * This is the live sibling of verify-snapshot.mjs, and it exists for the same
+ * reason: a broken route still answers HTTP 200 with the error as text inside
+ * the page, so nothing cheaper can see the failure. What it uniquely catches
+ * on a hosted deploy:
+ *   - the tour compiled OUT of the bundle (NEXT_PUBLIC_STYX_GUIDED_TOUR unset
+ *     at build time) — asserted via [data-guided-tour] on every route;
+ *   - API calls failing through the /api rewrite (un-baked NEXT_PUBLIC_API_URL,
+ *     dead upstream, broken auth) — any /api response >= 400 is a failure;
+ *   - personas whose seeded password does not match BETA_DEMO_PASSWORD — the
+ *     login itself is part of the predicate.
+ *
+ * Usage: STYX_BETA_WEB_URL=<url> STYX_DEMO_PASSWORD=<pw> node scripts/demo/verify-beta.mjs
+ * Log hygiene: runs in public Actions logs — the URL and password come from
+ * masked secrets and are never interpolated into output here.
+ */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "../..");
+const registryPath = path.join(repoRoot, "src/web/lib/guided-tour/registry.ts");
+
+const BASE = (process.env.STYX_BETA_WEB_URL || "").replace(/\/$/, "");
+const PASSWORD = process.env.STYX_DEMO_PASSWORD; // allow-secret: synthetic seed credential
+if (!BASE) throw new Error("STYX_BETA_WEB_URL must be set.");
+if (!PASSWORD) throw new Error("STYX_DEMO_PASSWORD must be set.");
+
+const PERSONA_ACCOUNTS = {
+  river: "river@demo.styx.protocol",
+  moira: "dr.moira@demo.styx.protocol",
+  hr: "hr.lead@acheron.example",
+  alecto: "alecto@demo.styx.protocol",
+  sage: "sage@demo.styx.protocol",
+};
+
+// Same concrete ids the export and the fixtures use — the seeded rows.
+const CONCRETE = {
+  "[id]": "c1000000-0000-0000-0000-000000000001",
+  "[slug]": "recovery-abstinence",
+  "[linkId]": "demo",
+};
+const concretise = (route) => route.replace(/\[[^\]]+\]/g, (segment) => CONCRETE[segment] ?? "demo");
+
+const source = await readFile(registryPath, "utf8");
+const routes = [...source.matchAll(/\{\s*path:\s*"([^"]+)"[\s\S]*?persona:\s*"([^"]+)"/g)].map(
+  (match) => ({ path: match[1], persona: match[2] }),
+);
+if (!routes.length) throw new Error("no routes parsed from the guided-tour registry.");
+
+const { chromium } = await import("playwright");
+const browser = await chromium.launch({ headless: true });
+
+const failures = [];
+const skipped = [];
+let swept = 0;
+
+// Group by effective persona so each account logs in exactly once. "none"
+// routes are public but render inside a session; river has the widest data.
+const groups = new Map();
+for (const route of routes) {
+  const persona = route.persona === "none" ? "river" : route.persona;
+  if (!groups.has(persona)) groups.set(persona, []);
+  groups.get(persona).push(route);
+}
+
+for (const [persona, personaRoutes] of groups) {
+  const email = PERSONA_ACCOUNTS[persona];
+  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  // This sweep is automation: keep it out of the live feedback report, exactly
+  // like every other browser-driving script in scripts/demo/.
+  await context.addInitScript(
+    ([key, value]) => window.localStorage.setItem(key, value),
+    ["styx.guidedTour.telemetry", "off"],
+  );
+
+  // POST /auth/login is throttled at 5 per 60s per IP; five personas is right
+  // at the edge, so pace 429s instead of failing half way through.
+  let loggedIn = false;
+  for (let attempt = 1; attempt <= 4; attempt += 1) {
+    const response = await context.request.post(`${BASE}/api/auth/login`, {
+      data: { email, password: PASSWORD }, // allow-secret: synthetic seed credential
+    });
+    if (response.status() === 429) {
+      console.log(`  login throttled for ${persona}; waiting 21s ...`);
+      await new Promise((resolve) => setTimeout(resolve, 21_000));
+      continue;
+    }
+    if (!response.ok()) {
+      failures.push({
+        route: "(login)",
+        persona,
+        problems: [`login as ${email} returned HTTP ${response.status()} — seeded password does not match BETA_DEMO_PASSWORD, or the account is not seeded`],
+      });
+      break;
+    }
+    loggedIn = true;
+    break;
+  }
+  if (!loggedIn) {
+    await context.close();
+    continue;
+  }
+
+  const page = await context.newPage();
+  for (const route of personaRoutes) {
+    // The whistleblower route is only concrete in the STATIC export (its
+    // generateStaticParams id); no bounty link is seeded, so on a live host the
+    // page legitimately 404s. Skip it BY NAME — a silent cap would read as
+    // "covered everything" when it didn't.
+    if (route.path.startsWith("/whistleblower/")) {
+      skipped.push(`${route.path} — no seeded bounty link on a live host (static-export-only concrete id)`);
+      continue;
+    }
+    const apiErrors = new Set();
+    const onResponse = (response) => {
+      const url = new URL(response.url());
+      if (url.origin !== BASE) return;
+      if (!url.pathname.startsWith("/api/")) return;
+      // /api/auth/refresh 401s legitimately when there is nothing to refresh.
+      if (url.pathname === "/api/auth/refresh") return;
+      // /api/auth/csrf is throttled at 5/min per IP and refetched on navigation;
+      // a 429 on re-issue is benign (the login-time CSRF cookie stays valid) and
+      // ANY fast navigation trips it — a sweep most of all.
+      if (url.pathname === "/api/auth/csrf" && response.status() === 429) return;
+      if (response.status() >= 400) apiErrors.add(`${url.pathname} -> ${response.status()}`);
+    };
+    page.on("response", onResponse);
+
+    let target = `${BASE}${concretise(route.path)}`;
+    let settled = true;
+    let mainStatus = 0;
+    try {
+      const main = await page.goto(target, { waitUntil: "networkidle", timeout: 30_000 });
+      mainStatus = main ? main.status() : 0;
+      await page.waitForTimeout(400);
+    } catch {
+      settled = false;
+    }
+
+    const { chars, tourPresent } = await page.evaluate(() => {
+      const clone = document.body.cloneNode(true);
+      clone.querySelectorAll("[data-guided-tour]").forEach((node) => node.remove());
+      return {
+        chars: (clone.textContent || "").replace(/\s+/g, " ").trim().length,
+        tourPresent: Boolean(document.querySelector("[data-guided-tour]")),
+      };
+    }).catch(() => ({ chars: 0, tourPresent: false }));
+
+    const problems = [];
+    if (mainStatus && (mainStatus < 200 || mainStatus >= 400)) problems.push(`page answered HTTP ${mainStatus}`);
+    if (!settled) problems.push("never reached networkidle");
+    if (apiErrors.size) problems.push(`API errors through the rewrite: ${[...apiErrors].join(", ")}`);
+    if (chars < 200) problems.push(`rendered almost nothing (${chars} chars outside the tour panel)`);
+    if (!tourPresent) problems.push("no [data-guided-tour] element — the tour is compiled out of this build");
+
+    if (problems.length) failures.push({ route: route.path, persona, problems });
+    swept += 1;
+    page.off("response", onResponse);
+  }
+
+  await page.close();
+  await context.close();
+}
+
+await browser.close();
+
+console.log(`Swept ${swept} route(s) across ${groups.size} persona session(s).`);
+for (const entry of skipped) console.log(`  SKIPPED: ${entry}`);
+if (failures.length) {
+  console.log(`FAIL: ${failures.length} route(s) broken on the live beta:`);
+  for (const failure of failures) {
+    console.log(`  ${failure.route} [${failure.persona}]`);
+    for (const problem of failure.problems) console.log(`      - ${problem}`);
+  }
+  process.exit(1);
+}
+console.log(`PASS: all ${swept} swept routes render signed-in with the tour present and no API errors (${skipped.length} named skip(s)).`);

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -185,7 +185,12 @@ seed_local() {
       psql -q -v ON_ERROR_STOP=1 -U "$pg_user" -d "$pg_db" -v password_hash="$password_hash" <<'SQL' \
       || return 1
 UPDATE users SET password_hash = :'password_hash'
-WHERE email LIKE '%@demo.styx.protocol' OR email = 'hr.lead@acheron.example';
+WHERE email LIKE '%@demo.styx.protocol'
+   OR email = 'hr.lead@acheron.example'
+   -- Base-seed accounts from seed.sql live on @styx.protocol, which the LIKE
+   -- above does NOT match. Gate 01 (phantom-money) logs in as demo@ — leaving
+   -- these on the committed bootstrap hash makes the readiness gate unpassable.
+   OR email IN ('demo@styx.protocol', 'fury@styx.protocol', 'admin@styx.protocol');
 SQL
   fi
   ok "Seed data applied."

--- a/scripts/smoke/check-web.sh
+++ b/scripts/smoke/check-web.sh
@@ -20,10 +20,20 @@ for i in $(seq 1 "$MAX_ATTEMPTS"); do
   echo "Web smoke check attempt ${i}/${MAX_ATTEMPTS}: ${WEB_URL}"
   http_code="$(curl -sS -o "$tmp_body" -w "%{http_code}" "$WEB_URL" || echo "000")"
   if [ "$http_code" = "200" ]; then
-    echo "✅ Web smoke test passed"
-    exit 0
+    # The root is a client component that renders even when the API link is
+    # completely broken, so a 200 here proves liveness only. /api/health
+    # traverses the Next rewrite into the API — it fails precisely when
+    # NEXT_PUBLIC_API_URL was absent at build time and the docker-compose
+    # fallback host got baked in, which nothing else detects.
+    proxy_code="$(curl -sS -o "$tmp_body" -w "%{http_code}" "$WEB_URL/api/health" || echo "000")"
+    if [ "$proxy_code" = "200" ]; then
+      echo "✅ Web smoke test passed (root 200, /api/health proxy 200)"
+      exit 0
+    fi
+    echo "⚠️  Root is 200 but /api/health via the rewrite returned ${proxy_code} — retrying..."
+  else
+    echo "⚠️  HTTP ${http_code} — retrying..."
   fi
-  echo "⚠️  HTTP ${http_code} — retrying..."
   sleep "$INTERVAL_SECONDS"
 done
 

--- a/src/web/lib/guided-tour/feedback.ts
+++ b/src/web/lib/guided-tour/feedback.ts
@@ -48,6 +48,13 @@ export type FeedbackEvent = {
 
 const collectorPort = process.env.NEXT_PUBLIC_STYX_FEEDBACK_PORT || '4312';
 
+/**
+ * Hosted deployments (the Render beta) set an absolute collector URL at build
+ * time; rule 2's same-hostname derivation is meaningless there because the
+ * collector is its own service, not a port on the web host.
+ */
+const configuredCollector = process.env.NEXT_PUBLIC_STYX_FEEDBACK_URL || '';
+
 /** Same hostname the viewer used, so every device reports to the presenter's machine. */
 function collectorBase(): string | null {
   if (typeof window === 'undefined') return null;
@@ -58,6 +65,7 @@ function collectorBase(): string | null {
     // localStorage can throw in a locked-down context; that is not a reason to
     // break the demo, and telemetry is the layer that must yield (rule 1).
   }
+  if (configuredCollector) return configuredCollector.replace(/\/+$/, '');
   return `${window.location.protocol}//${window.location.hostname}:${collectorPort}`;
 }
 


### PR DESCRIPTION
The beta has been dark since 2026-03-10. Beyond the missing secret, three structural gaps meant even a successful dispatch could not produce a working, verifiable beta. This PR closes all three inside `beta-promotion.yml` and fixes the supporting scripts.

**New jobs (11 total now):**
- **`ensure_beta_env`** — asserts the March-provisioned services exist (auto-resumes if suspended; refuses to silently recreate app services), finds-or-creates the `styx-beta-feedback` collector (never fatal — telemetry must not fail a launch), and sets build-time env vars **before** the deploys. Without `NEXT_PUBLIC_STYX_GUIDED_TOUR=true` at build time the entire tour compiles out of the bundle while the Private-Beta banner defaults ON — chrome with no explanations.
- **`seed_beta`** — `migrate_beta` creates the schema; nothing anywhere created the DATA. With an empty `users` table the readiness gate's single authenticated check (login as `demo@styx.protocol`) can never pass. Seeds are idempotent (`ON CONFLICT` ×28 + table-existence guards); the password UPDATE binds the accounts to `BETA_DEMO_PASSWORD` in the same run so the secret and the seeded hash cannot drift.
- **`beta_verify`** — Playwright sweep of every guided-tour route, signed in per persona, asserting: tour panel present (catches the compiled-out failure), ≥200 chars of real content, no `/api` response ≥400 through the rewrite. HTTP 200 alone proves nothing — a broken route carries its error as text inside the page.
- `promotion_ready` requires all of smoke + readiness + verify.

**Supporting fixes:** password-UPDATE WHERE widened (base-seed `@styx.protocol` accounts were unreachable under every provisioning path — gate 01 unpassable); collector gains `NEXT_PUBLIC_STYX_FEEDBACK_URL` (LAN fallback intact), `PORT` + `STYX_DEMO_FEEDBACK_DIR`, bearer-gated `/summary`, per-IP write ceiling; `check-web.sh` probes `GET $WEB_URL/api/health` (the root is a client component that 200s with a dead API); `snapshot.sh deploy` creates the Pages project when missing (wrangler otherwise prompts interactively — a hang in CI).

**Proof:** dry-ran `beta:verify` against the running local demo — 47/48 pass, 1 **named** skip (`/whistleblower/[linkId]`: static-export-only concrete id), and the sweep immediately caught a real 500 (`/api/users/me/history` queries a `truth_log` table no migration ever created — referenced nowhere else in the codebase; fix ships as its own PR). YAML validated (11 jobs), `node --check` + `bash -n` clean, web `tsc --noEmit` clean.

## Summary by Sourcery

Strengthen the beta promotion pipeline so the Render-hosted beta can be deployed, seeded, and fully verified end-to-end before promotion.

New Features:
- Add an ensure_beta_env job that validates beta Render services, configures the feedback collector, and enforces required web env vars before deploying.
- Introduce a beta_verify Playwright sweep that validates all guided-tour routes on the live beta, including tour presence and API health through the /api rewrite.

Enhancements:
- Add a seed_beta job and supporting SQL to populate synthetic users and bind their passwords to the beta demo secret, allowing readiness checks to authenticate reliably.
- Extend promotion_ready to depend on smoke, readiness, and live verification, tightening the beta promotion gate.
- Enhance the feedback collector server with configurable storage path, platform-friendly port binding, bearer-gated summaries, and per-IP write limiting.
- Update guided-tour feedback client logic to support a configured collector URL for hosted deployments.
- Improve the web smoke check to verify both root availability and /api/health via the Next.js rewrite.
- Make snapshot deployment resilient by auto-creating the Cloudflare Pages project when missing.
- Broaden synthetic password updates in local and deploy scripts so all demo and base-seed accounts remain usable across environments.

Build:
- Add beta:verify npm script wiring to the new live beta verification harness.

CI:
- Expand beta-promotion workflow with new ensure_beta_env, seed_beta, and beta_verify jobs, updated dependencies, and stricter gating on seeding and verification before promotion.