### PR TITLE
fix(deps): hoist class-validator to root — Nest resolves peers from root scope

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
         "src/*",
         "packages/*"
       ],
+      "dependencies": {
+        "class-validator": "^0.15.1"
+      },
       "devDependencies": {
         "@nestjs/common": "11.1.28",
         "@nestjs/core": "11.1.28",
@@ -9513,6 +9516,17 @@
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
       "license": "MIT"
+    },
+    "node_modules/class-validator": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
+      "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/validator": "^13.15.3",
+        "libphonenumber-js": "^1.11.1",
+        "validator": "^13.15.22"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -21997,17 +22011,6 @@
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "src/api/node_modules/class-validator": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
-      "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/validator": "^13.15.3",
-        "libphonenumber-js": "^1.11.1",
-        "validator": "^13.15.22"
-      }
     },
     "src/api/node_modules/commander": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -80,5 +80,8 @@
     "yaml": "2.8.3",
     "cross-spawn": "7.0.5",
     "postcss": "8.5.15"
+  },
+  "dependencies": {
+    "class-validator": "^0.15.1"
   }
 }


### PR DESCRIPTION
Fourth beta API deploy attempt (clean cache) died at boot: ValidationPipe's PackageLoader can't find `class-validator` and exits 1. The lock nested it at `src/api/node_modules` while `@nestjs/common`/`core` are root-hoisted — Nest's require walks root scope and misses it. Every other Nest peer (class-transformer, reflect-metadata, rxjs) already has a root copy; this was the single gap, present in the pre-#895 lock too (months of dependency drift since March, untested because no API deploy happened in between).

One root `dependencies` declaration collapses the nested copy into the hoist (npm: added 1, removed 1). Verified with the exact resolution PackageLoader performs — `require.resolve('class-validator', {paths: [@nestjs/common]})` → root copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmP1SLhXcZBmA7g4NM6PTY

## Summary by Sourcery

Build:
- Declare class-validator as a root-level dependency in package.json to eliminate nested installation under src/api.