### PR TITLE
feat(demo): Render-native beta seeder for the pre-deploy command

### DIFF
--- a/scripts/demo/seed-beta.mjs
+++ b/scripts/demo/seed-beta.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Seed the hosted beta database — the Render-native half of the seeding contract.
+ *
+ * The GitHub workflow's seed_beta job (psql on a runner) is the CI path; this
+ * script is the same operation shaped for Render's pre-deploy command, where
+ * one-off jobs are unavailable and psql is not installed but node + pg are.
+ * Runs from the repo root with the API service's own environment:
+ *
+ *   DATABASE_URL              (required) — the service's database
+ *   STYX_SEED_PASSWORD_HASH   (optional) — bcrypt hash to bind the shared demo
+ *                             password to the synthetic accounts. When unset,
+ *                             seeding still runs and account passwords keep
+ *                             their committed bootstrap hashes.
+ *
+ * Idempotent by construction: both seed files are ON CONFLICT-guarded, and the
+ * UPDATE is a fixed-point assignment. Nothing here prints a secret; the hash
+ * is data the users table already stores.
+ */
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { Pool } = require("pg");
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  console.error("SEED FAIL: DATABASE_URL is required");
+  process.exit(1);
+}
+
+const pool = new Pool({ connectionString: databaseUrl });
+
+const SEED_FILES = ["src/api/database/seed.sql", "scripts/demo/seed-circles.sql"];
+
+try {
+  for (const file of SEED_FILES) {
+    await pool.query(readFileSync(file, "utf8"));
+    console.log(`seeded: ${file}`);
+  }
+
+  const hash = process.env.STYX_SEED_PASSWORD_HASH || "";
+  if (hash) {
+    const result = await pool.query(
+      `UPDATE users SET password_hash = $1
+       WHERE email LIKE '%@demo.styx.protocol'
+          OR email = 'hr.lead@acheron.example'
+          -- Base-seed accounts live on @styx.protocol, which the LIKE above
+          -- does NOT match. Gate 01 logs in as demo@ — leaving these on the
+          -- committed bootstrap hash makes the readiness gate unpassable.
+          OR email IN ('demo@styx.protocol', 'fury@styx.protocol', 'admin@styx.protocol')`,
+      [hash],
+    );
+    console.log(`password bound: ${result.rowCount} account(s)`);
+  } else {
+    console.log("STYX_SEED_PASSWORD_HASH unset — bootstrap hashes left in place");
+  }
+  console.log("seed-beta complete");
+  process.exit(0);
+} catch (error) {
+  console.error("SEED FAIL:", error instanceof Error ? error.message : error);
+  process.exit(1);
+}


### PR DESCRIPTION
Jobs are unavailable on this Render account (402), so seeding gets a pre-deploy-shaped path: plain node+pg script run by the API service's pre-deploy command with its own env. Hash comes from `STYX_SEED_PASSWORD_HASH` service env — nothing secret in the repo; hash-less runs are safe no-ops for passwords. Verified idempotent against the local demo DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmP1SLhXcZBmA7g4NM6PTY

## Summary by Sourcery

Add a Render pre-deploy compatible database seeding script for the hosted beta demo environment.

New Features:
- Introduce a Node+pg-based seeding script that runs in Render pre-deploy to apply existing seed SQL files to the demo database.
- Support optional binding of demo user account password hashes from the STYX_SEED_PASSWORD_HASH environment variable during seeding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a deployment-compatible script for initializing beta database data.
  * Supports optional demo-account password configuration.
  * Provides progress reporting and clear success or failure status.
  * Can be safely rerun without duplicating seeded data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->