### PR TITLE
test(web): pin the dashboard jurisdiction notice — the branch #867 reported unreachable

### DIFF
--- a/src/web/app/dashboard/page.tsx
+++ b/src/web/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import { Activity, ShieldCheck, Flame, History, User, Loader2, AlertTriangle, LogOut, Bell, Settings, ScrollText, HelpCircle } from 'lucide-react';
+import { Activity, ShieldCheck, Flame, History, User, Loader2, LogOut, Bell, Settings, ScrollText, HelpCircle } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { api, ApiError } from '../../services/api-client';
@@ -10,6 +10,7 @@ import Leaderboard from '../../components/Leaderboard';
 import NotificationPanel from '../../components/NotificationPanel';
 import StreakChain from '../../components/StreakChain';
 import { OnboardingWizard } from '../../components/OnboardingWizard';
+import { DashboardErrorNotice } from '../../components/DashboardErrorNotice';
 
 interface BalanceData {
   id: string;
@@ -96,29 +97,7 @@ export default function IdentityDashboard() {
   }
 
   if (error) {
-    const apiError = error instanceof ApiError ? error : null;
-    const jurisdictionBlocked = apiError?.code === 'JURISDICTION_BLOCKED';
-    const isNetworkError = apiError?.status === 0;
-    return (
-      <div className="min-h-screen bg-black text-white flex items-center justify-center">
-        <div className="text-center space-y-4 max-w-md px-6">
-          <AlertTriangle className={`mx-auto ${jurisdictionBlocked ? 'text-yellow-500' : 'text-red-500'}`} size={48} />
-          {jurisdictionBlocked ? (
-            <>
-              <p className="text-yellow-400 font-bold">Not available in your jurisdiction</p>
-              <p className="text-neutral-400 text-sm">{error.message}</p>
-            </>
-          ) : (
-            <>
-              <p className="text-red-400 font-bold">{error.message}</p>
-              {isNetworkError && (
-                <p className="text-neutral-500 text-sm">Ensure the backend service is reachable.</p>
-              )}
-            </>
-          )}
-        </div>
-      </div>
-    );
+    return <DashboardErrorNotice error={error} />;
   }
 
   const integrityScore = balance?.integrity_score ?? 0;

--- a/src/web/components/DashboardErrorNotice.test.tsx
+++ b/src/web/components/DashboardErrorNotice.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { DashboardErrorNotice } from './DashboardErrorNotice';
+import { ApiError } from '../services/api-client';
+
+// Regression guard for issue #867: the jurisdiction notice was unreachable
+// (the 403 was swallowed into an empty contract list) until #868, and no test
+// pinned the repaired behavior. These three branches are the contract.
+describe('DashboardErrorNotice', () => {
+  it('renders the jurisdiction notice with the API message for JURISDICTION_BLOCKED', () => {
+    const err = new ApiError(
+      'Styx is not available in your region yet.',
+      403,
+      'JURISDICTION_BLOCKED',
+      'trace-123',
+    );
+    const html = renderToStaticMarkup(<DashboardErrorNotice error={err} />);
+
+    expect(html).toContain('Not available in your jurisdiction');
+    expect(html).toContain('Styx is not available in your region yet.');
+    // A deliberate product state must not read as an outage.
+    expect(html).not.toContain('Ensure the backend service is reachable.');
+  });
+
+  it('renders the reachability hint only for network errors (status 0)', () => {
+    const err = new ApiError('Network request failed', 0, null, null);
+    const html = renderToStaticMarkup(<DashboardErrorNotice error={err} />);
+
+    expect(html).toContain('Network request failed');
+    expect(html).toContain('Ensure the backend service is reachable.');
+  });
+
+  it('renders a plain message with no reachability hint for other errors', () => {
+    const err = new ApiError('Forbidden', 403, 'FORBIDDEN', null);
+    const html = renderToStaticMarkup(<DashboardErrorNotice error={err} />);
+
+    expect(html).toContain('Forbidden');
+    expect(html).not.toContain('Ensure the backend service is reachable.');
+    expect(html).not.toContain('Not available in your jurisdiction');
+  });
+});

--- a/src/web/components/DashboardErrorNotice.tsx
+++ b/src/web/components/DashboardErrorNotice.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { ApiError } from '../services/api-client';
+
+/**
+ * The dashboard's full-page error surface, extracted so the branch that renders
+ * the jurisdiction notice is testable in isolation (issue #867: the notice was
+ * unreachable until #868, and nothing pinned it afterwards). Three branches:
+ *
+ * - JURISDICTION_BLOCKED ApiError → the yellow notice carrying the API's own
+ *   message (a deliberate product state, not an outage)
+ * - network error (ApiError status 0) → the reachability hint
+ * - anything else → the message alone, with no misleading reachability line
+ */
+export function DashboardErrorNotice({ error }: { error: Error }) {
+  const apiError = error instanceof ApiError ? error : null;
+  const jurisdictionBlocked = apiError?.code === 'JURISDICTION_BLOCKED';
+  const isNetworkError = apiError?.status === 0;
+  return (
+    <div className="min-h-screen bg-black text-white flex items-center justify-center">
+      <div className="text-center space-y-4 max-w-md px-6">
+        <AlertTriangle className={`mx-auto ${jurisdictionBlocked ? 'text-yellow-500' : 'text-red-500'}`} size={48} />
+        {jurisdictionBlocked ? (
+          <>
+            <p className="text-yellow-400 font-bold">Not available in your jurisdiction</p>
+            <p className="text-neutral-400 text-sm">{error.message}</p>
+          </>
+        ) : (
+          <>
+            <p className="text-red-400 font-bold">{error.message}</p>
+            {isNetworkError && (
+              <p className="text-neutral-500 text-sm">Ensure the backend service is reachable.</p>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
#868 repaired the defect #867 describes (the contracts call re-throws `JURISDICTION_BLOCKED`; the dashboard renders a dedicated yellow notice with the API's own message) — but the issue stayed open and **nothing pinned the repaired behavior**: the page tests only exercise the loading state, since `renderToStaticMarkup` runs no effects.

This extracts the error surface into `DashboardErrorNotice` (App Router page files can't export extra components) and pins its three branches in the repo's existing static-markup idiom: jurisdiction → notice + API message and **no** misleading reachability hint; network (status 0) → reachability hint; anything else → message alone.

6/6 web tests green, tsc clean. Closes #867. Wave 2 of the full-build program (#904).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmP1SLhXcZBmA7g4NM6PTY

## Summary by Sourcery

Extract the dashboard’s full-page error UI into a reusable DashboardErrorNotice component and wire the dashboard page to use it.

Bug Fixes:
- Ensure the jurisdiction-blocked dashboard error state is reachable and correctly shows the API’s message without a misleading reachability hint.
- Restrict the backend reachability hint to network errors only, showing a plain message for other error types.

Enhancements:
- Introduce a dedicated DashboardErrorNotice component to centralize and standardize error rendering for the dashboard.

Tests:
- Add regression tests for the three DashboardErrorNotice branches: jurisdiction-blocked, network error, and other errors.