### PR TITLE
fix(fury): peer reviewers were being served RAW, unredacted proof media

### DIFF
--- a/src/api/src/modules/fury/fury.controller.spec.ts
+++ b/src/api/src/modules/fury/fury.controller.spec.ts
@@ -6,6 +6,11 @@ import { FuryViolationCode } from '../../../../shared/fury-logic/violation-codes
 describe('FuryController', () => {
   let controller: FuryController;
   let mockPool: { query: jest.Mock };
+  // The R2 mock used to be `{}` — generateViewUrl always threw, every viewUrl
+  // resolved to null through the catch, and the masked-vs-raw selection branch
+  // was never exercised by any test. That is why the queue shipped serving raw
+  // media to peer reviewers: the assertion could not fail.
+  let mockR2: { generateViewUrl: jest.Mock };
 
   const mockFuryWorker = {
     checkConsensus: jest.fn().mockResolvedValue(undefined),
@@ -17,11 +22,14 @@ describe('FuryController', () => {
 
   beforeEach(() => {
     mockPool = { query: jest.fn() };
+    mockR2 = {
+      generateViewUrl: jest.fn(async (key: string) => `https://signed.example/${key}`),
+    };
     controller = new FuryController(
       mockPool as unknown as Pool,
       mockFuryWorker,
       mockTruthLog,
-      {} as any
+      mockR2 as any
     );
     jest.clearAllMocks();
   });
@@ -87,6 +95,57 @@ describe('FuryController', () => {
       ]) {
         expect(sql).toContain(column);
       }
+    });
+
+    // The invariant: a Fury auditor is NEVER served raw media, and the decision
+    // keys on the PRESENCE of a masked asset — not on the redaction_status
+    // string, which the production finalize path writes as 'MASKED' while the
+    // dev-only worker fallback writes 'COMPLETED'. The old code compared against
+    // 'COMPLETED' only and fell through to media_uri, so the production path
+    // leaked the unredacted original to peer reviewers.
+    it.each(['MASKED', 'COMPLETED', 'NOT_APPLICABLE', null])(
+      'signs the MASKED asset and never the raw one (redaction_status=%s)',
+      async (redactionStatus) => {
+        mockPool.query.mockResolvedValueOnce({
+          rows: [
+            {
+              assignment_id: 'a-1',
+              proof_id: 'p-1',
+              media_uri: 'raw/original.mp4',
+              masked_media_uri: 'masked/redacted.mp4',
+              redaction_status: redactionStatus,
+              oath_category: 'RECOVERY_NOCONTACT',
+            },
+          ],
+        });
+
+        const result = await controller.getAssignments({ id: 'fury-user-1' });
+
+        expect(result.assignments[0].viewUrl).toBe('https://signed.example/masked/redacted.mp4');
+        expect(mockR2.generateViewUrl).toHaveBeenCalledWith('masked/redacted.mp4');
+        expect(mockR2.generateViewUrl).not.toHaveBeenCalledWith('raw/original.mp4');
+      },
+    );
+
+    it('fails CLOSED — no masked asset means no url, never the raw original', async () => {
+      mockPool.query.mockResolvedValueOnce({
+        rows: [
+          {
+            assignment_id: 'a-1',
+            proof_id: 'p-1',
+            media_uri: 'raw/original.mp4',
+            masked_media_uri: null,
+            // Even a status claiming redaction finished cannot conjure an asset.
+            redaction_status: 'COMPLETED',
+            oath_category: 'RECOVERY_NOCONTACT',
+          },
+        ],
+      });
+
+      const result = await controller.getAssignments({ id: 'fury-user-1' });
+
+      expect(result.assignments[0].viewUrl).toBeNull();
+      expect(mockR2.generateViewUrl).not.toHaveBeenCalled();
     });
 
     it('should return empty assignments when Fury has no pending reviews', async () => {

--- a/src/api/src/modules/fury/fury.controller.ts
+++ b/src/api/src/modules/fury/fury.controller.ts
@@ -129,10 +129,17 @@ export class FuryController {
       result.rows.map(async (row: any) => {
         let viewUrl: string | null = null;
 
-        // Prefer masked media if redaction is completed
-        const mediaToView = (row.redaction_status === 'COMPLETED' && row.masked_media_uri)
-          ? row.masked_media_uri
-          : row.media_uri;
+        // A Fury auditor is NEVER authorized to see raw media. This mirrors the
+        // rule already enforced in ProofsService.getProofDetail: key the decision
+        // on the PRESENCE OF A MASKED ASSET, never on the redaction_status
+        // string, which is inconsistent across the codebase ('MASKED' from the
+        // production finalize path in proofs.controller.ts, 'COMPLETED' from the
+        // dev-only direct-DB fallback in video-processing.worker.ts, plus
+        // 'NOT_APPLICABLE'/null). The old code compared against 'COMPLETED'
+        // ONLY — so on the production path the test failed and it fell through
+        // to `row.media_uri`, serving peer reviewers the unredacted original.
+        // Fail closed: no masked asset means no url at all.
+        const mediaToView = row.masked_media_uri ?? null;
 
         if (mediaToView) {
           try {

--- a/src/api/src/modules/proofs/proofs.controller.spec.ts
+++ b/src/api/src/modules/proofs/proofs.controller.spec.ts
@@ -10,6 +10,7 @@ import { ProofMediaType } from './dto';
 import { ProofsService } from './proofs.service';
 import { CrisisDetectionService } from '../../../services/security/crisis-detection.service';
 import { CrisisInterventionService } from '../../../services/security/crisis-intervention.service';
+import { VideoProcessingService } from './video-processing.service';
 
 describe('ProofsController', () => {
   let controller: ProofsController;
@@ -22,6 +23,7 @@ describe('ProofsController', () => {
   let mockProofsService: jest.Mocked<Pick<ProofsService, 'getProofUploadContractAccess' | 'getProofUploadConfirmationAccess' | 'getProofDetail'>>;
   let mockCrisisDetection: jest.Mocked<Pick<CrisisDetectionService, 'analyzeContent'>>;
   let mockCrisisIntervention: jest.Mocked<Pick<CrisisInterventionService, 'reportCrisis'>>;
+  let mockVideoProcessing: jest.Mocked<Pick<VideoProcessingService, 'dispatchForProcessing'>>;
 
   beforeEach(() => {
     mockPool = { query: jest.fn() };
@@ -49,6 +51,9 @@ describe('ProofsController', () => {
     mockCrisisIntervention = {
       reportCrisis: jest.fn().mockResolvedValue({ escalated: false }),
     };
+    mockVideoProcessing = {
+      dispatchForProcessing: jest.fn().mockResolvedValue(undefined),
+    };
 
     controller = new ProofsController(
       mockPool as unknown as Pool,
@@ -60,6 +65,7 @@ describe('ProofsController', () => {
       mockProofsService as unknown as ProofsService,
       mockCrisisDetection as unknown as CrisisDetectionService,
       mockCrisisIntervention as unknown as CrisisInterventionService,
+      mockVideoProcessing as unknown as VideoProcessingService,
     );
     jest.clearAllMocks();
   });
@@ -196,6 +202,49 @@ describe('ProofsController', () => {
         expect.stringContaining('UPDATE proofs'),
         expect.arrayContaining([expect.any(String), 'p-1', '["EXIF_TIMESTAMP_DISCREPANCY"]', '{}'])
       );
+    });
+
+    // The whole redaction pipeline was built, registered, exported and specced —
+    // and called by nobody, so masked_media_uri was never populated on a real
+    // proof and Fury reviewers were served raw media. This assertion is the
+    // guard against it silently returning to zero callers.
+    it('enqueues redaction before routing the proof to reviewers', async () => {
+      mockProofsService.getProofUploadConfirmationAccess.mockResolvedValue({
+        status: 'PENDING_UPLOAD',
+        contractId: 'c-1',
+        ownerUserId: 'user-1',
+      } as any);
+      mockR2.downloadFile.mockResolvedValue(Buffer.from('fake-media'));
+      mockAnomaly.analyze.mockResolvedValue({ rejected: false, flags: [] });
+      mockPhash.computeFrameHash.mockResolvedValue('hash-123');
+      mockPhash.isDuplicate.mockResolvedValue({ duplicate: false, closestDistance: 64 });
+      mockPool.query.mockResolvedValue({ rows: [] });
+
+      await controller.confirmUpload('p-1', user, dto);
+
+      expect(mockVideoProcessing.dispatchForProcessing).toHaveBeenCalledWith('p-1');
+      expect(mockVideoProcessing.dispatchForProcessing.mock.invocationCallOrder[0]).toBeLessThan(
+        (mockFuryRouter.routeProof as jest.Mock).mock.invocationCallOrder[0],
+      );
+    });
+
+    it('still routes the proof when redaction dispatch fails (reviewers see no media, not raw media)', async () => {
+      mockProofsService.getProofUploadConfirmationAccess.mockResolvedValue({
+        status: 'PENDING_UPLOAD',
+        contractId: 'c-1',
+        ownerUserId: 'user-1',
+      } as any);
+      mockR2.downloadFile.mockResolvedValue(Buffer.from('fake-media'));
+      mockAnomaly.analyze.mockResolvedValue({ rejected: false, flags: [] });
+      mockPhash.computeFrameHash.mockResolvedValue('hash-123');
+      mockPhash.isDuplicate.mockResolvedValue({ duplicate: false, closestDistance: 64 });
+      mockPool.query.mockResolvedValue({ rows: [] });
+      mockVideoProcessing.dispatchForProcessing.mockRejectedValueOnce(new Error('redis down'));
+
+      const result = await controller.confirmUpload('p-1', user, dto);
+
+      expect(result.status).toBe('PENDING_REVIEW');
+      expect(mockFuryRouter.routeProof).toHaveBeenCalled();
     });
 
     it('should reject duplicate proofs', async () => {

--- a/src/api/src/modules/proofs/proofs.controller.ts
+++ b/src/api/src/modules/proofs/proofs.controller.ts
@@ -18,6 +18,7 @@ import { ProofsService } from './proofs.service';
 import { getEffectiveVerificationTier, validateProofMedia } from '../../../../shared/config/verification-tiers';
 import { CrisisDetectionService } from '../../../services/security/crisis-detection.service';
 import { CrisisInterventionService } from '../../../services/security/crisis-intervention.service';
+import { VideoProcessingService } from './video-processing.service';
 import { Logger } from '@nestjs/common';
 
 @ApiTags('Proofs')
@@ -36,6 +37,7 @@ export class ProofsController {
     private readonly proofsService: ProofsService,
     private readonly crisisDetection: CrisisDetectionService,
     private readonly crisisIntervention: CrisisInterventionService,
+    private readonly videoProcessing: VideoProcessingService,
   ) {}
 
   @UseGuards(AuthGuard, GeofenceGuard, ComplianceAccessGuard, BannedUserGuard)
@@ -274,6 +276,18 @@ export class ProofsController {
         JSON.stringify(dto.deviceMetadata || {}),
       ],
     );
+
+    // Enqueue redaction BEFORE routing to reviewers. Nothing called this before
+    // — VideoProcessingService was registered, exported, specced, and invoked by
+    // zero code paths — so masked_media_uri was never populated on a real proof
+    // and the Fury queue had no redacted asset to serve. Redaction failing must
+    // not block the audit: the queue now fails CLOSED (no masked asset means no
+    // url), so a reviewer sees no media rather than the raw original.
+    await this.videoProcessing.dispatchForProcessing(proofId).catch((err) => {
+      this.logger.error(
+        `Redaction dispatch failed for proof ${proofId}: ${err?.message}. The proof stays NOT_STARTED for the sweeper; reviewers receive no media until it is redacted.`,
+      );
+    });
 
     const jobId = await this.furyRouter.routeProof(proofId, proofAccess.ownerUserId);
 

--- a/src/api/src/modules/proofs/proofs.module.ts
+++ b/src/api/src/modules/proofs/proofs.module.ts
@@ -8,6 +8,7 @@ import { AnomalyService } from '../../../services/anomaly/anomaly.service';
 import { ProofsService } from './proofs.service';
 import { VideoProcessingService } from './video-processing.service';
 import { VideoProcessingWorker } from './video-processing.worker';
+import { VideoProcessingScheduler } from './video-processing.scheduler';
 import { TranscodingService } from '../../../services/media/transcoding.service';
 import { RedactionService } from '../../../services/media/redaction.service';
 import { CrisisModule } from '../crisis/crisis.module';
@@ -18,7 +19,7 @@ import { CrisisModule } from '../crisis/crisis.module';
   providers: [
     R2StorageService, FuryRouterService, TruthLogService, PHashService,
     AnomalyService, ProofsService, VideoProcessingService, VideoProcessingWorker,
-    TranscodingService, RedactionService,
+    VideoProcessingScheduler, TranscodingService, RedactionService,
   ],
   exports: [R2StorageService, VideoProcessingService],
 })

--- a/src/api/src/modules/proofs/video-processing.scheduler.ts
+++ b/src/api/src/modules/proofs/video-processing.scheduler.ts
@@ -1,0 +1,35 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { VideoProcessingService } from './video-processing.service';
+
+/**
+ * The redaction safety net.
+ *
+ * `ProofsController.confirmUpload` enqueues redaction inline, but that call can
+ * fail (Redis blip, queue backpressure) and it deliberately does not abort the
+ * upload when it does. Without a sweeper a proof that missed its enqueue stays
+ * `NOT_STARTED` forever — and since the Fury queue now fails CLOSED, that means
+ * a permanently unreviewable proof.
+ *
+ * `dispatchPendingProofs` is idempotent by construction: its UPDATE matches only
+ * rows still in `NOT_STARTED`, so a proof already queued or processing is never
+ * double-dispatched, and a sweep that overlaps an inline dispatch is harmless.
+ */
+@Injectable()
+export class VideoProcessingScheduler {
+  private readonly logger = new Logger(VideoProcessingScheduler.name);
+
+  constructor(private readonly videoProcessing: VideoProcessingService) {}
+
+  @Cron('0 */10 * * * *') // every 10 minutes
+  async sweepPendingProofs(): Promise<void> {
+    try {
+      const dispatched = await this.videoProcessing.dispatchPendingProofs();
+      if (dispatched > 0) {
+        this.logger.log(`Redaction sweep dispatched ${dispatched} proof(s) that missed their inline enqueue.`);
+      }
+    } catch (error) {
+      this.logger.error(`Redaction sweep failed: ${(error as Error)?.message}`);
+    }
+  }
+}


### PR DESCRIPTION
Three defects compounding into one **live privacy failure**, found by auditing the Gamma surface for built-but-unwired code.

**1. Nobody called the redaction pipeline.** `VideoProcessingService.dispatchForProcessing`/`dispatchPendingProofs` is registered, exported and specced in `proofs.module.ts` — and had **zero callers repo-wide**. So `masked_media_uri` was never populated on any real proof. `confirmUpload` now enqueues redaction *before* routing to reviewers, plus a `VideoProcessingScheduler` sweeps every 10 min for proofs whose inline enqueue failed (the dispatch UPDATE only matches `NOT_STARTED`, so a sweep can never double-dispatch).

**2. The queue fell back to raw media.** `fury.controller.ts` gated on `redaction_status === 'COMPLETED'`, but the **production** finalize path writes `'MASKED'` — only the dev-only direct-DB fallback writes `'COMPLETED'`. On the production path the test failed and the else-branch served `row.media_uri`: the unredacted original. Now keyed on the **presence of a masked asset**, exactly as `ProofsService.getProofDetail` already documents, and it **fails closed** — no masked asset means no url, never the raw one.

**3. The test could not fail.** The spec injected the R2 mock as `{}`, so `generateViewUrl` always threw, every `viewUrl` resolved null through the catch, and the masked-vs-raw branch was never exercised. That is why this shipped. The mock is now real and the branch is pinned across all four `redaction_status` values plus the no-masked-asset case.

**A/B verified**: restoring the old selection line fails **5** of the new assertions, including all three production-path (`'MASKED'`) cases. With the fix: **93/93** fury+proofs specs green, api `tsc` clean.

Gamma wave of the full-build program (#904).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmP1SLhXcZBmA7g4NM6PTY

## Summary by Sourcery

Ensure proof redaction is reliably triggered and that Fury reviewers can only ever access masked media assets, never raw originals.

New Features:
- Add a scheduled redaction sweeper that periodically enqueues pending proofs that never started video processing.

Bug Fixes:
- Change Fury assignment media selection to rely on the presence of a masked asset and fail closed when none exists, preventing exposure of raw proof media to auditors.
- Wire ProofsController upload confirmation to dispatch video processing so real proofs enter the redaction pipeline instead of remaining unprocessed.
- Fix the Fury controller tests to exercise masked-vs-raw selection using a real R2 mock and assert correct behaviour across redaction status variants.
- Add tests ensuring redaction is enqueued before routing proofs to reviewers and that failed dispatch does not fall back to serving raw media.

Enhancements:
- Register the video processing scheduler in the proofs module to make the redaction safety net part of the normal runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Prevented raw media from being exposed when masked media is unavailable.
  * Reviewers only receive media after redaction is complete.

* **New Features**
  * Proofs are automatically submitted for redaction after confirmation.
  * Failed processing attempts can be retried automatically every 10 minutes.

* **Bug Fixes**
  * Confirmation and reviewer routing continue safely if redaction dispatch temporarily fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->