### PR TITLE
fix(docker): the web image builds the output it copies, and bakes real URLs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,6 +11,15 @@ name: Build & Publish Docker Images
 
 on:
   workflow_dispatch:
+    inputs:
+      web_api_url:
+        description: "Public API base URL baked into the web bundle (NEXT_PUBLIC_* is build-time)"
+        required: false
+        type: string
+      web_web_url:
+        description: "Public web base URL baked into the web bundle"
+        required: false
+        type: string
   push:
     tags:
       - "v*"
@@ -35,16 +44,34 @@ jobs:
             image: styx-api
             build_args: |
               API_CONTAINER_PORT=3000
+          # NEXT_PUBLIC_* values are inlined into the client bundle at BUILD
+          # time, so a published web image is bound to the URLs baked here
+          # (issue #893: hardcoded localhost made the ghcr image unusable
+          # anywhere). Resolution order: dispatch input → repo variables
+          # DOCKER_WEB_API_URL / DOCKER_WEB_WEB_URL → localhost (compose-only
+          # dev fallback, and the run summary names which value was used).
           - service: web
             dockerfile: src/web/Dockerfile
             image: styx-web
             build_args: |
               WEB_CONTAINER_PORT=3001
-              NEXT_PUBLIC_API_URL=http://localhost:3000
-              NEXT_PUBLIC_WEB_URL=http://localhost:3001
+              NEXT_PUBLIC_API_URL=${{ inputs.web_api_url || vars.DOCKER_WEB_API_URL || 'http://localhost:3000' }}
+              NEXT_PUBLIC_WEB_URL=${{ inputs.web_web_url || vars.DOCKER_WEB_WEB_URL || 'http://localhost:3001' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+
+      - name: Record baked public URLs (web image provenance)
+        if: matrix.service == 'web'
+        env:
+          BUILD_ARGS: ${{ matrix.build_args }}
+        run: |
+          {
+            echo "### styx-web baked build args"
+            echo '```'
+            printf '%s\n' "$BUILD_ARGS" | grep NEXT_PUBLIC || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/src/web/Dockerfile
+++ b/src/web/Dockerfile
@@ -21,6 +21,9 @@ COPY src/shared ./src/shared
 # Build Next.js
 WORKDIR /app/src/web
 ENV NEXT_TELEMETRY_DISABLED=1
+# Selects output:'standalone' in next.config.js — the runner stage below copies
+# .next/standalone and runs server.js, which only exist in standalone mode.
+ENV STYX_DOCKER_BUILD=true
 ARG NEXT_PUBLIC_API_URL
 ARG NEXT_PUBLIC_WEB_URL
 ARG NEXT_PUBLIC_STYX_ENV_LABEL

--- a/src/web/next.config.js
+++ b/src/web/next.config.js
@@ -31,6 +31,15 @@ const nextConfig = {
         trailingSlash: true,
       }
     : {}),
+  // The Docker image's runner stage copies .next/standalone and runs
+  // src/web/server.js — output that only exists when Next builds in
+  // standalone mode. Gated on the env the Dockerfile sets (same pattern as
+  // SNAPSHOT above) so the Render path (`next start`) and the snapshot
+  // export keep their existing build shapes. Issue #890: the Dockerfile
+  // assumed standalone output that no config ever produced.
+  ...(!SNAPSHOT && process.env.STYX_DOCKER_BUILD === "true"
+    ? { output: "standalone" }
+    : {}),
   async rewrites() {
     // Static export has no proxy layer. In snapshot mode the client answers from
     // bundled fixtures and never calls /api at all.


### PR DESCRIPTION
Two defects in the tag-triggered publish path (never exercised by pr-gate, so never caught):

**#890** — the Dockerfile's runner stage copies `.next/standalone` and runs `src/web/server.js`, but `next.config.js` never set `output:'standalone'`; the copy had nothing to copy. Now gated on `STYX_DOCKER_BUILD=true` (set in the build stage) — the same conditional pattern as `SNAPSHOT`, so the Render path (`next start`) and the snapshot export keep their existing build shapes. **Verified locally**: the gated build produces `.next/standalone/src/web/server.js`, exit 0.

**#893** — `NEXT_PUBLIC_*` is inlined at build time, and the workflow baked `http://localhost:3000` into the published ghcr web image, making it unusable anywhere. Resolution now: dispatch input → repo vars `DOCKER_WEB_API_URL`/`DOCKER_WEB_WEB_URL` → localhost (compose-only dev fallback), with a run-summary step recording which values were baked into each image.

Closes #890. Closes #893. Wave 2 of the full-build program (#904).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmP1SLhXcZBmA7g4NM6PTY

## Summary by Sourcery

Ensure the Docker web image builds in standalone mode and bakes correct public URLs for published images.

New Features:
- Allow docker-publish workflow dispatches to specify public API and web base URLs for the web image.

Bug Fixes:
- Fix Docker web image build to produce standalone output required by the runner stage.
- Avoid hardcoded localhost URLs in published web images by resolving NEXT_PUBLIC_* values from dispatch inputs, repo variables, or localhost as a fallback.

Enhancements:
- Add a step to record the public URLs baked into the web image in the workflow run summary for traceability.

Build:
- Gate Next.js standalone output on a Docker-specific environment flag set during the web image build.
- Pass resolved public API and web URLs as build arguments when building the styx-web Docker image.