### PR TITLE
feat(web): recovery timelock + danger-zone client surface (TKT-P1-005)

### DIFF
--- a/src/web/app/contracts/[id]/page.tsx
+++ b/src/web/app/contracts/[id]/page.tsx
@@ -9,6 +9,8 @@ import {
 } from 'lucide-react';
 import { api } from '../../../services/api-client';
 import { useAuth } from '../../../contexts/AuthContext';
+import RecoveryLockCountdown from '../../../components/RecoveryLockCountdown';
+import DangerZoneBanner from '../../../components/DangerZoneBanner';
 
 type ContractStatus = 'ACTIVE' | 'COMPLETED' | 'FAILED' | 'PENDING_REVIEW' | 'PAYMENT_FAILED' | 'DISPUTED';
 
@@ -168,6 +170,7 @@ export default function ContractDetailPage() {
   const elapsedMs = Math.min(now.getTime() - startedAt.getTime(), totalMs);
   const progressPct = totalMs > 0 ? Math.round((elapsedMs / totalMs) * 100) : 0;
   const daysRemaining = Math.max(0, Math.ceil((endsAt.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)));
+  const isRecovery = contract.oath_category.startsWith('RECOVERY_');
 
   return (
     <div className="min-h-screen bg-black text-white font-sans p-6 md:p-12 max-w-4xl mx-auto">
@@ -189,6 +192,13 @@ export default function ContractDetailPage() {
           <span className={`font-bold text-sm ${statusCfg.color}`}>{statusCfg.label}</span>
         </div>
       </div>
+
+      {/* Danger windows — the API only evaluates them for ACTIVE contracts. */}
+      {contract.status === 'ACTIVE' && (
+        <div className="mb-6">
+          <DangerZoneBanner contractId={contract.id} />
+        </div>
+      )}
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {/* Stake & Timeline */}
@@ -328,6 +338,16 @@ export default function ContractDetailPage() {
           )}
         </div>
       </div>
+
+      {/* Recovery timelock — the break gate only exists on the recovery stream. */}
+      {isRecovery && (
+        <div className="mt-8">
+          <RecoveryLockCountdown
+            contractId={contract.id}
+            canRequestBreak={contract.status === 'ACTIVE'}
+          />
+        </div>
+      )}
 
       {/* Proof History */}
       {proofs.length > 0 && (

--- a/src/web/components/DangerZoneBanner.test.tsx
+++ b/src/web/components/DangerZoneBanner.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+jest.mock('../services/api-client', () => ({
+  api: {
+    getDangerZoneStatus: jest.fn().mockResolvedValue({
+      timezone: 'America/New_York',
+      inDangerZone: false,
+      contracts: [],
+    }),
+  },
+}));
+
+import DangerZoneBanner, { DangerZoneBanners } from './DangerZoneBanner';
+import type { ContractDangerStatus } from '../services/api-client';
+
+const IN_DANGER: ContractDangerStatus = {
+  contractId: 'contract-abc-123',
+  inDangerZone: true,
+  windows: [
+    { type: 'DAY_21', severity: 'CRITICAL', message: 'Day 21 is the extinction burst.' },
+    { type: 'LATE_NIGHT', severity: 'MEDIUM', message: 'It is past midnight in your timezone.' },
+  ],
+  recommendations: [
+    {
+      type: 'DAY_21',
+      action: 'Increase attestation frequency, consider reducing stakes',
+      description: 'The extinction burst is the last attempt to revert habits.',
+    },
+    {
+      type: 'LATE_NIGHT',
+      action: 'Enable do-not-disturb, delete tempting apps',
+      description: 'Late-night hours have weaker impulse control.',
+    },
+  ],
+};
+
+describe('DangerZoneBanners', () => {
+  it('renders one banner per open window with its severity label', () => {
+    const html = renderToStaticMarkup(<DangerZoneBanners status={IN_DANGER} />);
+
+    expect(html).toContain('Day 21 is the extinction burst.');
+    expect(html).toContain('It is past midnight in your timezone.');
+    expect(html).toContain('Critical risk');
+    expect(html).toContain('Medium risk');
+  });
+
+  // The API returns recommendations as a parallel list keyed by window type,
+  // so a mismatched order must not pair the wrong advice with a window.
+  it('pairs each recommendation with its own window by type, not by position', () => {
+    const shuffled: ContractDangerStatus = {
+      ...IN_DANGER,
+      recommendations: [...IN_DANGER.recommendations].reverse(),
+    };
+    const html = renderToStaticMarkup(<DangerZoneBanners status={shuffled} />);
+
+    const day21At = html.indexOf('Day 21 is the extinction burst.');
+    const lateNightAt = html.indexOf('It is past midnight in your timezone.');
+    const stakesAdviceAt = html.indexOf('consider reducing stakes');
+    const dndAdviceAt = html.indexOf('Enable do-not-disturb');
+
+    expect(day21At).toBeGreaterThan(-1);
+    expect(stakesAdviceAt).toBeGreaterThan(day21At);
+    expect(stakesAdviceAt).toBeLessThan(lateNightAt);
+    expect(dndAdviceAt).toBeGreaterThan(lateNightAt);
+  });
+
+  it('renders nothing when the contract is not in a danger zone', () => {
+    const html = renderToStaticMarkup(
+      <DangerZoneBanners status={{ ...IN_DANGER, inDangerZone: false, windows: [] }} />,
+    );
+
+    expect(html).toBe('');
+  });
+
+  it('renders nothing when the account-wide status held no row for the contract', () => {
+    expect(renderToStaticMarkup(<DangerZoneBanners status={null} />)).toBe('');
+  });
+});
+
+describe('DangerZoneBanner', () => {
+  it('renders nothing before the account-wide status resolves', () => {
+    const html = renderToStaticMarkup(<DangerZoneBanner contractId="contract-abc-123" />);
+
+    expect(html).toBe('');
+  });
+});

--- a/src/web/components/DangerZoneBanner.tsx
+++ b/src/web/components/DangerZoneBanner.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { AlertTriangle, ShieldAlert } from 'lucide-react';
+import { api } from '../services/api-client';
+import type { ContractDangerStatus } from '../services/api-client';
+
+const SEVERITY_STYLE: Record<string, { box: string; text: string; label: string }> = {
+  LOW: { box: 'bg-neutral-900 border-neutral-700', text: 'text-neutral-300', label: 'Low' },
+  MEDIUM: { box: 'bg-yellow-900/20 border-yellow-800', text: 'text-yellow-400', label: 'Medium' },
+  HIGH: { box: 'bg-orange-900/20 border-orange-800', text: 'text-orange-400', label: 'High' },
+  CRITICAL: { box: 'bg-red-900/20 border-red-800', text: 'text-red-400', label: 'Critical' },
+};
+
+/**
+ * The presentational half: one banner per open danger window, each paired with
+ * the protection the API recommends for it. Renders nothing when the contract
+ * is not in a danger zone, so a caller can mount it unconditionally.
+ */
+export function DangerZoneBanners({ status }: { status: ContractDangerStatus | null }) {
+  if (!status || !status.inDangerZone || status.windows.length === 0) return null;
+
+  return (
+    <div className="space-y-3">
+      {status.windows.map((danger) => {
+        const style = SEVERITY_STYLE[danger.severity] || SEVERITY_STYLE.LOW;
+        // Recommendations are returned keyed by the same window type, so the
+        // pairing is by type rather than by index.
+        const recommendation = status.recommendations.find((r) => r.type === danger.type);
+        return (
+          <div key={danger.type} className={`p-4 border rounded-xl ${style.box}`}>
+            <div className="flex items-center gap-2 mb-2">
+              <AlertTriangle size={16} className={`shrink-0 ${style.text}`} />
+              <span className={`font-bold text-sm ${style.text}`}>
+                {style.label} risk &mdash; {danger.type.replace(/_/g, ' ')}
+              </span>
+            </div>
+            <p className="text-sm text-neutral-300">{danger.message}</p>
+            {recommendation && (
+              <div className="mt-3 flex items-start gap-2">
+                <ShieldAlert size={14} className="text-neutral-500 shrink-0 mt-0.5" />
+                <div>
+                  <p className="text-sm font-bold text-neutral-200">{recommendation.action}</p>
+                  <p className="text-xs text-neutral-500 mt-1">{recommendation.description}</p>
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Danger-window banners for one contract. The API evaluates danger windows per
+ * user across every ACTIVE contract (GET /behavioral/retention/danger-zone) —
+ * there is no per-contract route — so this fetches the account-wide status and
+ * keeps the row for `contractId`.
+ */
+export default function DangerZoneBanner({ contractId }: { contractId: string }) {
+  const [status, setStatus] = useState<ContractDangerStatus | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const data = await api.getDangerZoneStatus();
+        if (cancelled) return;
+        setStatus(data.contracts.find((c) => c.contractId === contractId) ?? null);
+      } catch {
+        // Advisory surface: a failed danger-zone read must not put an error on
+        // a page whose primary content loaded fine.
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [contractId]);
+
+  return <DangerZoneBanners status={status} />;
+}

--- a/src/web/components/RecoveryLockCountdown.test.tsx
+++ b/src/web/components/RecoveryLockCountdown.test.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+jest.mock('../services/api-client', () => ({
+  api: {
+    getRecoveryLockStatus: jest.fn().mockResolvedValue({ activeRequest: null }),
+    requestRecoveryBreak: jest.fn(),
+    cancelRecoveryBreak: jest.fn(),
+  },
+}));
+
+import RecoveryLockCountdown, { RecoveryLockPanel, formatCountdown } from './RecoveryLockCountdown';
+import type { RecoveryBreakRequest } from '../services/api-client';
+
+const NOW = Date.parse('2026-02-01T00:00:00Z');
+
+function makeRequest(overrides: Partial<RecoveryBreakRequest> = {}): RecoveryBreakRequest {
+  return {
+    id: 'break-1',
+    contract_id: 'contract-abc-123',
+    requested_at: '2026-02-01T00:00:00Z',
+    unlock_at: '2026-02-02T00:00:00Z',
+    reason: 'I want out.',
+    status: 'PENDING_COOLDOWN',
+    ...overrides,
+  };
+}
+
+const NOOP_PROPS = {
+  now: NOW,
+  canRequestBreak: true,
+  reason: '',
+  onReasonChange: () => undefined,
+  onRequestBreak: () => undefined,
+  onCancel: () => undefined,
+  requesting: false,
+  cancelling: false,
+  error: null,
+  notice: null,
+};
+
+describe('formatCountdown', () => {
+  it('renders hours, zero-padded minutes and seconds', () => {
+    expect(formatCountdown(3 * 3600_000 + 7 * 60_000 + 5_000)).toBe('3h 07m 05s');
+  });
+
+  it('rounds up so a partial second is still time owed', () => {
+    expect(formatCountdown(1_200)).toBe('0h 00m 02s');
+  });
+
+  it('floors at zero rather than counting negative once unlock_at has passed', () => {
+    expect(formatCountdown(-90_000)).toBe('0h 00m 00s');
+  });
+});
+
+describe('RecoveryLockPanel', () => {
+  it('offers the break request form when nothing is queued', () => {
+    const html = renderToStaticMarkup(<RecoveryLockPanel {...NOOP_PROPS} request={null} />);
+
+    expect(html).toContain('Request Break');
+    expect(html).toContain('Why do you want to break this contract?');
+    expect(html).not.toContain('Cancel Break Request');
+  });
+
+  it('explains the request is unavailable when the contract is not active', () => {
+    const html = renderToStaticMarkup(
+      <RecoveryLockPanel {...NOOP_PROPS} request={null} canRequestBreak={false} />,
+    );
+
+    expect(html).toContain('only be requested while the contract is active');
+    expect(html).not.toContain('Request Break');
+  });
+
+  it('counts down to unlock_at and offers cancel while the cooldown runs', () => {
+    const html = renderToStaticMarkup(
+      <RecoveryLockPanel {...NOOP_PROPS} request={makeRequest()} />,
+    );
+
+    expect(html).toContain('Unlocks in');
+    expect(html).toContain('24h 00m 00s');
+    expect(html).toContain('Cancel Break Request');
+    expect(html).toContain('I want out.');
+    expect(html).not.toContain('Cooldown complete');
+  });
+
+  it('advances the countdown with the clock it is given', () => {
+    const html = renderToStaticMarkup(
+      <RecoveryLockPanel {...NOOP_PROPS} request={makeRequest()} now={NOW + 3600_000 + 90_000} />,
+    );
+
+    expect(html).toContain('22h 58m 30s');
+  });
+
+  // The UNLOCKED status is derived by the API from unlock_at; the client must
+  // render what the server said rather than re-deciding from its own clock.
+  it('shows the unlocked state for an UNLOCKED request even at a stale clock', () => {
+    const html = renderToStaticMarkup(
+      <RecoveryLockPanel {...NOOP_PROPS} request={makeRequest({ status: 'UNLOCKED' })} now={NOW} />,
+    );
+
+    expect(html).toContain('Cooldown complete');
+    expect(html).not.toContain('Unlocks in');
+    // The stored row is still PENDING_COOLDOWN, so cancelling remains real.
+    expect(html).toContain('Cancel Break Request');
+  });
+
+  it('returns to the request form after a cancellation, noting the last attempt', () => {
+    const html = renderToStaticMarkup(
+      <RecoveryLockPanel {...NOOP_PROPS} request={makeRequest({ status: 'CANCELLED' })} />,
+    );
+
+    expect(html).toContain('Last request cancelled');
+    expect(html).toContain('Request Break');
+    expect(html).not.toContain('Cancel Break Request');
+  });
+
+  it('renders the error and notice lines when present', () => {
+    const html = renderToStaticMarkup(
+      <RecoveryLockPanel
+        {...NOOP_PROPS}
+        request={null}
+        error="API 409: A break request is already in cooldown"
+        notice="Break queued."
+      />,
+    );
+
+    expect(html).toContain('A break request is already in cooldown');
+    expect(html).toContain('Break queued.');
+  });
+});
+
+describe('RecoveryLockCountdown', () => {
+  it('renders a skeleton until the lock status resolves', () => {
+    const html = renderToStaticMarkup(
+      <RecoveryLockCountdown contractId="contract-abc-123" canRequestBreak />,
+    );
+
+    expect(html).toContain('animate-pulse');
+    expect(html).not.toContain('Request Break');
+  });
+});

--- a/src/web/components/RecoveryLockCountdown.tsx
+++ b/src/web/components/RecoveryLockCountdown.tsx
@@ -1,0 +1,289 @@
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { AlertTriangle, Loader2, Lock, Unlock, X } from 'lucide-react';
+import { api } from '../services/api-client';
+import type { RecoveryBreakRequest } from '../services/api-client';
+
+/**
+ * Renders the remaining cooldown as `Hh MMm SSs`, rounding up so the display
+ * never shows 0 while time is still owed.
+ */
+export function formatCountdown(remainingMs: number): string {
+  const totalSeconds = Math.max(0, Math.ceil(remainingMs / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return `${hours}h ${String(minutes).padStart(2, '0')}m ${String(seconds).padStart(2, '0')}s`;
+}
+
+export interface RecoveryLockPanelProps {
+  request: RecoveryBreakRequest | null;
+  now: number;
+  canRequestBreak: boolean;
+  reason: string;
+  onReasonChange: (reason: string) => void;
+  onRequestBreak: () => void;
+  onCancel: () => void;
+  requesting: boolean;
+  cancelling: boolean;
+  error: string | null;
+  notice: string | null;
+}
+
+/**
+ * The presentational half of the recovery timelock, split out so every branch
+ * is renderable from fixed props (the same reason DashboardErrorNotice is its
+ * own component): the container below owns fetching, the ticking clock, and
+ * the two POSTs.
+ */
+export function RecoveryLockPanel({
+  request,
+  now,
+  canRequestBreak,
+  reason,
+  onReasonChange,
+  onRequestBreak,
+  onCancel,
+  requesting,
+  cancelling,
+  error,
+  notice,
+}: RecoveryLockPanelProps) {
+  // UNLOCKED is derived by the API from unlock_at, not stored, so both live
+  // states arrive on the same row and share this branch.
+  const live =
+    request !== null &&
+    (request.status === 'PENDING_COOLDOWN' || request.status === 'UNLOCKED');
+  const unlocked = request?.status === 'UNLOCKED';
+
+  return (
+    <div className="p-6 bg-neutral-900 border border-neutral-800 rounded-2xl space-y-4">
+      <div className="flex items-center gap-3">
+        {unlocked ? (
+          <Unlock className="text-red-500" size={20} />
+        ) : (
+          <Lock className="text-amber-500" size={20} />
+        )}
+        <h2 className="font-bold text-sm uppercase tracking-widest text-neutral-500">
+          Break Timelock
+        </h2>
+      </div>
+
+      {live && request !== null ? (
+        <div className="space-y-4">
+          {unlocked ? (
+            <div className="p-4 bg-red-900/20 border border-red-800 rounded-xl">
+              <p className="font-bold text-red-400">Cooldown complete</p>
+              <p className="text-neutral-400 text-sm mt-1">
+                The 24-hour hold on this break has expired. It is unlocked.
+              </p>
+            </div>
+          ) : (
+            <div className="p-4 bg-amber-900/20 border border-amber-800 rounded-xl">
+              <p className="text-xs uppercase tracking-widest text-neutral-500 mb-1">
+                Unlocks in
+              </p>
+              <p className="text-4xl font-black tabular-nums text-amber-400">
+                {formatCountdown(new Date(request.unlock_at).getTime() - now)}
+              </p>
+              <p className="text-neutral-400 text-sm mt-2">
+                Unlocks {new Date(request.unlock_at).toLocaleString()}
+              </p>
+            </div>
+          )}
+
+          {request.reason && (
+            <div>
+              <p className="text-xs uppercase tracking-widest text-neutral-500 mb-1">
+                Your stated reason
+              </p>
+              <p className="text-sm text-neutral-300">{request.reason}</p>
+            </div>
+          )}
+
+          {/* Cancel stays available after the countdown ends: the row is still
+              stored as PENDING_COOLDOWN, so the API accepts a cancel right up
+              until the break is consumed. */}
+          <button
+            onClick={onCancel}
+            disabled={cancelling}
+            className="w-full py-3 bg-neutral-800 hover:bg-neutral-700 disabled:opacity-50 text-white font-bold rounded-xl transition-colors flex items-center justify-center gap-2"
+          >
+            {cancelling ? <Loader2 className="animate-spin" size={16} /> : <X size={16} />}
+            Cancel Break Request
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <p className="text-neutral-400 text-sm">
+            Breaking a recovery contract is deliberate, never immediate. A
+            request sits behind a 24-hour cooldown you can cancel at any point.
+          </p>
+          {request?.status === 'CANCELLED' && (
+            <p className="text-xs text-neutral-500">
+              Last request cancelled &mdash; requested {new Date(request.requested_at).toLocaleString()}.
+            </p>
+          )}
+          {request?.status === 'CONSUMED' && (
+            <p className="text-xs text-neutral-500">
+              Last break used &mdash; requested {new Date(request.requested_at).toLocaleString()}.
+            </p>
+          )}
+          {canRequestBreak ? (
+            <>
+              <textarea
+                value={reason}
+                onChange={(e) => onReasonChange(e.target.value)}
+                rows={3}
+                placeholder="Why do you want to break this contract?"
+                className="w-full px-4 py-3 bg-black border border-neutral-700 rounded-xl text-white placeholder-neutral-600 focus:outline-none focus:border-amber-600"
+              />
+              <button
+                onClick={onRequestBreak}
+                disabled={requesting || !reason.trim()}
+                className="w-full py-3 bg-amber-700 hover:bg-amber-600 disabled:opacity-50 text-white font-bold rounded-xl transition-colors flex items-center justify-center gap-2"
+              >
+                {requesting ? <Loader2 className="animate-spin" size={16} /> : <Lock size={16} />}
+                Request Break
+              </button>
+            </>
+          ) : (
+            <p className="text-xs text-neutral-500">
+              A break can only be requested while the contract is active.
+            </p>
+          )}
+        </div>
+      )}
+
+      {notice && <p className="text-sm text-neutral-400">{notice}</p>}
+      {error && (
+        <p className="text-sm text-red-400 flex items-center gap-2">
+          <AlertTriangle size={14} className="shrink-0" />
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Recovery timelock surface (TKT-P1-005) for a single RECOVERY_* contract:
+ * the live cooldown, the request CTA, and the cancel CTA.
+ */
+export default function RecoveryLockCountdown({
+  contractId,
+  canRequestBreak,
+}: {
+  contractId: string;
+  canRequestBreak: boolean;
+}) {
+  const [request, setRequest] = useState<RecoveryBreakRequest | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [reason, setReason] = useState('');
+  const [requesting, setRequesting] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
+
+  const refresh = useCallback(async () => {
+    const status = await api.getRecoveryLockStatus(contractId);
+    setRequest(status.activeRequest);
+    setNow(Date.now());
+  }, [contractId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const status = await api.getRecoveryLockStatus(contractId);
+        if (cancelled) return;
+        setRequest(status.activeRequest);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'Failed to load timelock status');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [contractId]);
+
+  useEffect(() => {
+    if (!request || request.status !== 'PENDING_COOLDOWN') return;
+    const unlockAt = new Date(request.unlock_at).getTime();
+    const timer = setInterval(() => {
+      const tick = Date.now();
+      setNow(tick);
+      if (tick >= unlockAt) {
+        clearInterval(timer);
+        // The UNLOCKED transition belongs to the server, so an expiring
+        // countdown asks for the authoritative status instead of relabelling
+        // the row from the browser's clock.
+        void refresh().catch(() => undefined);
+      }
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [request, refresh]);
+
+  const handleRequestBreak = async () => {
+    setRequesting(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const created = await api.requestRecoveryBreak(contractId, reason.trim());
+      setRequest(created);
+      setReason('');
+      setNow(Date.now());
+      setNotice('Break queued. The 24-hour cooldown has started.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to request break');
+    } finally {
+      setRequesting(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    setCancelling(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const result = await api.cancelRecoveryBreak(contractId);
+      setRequest(result.request);
+      setNotice('Break request cancelled. Your contract stands.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to cancel break request');
+    } finally {
+      setCancelling(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="p-6 bg-neutral-900 border border-neutral-800 rounded-2xl animate-pulse">
+        <div className="h-4 w-32 bg-neutral-800 rounded mb-4" />
+        <div className="h-12 w-full bg-neutral-800 rounded" />
+      </div>
+    );
+  }
+
+  return (
+    <RecoveryLockPanel
+      request={request}
+      now={now}
+      canRequestBreak={canRequestBreak}
+      reason={reason}
+      onReasonChange={setReason}
+      onRequestBreak={handleRequestBreak}
+      onCancel={handleCancel}
+      requesting={requesting}
+      cancelling={cancelling}
+      error={error}
+      notice={notice}
+    />
+  );
+}

--- a/src/web/services/api-client.ts
+++ b/src/web/services/api-client.ts
@@ -262,6 +262,41 @@ export interface LeaderboardEntry {
   created_at: string;
 }
 
+/**
+ * A queued intentional break on a recovery contract (TKT-P1-005). `status` is
+ * the row's stored value except for the one case the server derives: a
+ * PENDING_COOLDOWN row whose `unlock_at` has passed is returned as UNLOCKED.
+ * The client renders that field as given — it never decides the lock state
+ * from its own clock, which can be wrong or deliberately wound forward.
+ */
+export interface RecoveryBreakRequest {
+  id: string;
+  contract_id: string;
+  requested_at: string;
+  unlock_at: string;
+  reason: string | null;
+  status: "PENDING_COOLDOWN" | "UNLOCKED" | "CANCELLED" | "CONSUMED";
+}
+
+export interface DangerWindow {
+  type: string;
+  severity: "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
+  message: string;
+}
+
+export interface ProtectionRecommendation {
+  type: string;
+  action: string;
+  description: string;
+}
+
+export interface ContractDangerStatus {
+  contractId: string;
+  inDangerZone: boolean;
+  windows: DangerWindow[];
+  recommendations: ProtectionRecommendation[];
+}
+
 export const api = {
   health: () => request<{ status: string }>("/health"),
   getMobileBootstrap: () =>
@@ -392,6 +427,41 @@ export const api = {
         method: "POST",
       },
     ),
+
+  // Recovery timelock (TKT-P1-005). A recovery contract cannot be broken on
+  // impulse: the break is queued, and only the 24h cooldown expiring unlocks
+  // it. `activeRequest` is null when nothing has ever been queued.
+  getRecoveryLockStatus: (contractId: string) =>
+    request<{ activeRequest: RecoveryBreakRequest | null }>(
+      `/contracts/${contractId}/recovery/lock-status`,
+    ),
+
+  requestRecoveryBreak: (contractId: string, reason: string) =>
+    request<RecoveryBreakRequest>(
+      `/contracts/${contractId}/recovery/break-request`,
+      {
+        method: "POST",
+        body: JSON.stringify({ reason }),
+      },
+    ),
+
+  cancelRecoveryBreak: (contractId: string) =>
+    request<{ success: boolean; request: RecoveryBreakRequest }>(
+      `/contracts/${contractId}/recovery/break-cancel`,
+      {
+        method: "POST",
+      },
+    ),
+
+  // Danger windows are evaluated per user across every ACTIVE contract, so
+  // there is no per-contract route to call — a caller scoped to one contract
+  // filters the `contracts` array itself.
+  getDangerZoneStatus: () =>
+    request<{
+      timezone: string;
+      inDangerZone: boolean;
+      contracts: ContractDangerStatus[];
+    }>("/behavioral/retention/danger-zone"),
 
   // Fury — userId comes from JWT
   getFuryAssignments: () =>


### PR DESCRIPTION
## The gap

TKT-P1-005's backend is complete and wired — `GET /contracts/:id/recovery/lock-status`, `POST /contracts/:id/recovery/break-request`, `POST /contracts/:id/recovery/break-cancel` all exist in `contracts.controller.ts` with service implementations and tests. **Nothing in `src/web` called any of them.** A grep for `lock-status` / `break-request` / `break-cancel` / `dangerZone` across `src/web/app` and `src/web/components` returned zero hits before this branch; the `/recovery/*` routes under `src/web/app` are marketing content, not product UI.

So the 24-hour cooldown that is the entire point of the feature was unreachable: a user could not queue a break, could not see one running, and could not cancel one.

## What this lands

**`src/web/services/api-client.ts`** — `getRecoveryLockStatus`, `requestRecoveryBreak`, `cancelRecoveryBreak` beside the other contract calls, plus `getDangerZoneStatus`, and the response types (`RecoveryBreakRequest`, `DangerWindow`, `ProtectionRecommendation`, `ContractDangerStatus`).

**`src/web/components/RecoveryLockCountdown.tsx`** — live countdown to `unlock_at`, a Request-break form (reason required, as the endpoint's body demands), and the Cancel CTA. Two behaviours worth calling out:

- `UNLOCKED` is *derived server-side* from `unlock_at` (`contracts.service.ts:3497`), not stored. The component renders the status it was handed; when its own countdown reaches zero it re-reads `lock-status` rather than relabelling the row from the browser's clock.
- Cancel stays offered in the `UNLOCKED` state, because the stored row is still `PENDING_COOLDOWN` — which is exactly what `cancelRecoveryBreak`'s `UPDATE ... WHERE status = 'PENDING_COOLDOWN'` targets.

**`src/web/components/DangerZoneBanner.tsx`** — on the danger-zone question in the ticket: **an endpoint does exist**, but not on `DangerZoneService` itself, which has no controller. It is `GET /behavioral/retention/danger-zone` on `RetentionController` (`behavioral/retention.controller.ts:78`), and it is evaluated **per user across every ACTIVE contract**, returning a `contracts[]` array. So the banner fetches the account-wide status and filters by `contractId` — no per-contract route was invented. Each open window renders with its severity and the protection the API recommends for it, paired **by window type rather than by array position**. A failed read is silent: this is an advisory surface and must not put an error banner on a page whose primary content loaded fine.

**`src/web/app/contracts/[id]/page.tsx`** — both are mounted. The timelock renders for `RECOVERY_*` contracts only, with the request CTA gated on `status === 'ACTIVE'` to match `requestRecoveryBreak`'s own precondition; the danger banners render for ACTIVE contracts.

Each component splits its presentational half from its fetching container (the `DashboardErrorNotice` pattern already in the repo) so every branch is renderable from fixed props — that is what the specs exercise.

## Verification

Scoped to the diff; both run from `src/web`:

```
npx jest components/RecoveryLockCountdown.test.tsx components/DangerZoneBanner.test.tsx app/contracts
  → Test Suites: 5 passed, 5 total / Tests: 34 passed, 34 total

npx tsc --noEmit   (this is src/web's `npm run lint`)
  → exit 0
```

New specs follow the repo's static-markup idiom (`renderToStaticMarkup`, no testing-library, `api-client` jest-mocked). The pre-existing `app/contracts/**` specs still pass unchanged.

**No API code is touched by this PR**, so no SQL is added or modified and nothing here needs a database claim either way. The client is asserted against the endpoint contracts as they are written in `contracts.controller.ts` / `retention.controller.ts`; end-to-end behaviour against a live Postgres is not exercised by these unit tests.

## Summary by Sourcery

Expose recovery timelock and behavioral danger-zone information in the web client for contract detail pages.

New Features:
- Add API client support for recovery timelock operations and danger-zone status retrieval.
- Introduce a recovery lock countdown UI that surfaces cooldown state, break requests, and cancellation for recovery contracts.
- Add danger-zone banners that highlight current risk windows and recommended protections per contract on the dashboard.

Enhancements:
- Wire recovery timelock and danger-zone banners into the contract detail page, gated by contract type and status.
- Structure timelock and danger-zone components with presentational/container separation to keep UI renderable from fixed props.

Tests:
- Add unit tests for the recovery timelock countdown and panel behaviour, including countdown formatting and state transitions.
- Add unit tests for danger-zone banners to verify window severity display, recommendation pairing by type, and non-rendering when not applicable.