### PR TITLE
fix(seed): seeded personas get a date_of_birth — the age gate was blocking every demo contract creation

### DIFF
--- a/scripts/demo/seed-circles.sql
+++ b/scripts/demo/seed-circles.sql
@@ -466,3 +466,13 @@ BEGIN
     );
   END IF;
 END $$;
+
+-- Circle personas are synthetic ADULTS. Same rationale as the stamp in
+-- src/api/database/seed.sql: the age gate fails closed on NULL date_of_birth
+-- for monetized actions, and this file inserts the @demo.styx.protocol and
+-- hr.lead@acheron.example personas AFTER that stamp has already run.
+-- Fills NULLs only — never overwrites a real value.
+UPDATE users SET date_of_birth = DATE '1990-01-15'
+WHERE date_of_birth IS NULL
+  AND (email LIKE '%@demo.styx.protocol'
+       OR email = 'hr.lead@acheron.example');

--- a/src/api/database/seed.sql
+++ b/src/api/database/seed.sql
@@ -35,6 +35,16 @@ INSERT INTO users (id, email, password_hash, stripe_customer_id, integrity_score
   ('d0000000-0000-0000-0000-000000000003', 'admin@styx.protocol', '$2b$10$Qvqvkece7/TpoSbDjHr75eHpT7blt9.4dwoub11ClSk2/PCk4tehe', 'cus_admin_001', 200, 'a0000000-0000-0000-0000-000000000012', 'ADMIN', 'e0000000-0000-0000-0000-000000000001', 'ACTIVE')
 ON CONFLICT (id) DO NOTHING;
 
+-- Seeded personas are synthetic ADULTS. The age gate (migration 008 +
+-- compliance policy) fails closed on a NULL date_of_birth for every monetized
+-- action, so without this stamp no demo account can create a contract in a
+-- FULL_ACCESS jurisdiction. Fills NULLs only — never overwrites a real value.
+UPDATE users SET date_of_birth = DATE '1990-01-15'
+WHERE date_of_birth IS NULL
+  AND (email LIKE '%@demo.styx.protocol'
+       OR email = 'hr.lead@acheron.example'
+       OR email IN ('demo@styx.protocol', 'fury@styx.protocol', 'admin@styx.protocol'));
+
 -- Contracts in different states
 -- realm_id is NOT NULL since migration 025; realm rows are seeded by 025 itself.
 INSERT INTO contracts (id, user_id, oath_category, verification_method, stake_amount, payment_intent_id, duration_days, status, started_at, ends_at, realm_id) VALUES


### PR DESCRIPTION
Found by running the readiness suite against the live beta: gate 01 (phantom-money) got **403 AGE_VERIFICATION_REQUIRED** on `POST /contracts` as `demo@styx.protocol`. The age gate (migration 008 + compliance policy) fails closed on a NULL `date_of_birth` for monetized actions — that behavior is correct and stays — but both seed files insert synthetic adults with **no DOB**, so no seeded persona can create a contract in a FULL_ACCESS jurisdiction. Real beta testers on the demo personas hit the same wall on the create flow (the 47-route sweep rendered pages; it never exercised creation).

Fix: an idempotent `UPDATE … WHERE date_of_birth IS NULL` stamp in **both** seed files — `seed.sql` (demo/fury/admin) and `seed-circles.sql` (the circle personas it inserts after that stamp has already run). Fills NULLs only, never overwrites a real value. Reaches the live beta through the boot-path seeder on the next deploy.

Verification plan: merge → trigger API deploy → rerun `beta-readiness` against the live URLs → gate 01 exercises the ledger path and the suite goes fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmP1SLhXcZBmA7g4NM6PTY

## Summary by Sourcery

Ensure seeded demo personas have a non-null date_of_birth so they can pass age verification and create contracts in full-access jurisdictions.

New Features:
- Assign a default adult date_of_birth to seeded demo and circle personas lacking a DOB in both primary seed scripts.

Bug Fixes:
- Fix age gate failures for seeded demo personas by preventing NULL date_of_birth values from blocking monetized actions.