### PR TITLE
chore(render): the blueprint can now boot the API it describes

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -43,6 +43,38 @@ services:
         generateValue: true
       - key: STYX_API_KEY_PEPPER
         generateValue: true
+      # These six have NO insecure runtime fallback — the API throws at boot (or
+      # on first use) when any is unset (.env.example documents the contract;
+      # ENTERPRISE_SSO_SECRET is enforced in auth.service). The blueprint
+      # generated only JWT_SECRET and the pepper, so a fresh blueprint deploy
+      # crash-looped before serving its first request. All are API-internal
+      # (no web/worker consumer needs the same value), so per-service
+      # generation is correct.
+      - key: APP_SECRET
+        generateValue: true
+      - key: ANONYMIZE_SALT
+        generateValue: true
+      - key: ZK_EXHAUST_SECRET
+        generateValue: true
+      - key: STYX_WEBHOOK_SECRET
+        generateValue: true
+      - key: INTERNAL_SERVICE_TOKEN
+        generateValue: true
+      - key: ENTERPRISE_SSO_SECRET
+        generateValue: true
+      # /meta/release reports environment.label from this; the deploy smoke
+      # (check-api-release.sh) fails hard on a mismatch with its expected
+      # label. The blueprint never set it, so a blueprint-provisioned service
+      # reported no label and could not pass its own smoke.
+      - key: STYX_ENV_LABEL
+        value: production
+      # NOTE: this and styx-web's NEXT_PUBLIC_API_URL form a circular
+      # fromService pair. On the FIRST blueprint sync, whichever service builds
+      # before the other exists gets an empty value baked in — for styx-web that
+      # means the docker-compose fallback host (dead on Render) is compiled into
+      # the bundle and every /api call 502s until styx-web is manually
+      # redeployed AFTER styx-api is live. Render resolves both on subsequent
+      # deploys; the trap is first-sync only.
       - key: CORS_ORIGINS
         fromService:
           name: styx-web


### PR DESCRIPTION
Three gaps between `render.yaml` and the API it claims to provision, all found while auditing why a fresh blueprint deploy could never have worked:

1. **Six env vars with no insecure runtime fallback** (`APP_SECRET`, `ANONYMIZE_SALT`, `ZK_EXHAUST_SECRET`, `STYX_WEBHOOK_SECRET`, `INTERNAL_SERVICE_TOKEN`, `ENTERPRISE_SSO_SECRET`) were absent while the API throws without them — a fresh blueprint deploy crash-looped before serving a request. All are API-internal (no web consumer — verified by grep), so per-service `generateValue` is correct.
2. **`STYX_ENV_LABEL` was never set**, so a blueprint-provisioned API reported no `environment.label` and failed its own release smoke (`check-api-release.sh` hard-fails on label mismatch).
3. **The `CORS_ORIGINS` ↔ `NEXT_PUBLIC_API_URL` circular `fromService` pair** is now documented where it bites: on the *first* blueprint sync the web build bakes in the dead docker-compose fallback host and needs one manual redeploy after the API is live.

Prod-shape only — nothing deploys on merge (`deploy.yml` is tag/dispatch-gated). YAML validated; 27 API env keys.

## Summary by Sourcery

Update Render blueprint to fully provision the API’s required environment configuration and document a first-sync deployment caveat.

Enhancements:
- Add missing API-internal environment variables to the Render service so a fresh blueprint deploy can boot successfully.
- Set the environment label variable in the API service so release smoke checks can pass for blueprint-provisioned deployments.
- Document the circular dependency between API CORS origins and web NEXT_PUBLIC_API_URL in the blueprint to clarify the first-sync redeploy requirement.