### PR TITLE
fix(migrate): baseline-drift repair — vacuously-stamped ALTER-only files never ran

### DIFF
--- a/src/api/database/migrations/065_deco_commitment_privacy.sql
+++ b/src/api/database/migrations/065_deco_commitment_privacy.sql
@@ -8,13 +8,23 @@ ALTER TABLE deco_commitments ADD COLUMN IF NOT EXISTS domain TEXT;
 ALTER TABLE deco_commitments ADD COLUMN IF NOT EXISTS committed_at TEXT;
 
 -- Backfill the domain from any existing plaintext before dropping it.
-UPDATE deco_commitments
-   SET domain = NULLIF(SPLIT_PART(SPLIT_PART(url, '://', 2), '/', 1), '')
- WHERE domain IS NULL
-   AND EXISTS (
-     SELECT 1 FROM information_schema.columns
-      WHERE table_name = 'deco_commitments' AND column_name = 'url'
-   );
+-- Dynamic SQL on purpose: a plain UPDATE referencing url fails at PARSE time
+-- once the column is dropped — the runtime EXISTS guard never gets a say — so
+-- an idempotent replay of this file (baseline-drift repair) would error. The
+-- EXECUTE defers parsing until the guard has confirmed the column exists.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_name = 'deco_commitments' AND column_name = 'url'
+  ) THEN
+    EXECUTE $q$
+      UPDATE deco_commitments
+         SET domain = NULLIF(SPLIT_PART(SPLIT_PART(url, '://', 2), '/', 1), '')
+       WHERE domain IS NULL
+    $q$;
+  END IF;
+END $$;
 
 ALTER TABLE deco_commitments DROP COLUMN IF EXISTS url;
 ALTER TABLE deco_commitments DROP COLUMN IF EXISTS selector;

--- a/src/api/database/migrations/migrate.spec.ts
+++ b/src/api/database/migrations/migrate.spec.ts
@@ -8,6 +8,7 @@ import {
   getPendingMigrations,
   isSchemaPreInitialized,
   listMigrationFiles,
+  repairBaselineDrift,
   runMigrations,
 } from './migrate';
 
@@ -42,9 +43,11 @@ function routeQueries(options: {
   existingTables: string[];
   sentinelPresent: boolean;
   stamped?: string[];
+  executed?: string[];
 }): string[] {
   const existing = new Set(options.existingTables);
   const stamped = options.stamped ?? [];
+  const executed = options.executed ?? [];
 
   mockQuery.mockImplementation(async (text: string, params?: unknown[]) => {
     if (text.includes('CREATE TABLE IF NOT EXISTS schema_migrations')) {
@@ -65,6 +68,12 @@ function routeQueries(options: {
     }
     if (text.includes('SELECT name FROM schema_migrations')) {
       return { rows: stamped.map((name) => ({ name })) };
+    }
+    // Raw migration DDL executed by the baseline path (ALTER-only files) or
+    // by repairBaselineDrift's replay.
+    if (/^\s*(ALTER|CREATE INDEX|DROP|DO)\b/i.test(text)) {
+      executed.push(text);
+      return { rows: [] };
     }
     throw new Error(`Unexpected query in test: ${text}`);
   });
@@ -255,7 +264,12 @@ describe('Migration Runner', () => {
       expect(mockConnect).not.toHaveBeenCalled();
     });
 
-    it('vacuously covers ALTER-only migrations inside the prefix', async () => {
+    it('executes ALTER-only migrations inside the prefix before stamping them', async () => {
+      // The old behavior stamped these as "vacuously covered by schema.sql" —
+      // true only when the snapshot matches the migration tree's vintage. A
+      // database provisioned months earlier was stamped for columns it never
+      // received (the 2026-08-15 beta grace_period_month 500). ALTER-only
+      // files are idempotent by contract, so the baseline now runs them.
       (fs.readdirSync as jest.Mock).mockReturnValue([
         '001_initial_schema.sql',
         '007_user_compliance_identity_fields.sql',
@@ -267,15 +281,20 @@ describe('Migration Runner', () => {
           'ALTER TABLE users ADD COLUMN IF NOT EXISTS legal_name TEXT;',
         '050_behavioral_omega_tables.sql': 'CREATE TABLE IF NOT EXISTS pod_broadcast_log (id UUID);',
       });
+      const executed: string[] = [];
       const stamped = routeQueries({
         existingTables: ['accounts'],
         sentinelPresent: true,
+        executed,
       });
 
       await baselineFromExistingSchema(mockPool);
       expect(stamped).toEqual([
         '001_initial_schema.sql',
         '007_user_compliance_identity_fields.sql',
+      ]);
+      expect(executed).toEqual([
+        'ALTER TABLE users ADD COLUMN IF NOT EXISTS legal_name TEXT;',
       ]);
     });
 
@@ -321,13 +340,21 @@ describe('Migration Runner', () => {
         .mockResolvedValueOnce({ rows: [] }) // ensureMigrationsTable CREATE TABLE
         .mockResolvedValueOnce({ rows: [] }) // tracked getAppliedMigrations (empty)
         .mockResolvedValueOnce({ rows: [{ reg: null }] }) // isSchemaPreInitialized -> fresh DB
-        .mockResolvedValueOnce({ rows: [] }); // getPendingMigrations -> getAppliedMigrations (empty)
+        .mockResolvedValueOnce({ rows: [] }) // getPendingMigrations -> getAppliedMigrations (empty)
+        .mockResolvedValueOnce({
+          // repairBaselineDrift -> getAppliedMigrations (both now applied)
+          rows: [{ name: '001_initial_schema.sql' }, { name: '002_add_index.sql' }],
+        })
+        .mockResolvedValueOnce({ rows: [] }); // repair replays 002 (ALTER-only class)
 
       (fs.readdirSync as jest.Mock).mockReturnValue([
         '001_initial_schema.sql',
         '002_add_index.sql',
       ]);
       (fs.readFileSync as jest.Mock)
+        .mockReturnValueOnce('CREATE TABLE accounts (...);')
+        .mockReturnValueOnce('CREATE INDEX idx_foo ON bar(baz);')
+        // repairBaselineDrift re-reads the applied set
         .mockReturnValueOnce('CREATE TABLE accounts (...);')
         .mockReturnValueOnce('CREATE INDEX idx_foo ON bar(baz);');
 
@@ -353,9 +380,13 @@ describe('Migration Runner', () => {
       mockQuery
         .mockResolvedValueOnce({ rows: [] }) // CREATE TABLE
         .mockResolvedValueOnce({ rows: [{ name: '001_initial_schema.sql' }] }) // tracked (non-empty -> no baseline)
-        .mockResolvedValueOnce({ rows: [{ name: '001_initial_schema.sql' }] }); // getPendingMigrations -> getAppliedMigrations
+        .mockResolvedValueOnce({ rows: [{ name: '001_initial_schema.sql' }] }) // getPendingMigrations -> getAppliedMigrations
+        .mockResolvedValueOnce({ rows: [{ name: '001_initial_schema.sql' }] }); // repairBaselineDrift -> getAppliedMigrations
 
       (fs.readdirSync as jest.Mock).mockReturnValue(['001_initial_schema.sql']);
+      // repairBaselineDrift re-reads the applied file; a CREATE TABLE file is
+      // not replayed, so no further pool queries happen.
+      (fs.readFileSync as jest.Mock).mockReturnValue('CREATE TABLE accounts (id UUID);');
 
       const applied = await runMigrations(mockPool);
       expect(applied).toEqual([]);
@@ -379,6 +410,46 @@ describe('Migration Runner', () => {
       await expect(runMigrations(mockPool)).rejects.toThrow('syntax error');
       expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
       expect(mockClient.release).toHaveBeenCalled();
+    });
+  });
+
+  describe('repairBaselineDrift', () => {
+    it('replays applied ALTER-only migrations and skips table-creating ones', async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          // getAppliedMigrations: both files tracked
+          rows: [{ name: '001_initial_schema.sql' }, { name: '029_grace_month.sql' }],
+        })
+        .mockResolvedValueOnce({ rows: [] }); // replay of 029's ALTER
+
+      (fs.readdirSync as jest.Mock).mockReturnValue([
+        '001_initial_schema.sql',
+        '029_grace_month.sql',
+      ]);
+      routeMigrationSql({
+        '001_initial_schema.sql': 'CREATE TABLE accounts (id UUID);',
+        '029_grace_month.sql':
+          'ALTER TABLE contracts ADD COLUMN IF NOT EXISTS grace_period_month TEXT;',
+      });
+
+      await expect(repairBaselineDrift(mockPool)).resolves.toEqual(['029_grace_month.sql']);
+      expect(mockQuery).toHaveBeenCalledWith(
+        'ALTER TABLE contracts ADD COLUMN IF NOT EXISTS grace_period_month TEXT;',
+      );
+    });
+
+    it('leaves unapplied files alone', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] }); // getAppliedMigrations: nothing tracked
+
+      (fs.readdirSync as jest.Mock).mockReturnValue(['029_grace_month.sql']);
+      routeMigrationSql({
+        '029_grace_month.sql':
+          'ALTER TABLE contracts ADD COLUMN IF NOT EXISTS grace_period_month TEXT;',
+      });
+
+      await expect(repairBaselineDrift(mockPool)).resolves.toEqual([]);
+      // Only the applied-set lookup happened; nothing was replayed.
+      expect(mockQuery).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/api/database/migrations/migrate.ts
+++ b/src/api/database/migrations/migrate.ts
@@ -168,6 +168,15 @@ export async function baselineFromExistingSchema(pool: Pool): Promise<string[]> 
     if (!(await allTablesExist(pool, tables))) {
       break;
     }
+    // ALTER-only files were previously stamped as "vacuously covered by the
+    // schema.sql snapshot" — true only when the snapshot is the same vintage
+    // as the migration tree. A database provisioned months earlier stamps
+    // columns it never received (2026-08-15: grace_period_month on the
+    // March-provisioned beta). Every ALTER-only file is idempotent by
+    // contract, so execute it instead of assuming.
+    if (tables.length === 0) {
+      await pool.query(sql);
+    }
     await pool.query(
       `INSERT INTO ${MIGRATIONS_TABLE} (name) VALUES ($1) ON CONFLICT (name) DO NOTHING`,
       [file],
@@ -178,6 +187,33 @@ export async function baselineFromExistingSchema(pool: Pool): Promise<string[]> 
     `Baselined ${stamped.length}/${files.length} migration(s) whose schema objects already exist; the rest will execute.`,
   );
   return stamped;
+}
+
+/**
+ * Re-executes every applied migration that creates no tables. Databases
+ * baselined by an earlier version of baselineFromExistingSchema stamped
+ * ALTER-only files without running them (see the comment in that function);
+ * the hole is invisible until a query hits a missing column. Every ALTER-only
+ * file is idempotent by contract (IF NOT EXISTS DDL, fixed-point writes), so
+ * replaying the applied set is a fast no-op on healthy databases and a repair
+ * on drifted ones.
+ */
+export async function repairBaselineDrift(pool: Pool): Promise<string[]> {
+  const appliedSet = await getAppliedMigrations(pool);
+  const repaired: string[] = [];
+  for (const file of listMigrationFiles()) {
+    if (!appliedSet.has(file)) continue;
+    const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, file), 'utf-8');
+    if (extractCreatedTables(sql).length > 0) continue;
+    await pool.query(sql);
+    repaired.push(file);
+  }
+  if (repaired.length > 0) {
+    console.log(
+      `Baseline-drift repair replayed ${repaired.length} ALTER-only applied migration(s).`,
+    );
+  }
+  return repaired;
 }
 
 export async function runMigrations(pool: Pool): Promise<string[]> {
@@ -197,6 +233,7 @@ export async function runMigrations(pool: Pool): Promise<string[]> {
 
   if (pending.length === 0) {
     console.log('No pending migrations.');
+    await repairBaselineDrift(pool);
     return [];
   }
 
@@ -225,6 +262,7 @@ export async function runMigrations(pool: Pool): Promise<string[]> {
     }
   }
 
+  await repairBaselineDrift(pool);
   return applied;
 }
 


### PR DESCRIPTION
The live beta's first authenticated sweep hit a 500: `column "grace_period_month" does not exist`. Root cause: the baseline adopter stamps ALTER-only migrations as "vacuously covered by schema.sql" — valid only when the snapshot matches the migration tree's vintage. The March-provisioned DB baselined against August's tree stamped 15 ALTER-only files (007–030) that never executed.

- `baselineFromExistingSchema` now executes ALTER-only files (idempotent by contract) instead of assuming coverage.
- New `repairBaselineDrift` replays every applied ALTER-only migration on each migrate run — no-op when healthy, self-heal when stamped by the old baseliner (the live beta heals on next boot; a future prod provisioned from a stale snapshot heals identically).
- 065's backfill moves into DO/EXECUTE: plain SQL referencing a dropped column dies at parse time before its runtime guard — the only replay trap in all 73 files (audited).

Verified: dropped the column from a fully-migrated local DB → migrate restored it; second run replays 27 files, exit 0, fixed point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmP1SLhXcZBmA7g4NM6PTY

## Summary by Sourcery

Repair incorrect baselining of ALTER-only migrations and add automatic drift recovery during migrate runs.

Bug Fixes:
- Ensure ALTER-only migrations are executed during baseline creation instead of being assumed covered by the schema snapshot.
- Automatically re-run previously applied ALTER-only migrations on each migrate run to repair databases that were stamped but never actually migrated.
- Prevent replay failures in migration 065 by wrapping the backfill UPDATE in guarded dynamic SQL so it remains safe and idempotent on drift repair.

Enhancements:
- Log baseline drift repair activity when ALTER-only migrations are replayed during migration runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration handling for existing installations.
  * Automatically repairs previously skipped schema changes when migrations are replayed.
  * Prevented migration failures when optional database columns are no longer present.
  * Preserved existing domain extraction behavior while making migration reruns safer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->