### PR TITLE
feat(demo): the ensure-script honors the external collector — the Worker is the collector of record

### DIFF
--- a/.github/workflows/beta-promotion.yml
+++ b/.github/workflows/beta-promotion.yml
@@ -117,6 +117,10 @@ jobs:
           RENDER_BETA_API_SERVICE_ID: ${{ secrets.RENDER_BETA_API_SERVICE_ID }}
           RENDER_BETA_WEB_SERVICE_ID: ${{ secrets.RENDER_BETA_WEB_SERVICE_ID }}
           BETA_FEEDBACK_TOKEN: ${{ secrets.BETA_FEEDBACK_TOKEN }}
+          # External collector (the Cloudflare Worker, #894). Public by design —
+          # a repo VARIABLE, not a secret. When set, the ensure script skips
+          # Render collector provisioning entirely.
+          STYX_BETA_FEEDBACK_URL: ${{ vars.STYX_BETA_FEEDBACK_URL }}
         run: node scripts/demo/render-ensure-beta.mjs
 
   deploy_beta_api:

--- a/scripts/demo/render-ensure-beta.mjs
+++ b/scripts/demo/render-ensure-beta.mjs
@@ -102,7 +102,25 @@ async function ensureEnv(role, serviceId, wanted, current) {
   }
 }
 
-/** 2. Find-or-create the collector. Never fatal. */
+/**
+ * 2. Resolve the collector. An EXTERNAL collector URL wins (#894): the live
+ * collector is a Cloudflare Worker (KV-backed, token-gated summary), so when
+ * STYX_BETA_FEEDBACK_URL is configured, Render provisioning is skipped
+ * entirely — no find-or-create, no paid service, no 402 on free-tier
+ * workspaces. Only when no external URL is configured does the legacy Render
+ * path below run. The URL is public by design (baked into the shipped
+ * bundle); only the summary token is secret.
+ */
+async function resolveFeedbackUrl(ownerId) {
+  const external = (process.env.STYX_BETA_FEEDBACK_URL || "").replace(/\/+$/, "");
+  if (external) {
+    console.log("feedback collector: external URL configured — skipping Render provisioning");
+    return external;
+  }
+  return ensureFeedbackService(ownerId);
+}
+
+/** Legacy Render path: find-or-create the collector. Never fatal. */
 async function ensureFeedbackService(ownerId) {
   try {
     const found = await render("GET", `/services?name=${encodeURIComponent(feedbackName)}&limit=20`);
@@ -171,7 +189,7 @@ async function ensureFeedbackService(ownerId) {
 const apiService = await ensureLive("api", apiServiceId);
 await ensureLive("web", webServiceId);
 
-const feedbackUrl = await ensureFeedbackService(apiService.ownerId);
+const feedbackUrl = await resolveFeedbackUrl(apiService.ownerId);
 
 console.log("ensuring beta env vars (key names only) ...");
 const apiCurrent = await listEnvKeys(apiServiceId);


### PR DESCRIPTION
Completes #894's remainder: the live collector is the Cloudflare Worker (KV-backed, digest-gated summary), and `render-ensure-beta.mjs` now resolves `STYX_BETA_FEEDBACK_URL` first — when set, Render collector provisioning is skipped entirely (no find-or-create, no paid service, no 402 on free workspaces). Legacy Render path stays as the fallback.

`beta-promotion.yml` passes the URL from the repo **variable** `STYX_BETA_FEEDBACK_URL` (public by design — it's baked into the shipped bundle; only the summary token is secret). The variable is already set to the live Worker URL.

Closes #894. Wave 2 of the full-build program (#904) — and with it, every beta-residual issue (#890–#894) plus #867 is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmP1SLhXcZBmA7g4NM6PTY

## Summary by Sourcery

Honor an external beta feedback collector URL as the primary collector and wire it through the demo ensure script and beta promotion workflow.

New Features:
- Support configuring an external beta feedback collector URL that bypasses Render-based collector provisioning.

Enhancements:
- Introduce feedback URL resolution logic that prefers the external collector and falls back to the legacy Render service when no URL is set.

CI:
- Pass the external beta feedback collector URL from a public repository variable into the beta promotion workflow so it is available to the ensure script.