### PR TITLE
fix(users): /users/me/history queried a table no migration ever created

### DIFF
--- a/src/api/src/modules/users/users.service.spec.ts
+++ b/src/api/src/modules/users/users.service.spec.ts
@@ -82,6 +82,23 @@ describe("UsersService", () => {
     });
   });
 
+  describe("getUserHistory", () => {
+    it("queries event_log — the audit table this service writes — not a table that never existed", async () => {
+      // The old query named "truth_log", which no migration ever created; every
+      // call 500'd and /profile swallowed it into a plausible empty history.
+      (mockPool.query as jest.Mock).mockResolvedValue({
+        rows: [{ event_type: "CONTRACT_CREATED", payload: {}, created_at: "2026-01-01" }],
+      });
+
+      const rows = await service.getUserHistory("user-1");
+
+      expect(rows).toHaveLength(1);
+      const sql = (mockPool.query as jest.Mock).mock.calls[0][0] as string;
+      expect(sql).toContain("FROM event_log");
+      expect(sql).not.toContain("truth_log");
+    });
+  });
+
   describe("getPublicProfile", () => {
     it("should return limited public profile fields", async () => {
       const publicData = {

--- a/src/api/src/modules/users/users.service.ts
+++ b/src/api/src/modules/users/users.service.ts
@@ -141,8 +141,12 @@ export class UsersService {
   }
 
   async getUserHistory(userId: string, limit = 50) {
+    // event_log is the tamper-evident audit table this service itself appends
+    // to; no migration has ever created a "truth_log", so the old name made
+    // this endpoint a guaranteed 500 that /profile swallowed into an empty
+    // history panel.
     const result = await this.pool.query(
-      `SELECT event_type, payload, created_at FROM truth_log
+      `SELECT event_type, payload, created_at FROM event_log
        WHERE payload->>'userId' = $1
        ORDER BY created_at DESC
        LIMIT $2`,


### PR DESCRIPTION
`getUserHistory` selected `FROM truth_log` — a name that appears nowhere else in the codebase and in no migration. Every call to `GET /users/me/history` has 500'd for the endpoint's entire life, and `/profile` swallowed the error into a plausible empty history panel — which is exactly why it survived. Found by the new live route sweep (`verify-beta.mjs`, #886), not by any screen.

`event_log` is the tamper-evident audit table this same service appends to (`appendTruthLogEvent`), with exactly the selected columns (`event_type`, `payload` jsonb, `created_at`). Verified against the live demo database: the corrected query returns rows for the seeded river account.

Regression test asserts the query targets `event_log` and never `truth_log`. Suite: 19/19.

## Summary by Sourcery

Fix the user history endpoint to read from the correct audit log table and add coverage to prevent regressions.

Bug Fixes:
- Correct getUserHistory to query the existing event_log audit table instead of a non-existent truth_log table, restoring the /users/me/history endpoint.

Tests:
- Add a regression test ensuring getUserHistory queries event_log and never references the non-existent truth_log table.