### PR TITLE
fix(auth): stop the CSRF refill from tripping on ordinary navigation

### DIFF
--- a/src/api/src/modules/auth/auth.controller.ts
+++ b/src/api/src/modules/auth/auth.controller.ts
@@ -181,8 +181,13 @@ export class AuthController {
 
   @Get('csrf')
   @ApiOperation({ summary: 'Refresh CSRF cookie for browser session requests' })
-  // AU5: rate-limit CSRF cookie issuance like the other auth endpoints.
-  @Throttle({ default: { ttl: 60000, limit: 5 } })
+  // Rate-limited, but NOT like login/register: this endpoint requires an
+  // already-valid session cookie and DERIVES a deterministic token from it —
+  // it is a refill path, not a credential surface, so credential-stuffing
+  // limits don't transfer. 5/min tripped ordinary fast navigation and shared
+  // NAT egress (#891); 30/min stays far below abuse scale for an HMAC derive
+  // while never firing on human browsing.
+  @Throttle({ default: { ttl: 60000, limit: 30 } })
   async csrf(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
     // The CSRF token is bound to the active session, so it can only be derived
     // for a request that already carries a valid access-token cookie.

--- a/src/web/contexts/AuthContext.tsx
+++ b/src/web/contexts/AuthContext.tsx
@@ -2,7 +2,7 @@
 
 import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
 import { usePathname } from 'next/navigation';
-import { api, setAuthToken, setCsrfToken } from '../services/api-client';
+import { api, setAuthToken, setCsrfToken, readCsrfCookie } from '../services/api-client';
 
 interface User {
   id: string;
@@ -70,9 +70,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         if (cancelled) return;
         setUser(me);
         try {
-          const csrf = await api.getCsrf();
-          if (cancelled) return;
-          setCsrfToken(csrf.csrfToken);
+          // The CSRF cookie is readable by design (double-submit) and its
+          // value is deterministic per session — hydration takes it from the
+          // cookie and only calls the refresh endpoint when the cookie is
+          // missing. Calling on every page load tripped the endpoint's rate
+          // limit under ordinary fast navigation (#891).
+          const cookieCsrf = readCsrfCookie();
+          if (cookieCsrf) {
+            setCsrfToken(cookieCsrf);
+          } else {
+            const csrf = await api.getCsrf();
+            if (cancelled) return;
+            setCsrfToken(csrf.csrfToken);
+          }
         } catch {
           // Non-fatal: mutating requests will refresh/retry if needed.
         }

--- a/src/web/services/api-client.ts
+++ b/src/web/services/api-client.ts
@@ -41,6 +41,17 @@ export function getCsrfToken(): string {
   return currentCsrfToken;
 }
 
+/**
+ * The CSRF cookie is deliberately readable (httpOnly: false — double-submit
+ * pattern) and its value is deterministic per session, so session hydration
+ * can take it straight from the cookie instead of calling GET /auth/csrf on
+ * every page load (#891: the per-load call tripped the endpoint's rate limit
+ * on ordinary fast navigation).
+ */
+export function readCsrfCookie(): string | null {
+  return readCookie("styx_csrf_token");
+}
+
 function readCookie(name: string): string | null {
   if (typeof document === "undefined") return null;
   const cookies = document.cookie.split(";");


### PR DESCRIPTION
Client-first fix for #891, because the client was the storm's source: session hydration called `GET /auth/csrf` on **every page load**, and the endpoint's 5/min/IP throttle tripped under ordinary fast navigation.

- **Client**: hydration now reads the `styx_csrf_token` cookie (readable by design — double-submit pattern, deterministic per session) and only calls the endpoint when the cookie is absent. The per-load network call is gone entirely.
- **Server**: the throttle rises 5→30/min with the rationale recorded in-code — the endpoint requires an already-valid session cookie and *derives* the token, so credential-stuffing limits don't transfer; it's a refill path, not a credential surface.

Verified: 394 web tests green, web+api `tsc` clean. Closes #891. Wave 2 of the full-build program (#904).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmP1SLhXcZBmA7g4NM6PTY

## Summary by Sourcery

Reduce CSRF refresh traffic on ordinary navigation by reusing the existing session CSRF cookie and relaxing server-side rate limits to match real-world usage.

Bug Fixes:
- Prevent CSRF token refresh from failing under normal fast navigation due to aggressive rate limiting.

Enhancements:
- Update client auth hydration to read the deterministic CSRF cookie and only call the refresh endpoint when the cookie is missing.
- Expose a helper in the web API client to read the CSRF cookie directly.
- Increase the CSRF refresh endpoint rate limit to tolerate typical browsing patterns while remaining safely below abuse thresholds.