### PR TITLE
feat(notifications): resolve push tickets into real delivery receipts (TKT-P1-006)

### DIFF
--- a/src/api/database/migrations/069_push_delivery_receipts.sql
+++ b/src/api/database/migrations/069_push_delivery_receipts.sql
@@ -1,0 +1,44 @@
+-- 069: Two-phase push delivery — tickets on send, receipts afterwards.
+--
+-- Expo's push API is two-phase and 044 only recorded the first half. A 200 from
+-- /push/send returns a *ticket*, which means "accepted for delivery", not
+-- "delivered": DeviceNotRegistered, MessageTooBig and MessageRateExceeded are
+-- only ever reported later, by /push/getReceipts, keyed on the ticket id. A row
+-- whose status was 'SENT' therefore proved nothing about the device.
+--
+-- provider_ticket_id is what makes a delivery row addressable in phase two, and
+-- receipt_status is its own lifecycle independent of `status`:
+--
+--   PENDING     -- a ticket exists, no receipt has come back yet
+--   OK          -- the receipt confirmed delivery to the push service
+--   ERROR       -- the receipt reported a failure; receipt_error_code names it
+--   UNAVAILABLE -- Expo never produced a receipt within the poll ceiling
+--
+-- Receipts stay retrievable for roughly 24 hours, so a delivery that is still
+-- PENDING long after that will never resolve; receipt_attempts bounds the
+-- polling the same way contracts.reconcile_attempts bounds the stuck-contract
+-- sweep (068). Existing rows keep NULL and are never polled — they predate any
+-- ticket being recorded.
+
+ALTER TABLE push_deliveries
+    ADD COLUMN IF NOT EXISTS provider_ticket_id TEXT,
+    ADD COLUMN IF NOT EXISTS receipt_status TEXT,
+    ADD COLUMN IF NOT EXISTS receipt_error_code TEXT,
+    ADD COLUMN IF NOT EXISTS receipt_checked_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS receipt_attempts INTEGER NOT NULL DEFAULT 0;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'push_deliveries_receipt_status_check'
+    ) THEN
+        ALTER TABLE push_deliveries
+            ADD CONSTRAINT push_deliveries_receipt_status_check
+            CHECK (receipt_status IN ('PENDING', 'OK', 'ERROR', 'UNAVAILABLE'));
+    END IF;
+END $$;
+
+-- The receipt sweep's only query: the oldest tickets still awaiting a verdict.
+CREATE INDEX IF NOT EXISTS idx_push_deliveries_receipt_pending
+    ON push_deliveries (created_at)
+    WHERE receipt_status = 'PENDING';

--- a/src/api/src/modules/notifications/expo-push.provider.spec.ts
+++ b/src/api/src/modules/notifications/expo-push.provider.spec.ts
@@ -1,4 +1,4 @@
-import { ExpoPushProvider } from './expo-push.provider';
+import { ExpoPushProvider, EXPO_RECEIPT_BATCH_SIZE } from './expo-push.provider';
 
 describe('ExpoPushProvider', () => {
   let provider: ExpoPushProvider;
@@ -41,6 +41,64 @@ describe('ExpoPushProvider', () => {
 
       expect(result.status).toBe('SENT');
       expect(result.providerResult).toBe('ok');
+    });
+
+    it('returns the ticket id so the receipt sweep can resolve the send', async () => {
+      process.env.EXPO_ACCESS_TOKEN = 'test-token';
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [{ status: 'ok', id: 'ticket-abc' }] }),
+      });
+
+      const result = await provider.send({
+        token: 'ExponentPushToken[xxx]', // allow-secret
+        title: 'Test',
+      });
+
+      expect(result.ticketId).toBe('ticket-abc');
+    });
+
+    it('classifies MessageRateExceeded as FAILED, not UNREGISTERED', async () => {
+      process.env.EXPO_ACCESS_TOKEN = 'test-token';
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [{
+            status: 'error',
+            message: 'Rate limited',
+            details: { error: 'MessageRateExceeded' },
+          }],
+        }),
+      });
+
+      const result = await provider.send({
+        token: 'ExponentPushToken[xxx]', // allow-secret
+        title: 'Test',
+      });
+
+      // A rate limit is about this attempt; the device is still reachable.
+      expect(result.status).toBe('FAILED');
+    });
+
+    it('reads DeviceNotRegistered from the structured details code', async () => {
+      process.env.EXPO_ACCESS_TOKEN = 'test-token';
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [{
+            status: 'error',
+            message: 'gone',
+            details: { error: 'DeviceNotRegistered' },
+          }],
+        }),
+      });
+
+      const result = await provider.send({
+        token: 'ExponentPushToken[dead]', // allow-secret
+        title: 'Test',
+      });
+
+      expect(result.status).toBe('UNREGISTERED');
     });
 
     it('handles Expo API error (DeviceNotRegistered)', async () => {
@@ -87,6 +145,137 @@ describe('ExpoPushProvider', () => {
       });
 
       expect(result.status).toBe('FAILED');
+    });
+  });
+
+  describe('fetchReceipts', () => {
+    const originalEnv = process.env.EXPO_ACCESS_TOKEN;
+
+    afterEach(() => {
+      process.env.EXPO_ACCESS_TOKEN = originalEnv;
+    });
+
+    it('returns an empty map without calling the API for no ticket ids', async () => {
+      process.env.EXPO_ACCESS_TOKEN = 'test-token';
+      global.fetch = jest.fn();
+
+      const receipts = await provider.fetchReceipts([]);
+
+      expect(receipts.size).toBe(0);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns an empty map when EXPO_ACCESS_TOKEN is not set', async () => {
+      delete process.env.EXPO_ACCESS_TOKEN;
+      global.fetch = jest.fn();
+
+      const receipts = await provider.fetchReceipts(['ticket-1']);
+
+      expect(receipts.size).toBe(0);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('maps ok receipts to OK', async () => {
+      process.env.EXPO_ACCESS_TOKEN = 'test-token';
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { 'ticket-1': { status: 'ok' } } }),
+      });
+
+      const receipts = await provider.fetchReceipts(['ticket-1']);
+
+      expect(receipts.get('ticket-1')).toEqual({ status: 'OK' });
+    });
+
+    it('surfaces the machine-readable error code from an error receipt', async () => {
+      process.env.EXPO_ACCESS_TOKEN = 'test-token';
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: {
+            'ticket-1': {
+              status: 'error',
+              message: 'The device is not registered.',
+              details: { error: 'DeviceNotRegistered' },
+            },
+          },
+        }),
+      });
+
+      const receipts = await provider.fetchReceipts(['ticket-1']);
+
+      expect(receipts.get('ticket-1')).toEqual({
+        status: 'ERROR',
+        errorCode: 'DeviceNotRegistered',
+        errorMessage: 'The device is not registered.',
+      });
+    });
+
+    it('omits tickets Expo has not resolved yet', async () => {
+      process.env.EXPO_ACCESS_TOKEN = 'test-token';
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { 'ticket-1': { status: 'ok' } } }),
+      });
+
+      const receipts = await provider.fetchReceipts(['ticket-1', 'ticket-2']);
+
+      expect(receipts.has('ticket-1')).toBe(true);
+      expect(receipts.has('ticket-2')).toBe(false);
+    });
+
+    it('returns no verdicts on a non-ok HTTP response', async () => {
+      process.env.EXPO_ACCESS_TOKEN = 'test-token';
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        text: async () => 'Bad Gateway',
+      });
+
+      const receipts = await provider.fetchReceipts(['ticket-1']);
+
+      expect(receipts.size).toBe(0);
+    });
+
+    it('returns no verdicts when the request throws', async () => {
+      process.env.EXPO_ACCESS_TOKEN = 'test-token';
+      global.fetch = jest.fn().mockRejectedValueOnce(new Error('ECONNRESET'));
+
+      const receipts = await provider.fetchReceipts(['ticket-1']);
+
+      expect(receipts.size).toBe(0);
+    });
+
+    it('splits oversized id lists into batched requests', async () => {
+      process.env.EXPO_ACCESS_TOKEN = 'test-token';
+      const ids = Array.from({ length: EXPO_RECEIPT_BATCH_SIZE + 5 }, (_, i) => `ticket-${i}`);
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+
+      await provider.fetchReceipts(ids);
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      const firstBody = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+      const secondBody = JSON.parse((global.fetch as jest.Mock).mock.calls[1][1].body);
+      expect(firstBody.ids).toHaveLength(EXPO_RECEIPT_BATCH_SIZE);
+      expect(secondBody.ids).toHaveLength(5);
+    });
+
+    it('still returns the resolved verdicts when the response also carries request errors', async () => {
+      process.env.EXPO_ACCESS_TOKEN = 'test-token';
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: { 'ticket-1': { status: 'ok' } },
+          errors: [{ code: 'PUSH_TOO_MANY_EXPERIENCE_IDS', message: 'too many' }],
+        }),
+      });
+
+      const receipts = await provider.fetchReceipts(['ticket-1']);
+
+      expect(receipts.get('ticket-1')).toEqual({ status: 'OK' });
     });
   });
 });

--- a/src/api/src/modules/notifications/expo-push.provider.ts
+++ b/src/api/src/modules/notifications/expo-push.provider.ts
@@ -1,5 +1,25 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { PushProvider, PushMessage, PushResult } from './push-provider.interface';
+import {
+  PushProvider,
+  PushMessage,
+  PushResult,
+  PushReceipt,
+} from './push-provider.interface';
+
+const EXPO_SEND_URL = 'https://exp.host/--/api/v2/push/send';
+const EXPO_RECEIPTS_URL = 'https://exp.host/--/api/v2/push/getReceipts';
+
+// Expo caps a getReceipts call at 1000 ids; stay well inside it so a batch is
+// never rejected wholesale for being one id too long.
+export const EXPO_RECEIPT_BATCH_SIZE = 300;
+
+/**
+ * The only send-time error that means the device is gone for good. Everything
+ * else Expo can report at send time (rate limits, credential problems) is about
+ * this attempt, not about the token — deactivating on those would silently
+ * unsubscribe healthy devices.
+ */
+const DEVICE_GONE_CODE = 'DeviceNotRegistered';
 
 @Injectable()
 export class ExpoPushProvider implements PushProvider {
@@ -13,7 +33,7 @@ export class ExpoPushProvider implements PushProvider {
     }
 
     try {
-      const response = await fetch('https://exp.host/--/api/v2/push/send', {
+      const response = await fetch(EXPO_SEND_URL, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -35,34 +55,108 @@ export class ExpoPushProvider implements PushProvider {
       }
 
       const result = await response.json() as {
-        data?: Array<{ status: string; message?: string }>;
+        data?: Array<{
+          status: string;
+          id?: string;
+          message?: string;
+          details?: { error?: string };
+        }>;
       };
 
       if (!result.data || result.data.length === 0) {
         return { status: 'SENT' };
       }
 
-      const pushStatus = result.data[0].status;
-      const pushMessage = result.data[0].message;
+      const ticket = result.data[0];
+      const pushStatus = ticket.status;
+      const pushMessage = ticket.message;
 
       switch (pushStatus) {
         case 'ok':
-          return { status: 'SENT', providerResult: 'ok' };
+          // A ticket id, not a delivery — the receipt sweep resolves it later.
+          return { status: 'SENT', providerResult: 'ok', ticketId: ticket.id };
         case 'error': {
-          // Expo returns detailed error messages for specific failures
-          if (pushMessage?.includes('DeviceNotRegistered') ||
-              pushMessage?.includes('InvalidCredentials') ||
-              pushMessage?.includes('MessageRateExceeded')) {
+          const code = ticket.details?.error;
+          if (code === DEVICE_GONE_CODE || pushMessage?.includes(DEVICE_GONE_CODE)) {
             return { status: 'UNREGISTERED', errorMessage: pushMessage };
           }
           return { status: 'FAILED', errorMessage: pushMessage };
         }
         default:
-          return { status: 'SENT', providerResult: pushStatus };
+          return { status: 'SENT', providerResult: pushStatus, ticketId: ticket.id };
       }
     } catch (err: any) {
       this.logger.error(`Expo push request failed: ${err.message}`);
       return { status: 'FAILED', errorMessage: err.message };
     }
+  }
+
+  async fetchReceipts(ticketIds: string[]): Promise<Map<string, PushReceipt>> {
+    const receipts = new Map<string, PushReceipt>();
+    if (ticketIds.length === 0) return receipts;
+
+    if (!process.env.EXPO_ACCESS_TOKEN) {
+      // The dev fallback never issued real tickets, so there is nothing to
+      // resolve; returning an empty map lets the sweep age them out.
+      this.logger.warn('EXPO_ACCESS_TOKEN not set — cannot fetch push receipts');
+      return receipts;
+    }
+
+    for (let i = 0; i < ticketIds.length; i += EXPO_RECEIPT_BATCH_SIZE) {
+      const batch = ticketIds.slice(i, i + EXPO_RECEIPT_BATCH_SIZE);
+      try {
+        const response = await fetch(EXPO_RECEIPTS_URL, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${process.env.EXPO_ACCESS_TOKEN}`,
+          },
+          body: JSON.stringify({ ids: batch }),
+        });
+
+        if (!response.ok) {
+          const text = await response.text();
+          this.logger.error(
+            `Expo getReceipts returned ${response.status}: ${text}`,
+          );
+          continue;
+        }
+
+        const result = await response.json() as {
+          data?: Record<string, {
+            status: string;
+            message?: string;
+            details?: { error?: string };
+          }>;
+          errors?: Array<{ code?: string; message?: string }>;
+        };
+
+        if (result.errors?.length) {
+          this.logger.error(
+            `Expo getReceipts reported ${result.errors.length} request error(s): ${
+              result.errors.map((e) => e.message ?? e.code ?? 'unknown').join('; ')
+            }`,
+          );
+        }
+
+        for (const [ticketId, receipt] of Object.entries(result.data ?? {})) {
+          if (receipt.status === 'ok') {
+            receipts.set(ticketId, { status: 'OK' });
+            continue;
+          }
+          receipts.set(ticketId, {
+            status: 'ERROR',
+            errorCode: receipt.details?.error,
+            errorMessage: receipt.message,
+          });
+        }
+      } catch (err: any) {
+        // A transport failure is not a verdict — leave the batch unresolved so
+        // the next sweep asks again.
+        this.logger.error(`Expo getReceipts request failed: ${err.message}`);
+      }
+    }
+
+    return receipts;
   }
 }

--- a/src/api/src/modules/notifications/notifications.module.ts
+++ b/src/api/src/modules/notifications/notifications.module.ts
@@ -1,4 +1,5 @@
 import { Module } from "@nestjs/common";
+import { ScheduleModule } from "@nestjs/schedule";
 import {
   NotificationsController,
   PublicFeedController,
@@ -8,8 +9,10 @@ import { PushTokensService } from "./push-tokens.service";
 import { PushDispatchWorker } from "./push-dispatch.worker";
 import { ExpoPushProvider } from "./expo-push.provider";
 import { NotificationComposerService } from "./notification-composer.service";
+import { PushReceiptsScheduler } from "./push-receipts.scheduler";
 
 @Module({
+  imports: [ScheduleModule.forRoot()],
   controllers: [NotificationsController, PublicFeedController],
   providers: [
     NotificationsService,
@@ -17,6 +20,7 @@ import { NotificationComposerService } from "./notification-composer.service";
     ExpoPushProvider,
     PushDispatchWorker,
     NotificationComposerService,
+    PushReceiptsScheduler,
   ],
   exports: [NotificationsService, PushTokensService, NotificationComposerService],
 })

--- a/src/api/src/modules/notifications/push-dispatch.worker.spec.ts
+++ b/src/api/src/modules/notifications/push-dispatch.worker.spec.ts
@@ -29,6 +29,20 @@ describe('PushDispatchWorker', () => {
     expect(worker).toBeDefined();
   });
 
+  it('records the send ticket so the receipt sweep can resolve the delivery', async () => {
+    mockPushTokens.getActiveTokens.mockResolvedValue([{ id: 'token-1', token: 'tok-1', platform: 'ios' }]); // allow-secret
+    mockProvider.send.mockResolvedValue({ status: 'SENT', providerResult: 'ok', ticketId: 'ticket-abc' });
+
+    await (worker as any).process({
+      data: { userId: 'user-1', type: 'REMINDER', title: 'Title', body: 'Body' },
+    });
+
+    expect(mockPushTokens.markDelivery).toHaveBeenCalledWith(
+      'token-1', 'user-1', 'REMINDER', 'Title', 'Body', null,
+      'expo', 'SENT', 'ok', undefined, 'ticket-abc',
+    );
+  });
+
   it('initializes in onModuleInit', () => {
     worker.onModuleInit();
     const { Worker } = require('bullmq');

--- a/src/api/src/modules/notifications/push-dispatch.worker.ts
+++ b/src/api/src/modules/notifications/push-dispatch.worker.ts
@@ -66,6 +66,7 @@ export class PushDispatchWorker implements OnModuleInit {
         result.status,
         result.providerResult,
         result.errorMessage,
+        result.ticketId,
       );
 
       if (result.status === 'UNREGISTERED') {

--- a/src/api/src/modules/notifications/push-provider.interface.ts
+++ b/src/api/src/modules/notifications/push-provider.interface.ts
@@ -9,9 +9,33 @@ export interface PushResult {
   status: 'SENT' | 'FAILED' | 'UNREGISTERED';
   providerResult?: string;
   errorMessage?: string;
+  /**
+   * Handle for phase two. A send returns a ticket, not a delivery — the real
+   * verdict arrives later against this id (see {@link PushProvider.fetchReceipts}).
+   */
+  ticketId?: string;
+}
+
+/**
+ * Phase-two verdict for a single ticket.
+ *
+ * `errorCode` is the provider's machine-readable reason (DeviceNotRegistered,
+ * MessageTooBig, MessageRateExceeded, InvalidCredentials, …) — only that code
+ * is safe to branch on; the human message wording is not a contract.
+ */
+export interface PushReceipt {
+  status: 'OK' | 'ERROR';
+  errorCode?: string;
+  errorMessage?: string;
 }
 
 export interface PushProvider {
   readonly name: string;
   send(message: PushMessage): Promise<PushResult>;
+  /**
+   * Resolve receipts for previously issued tickets. Tickets whose receipt is
+   * not ready yet are simply absent from the returned map — absence is "ask
+   * again later", never a failure.
+   */
+  fetchReceipts(ticketIds: string[]): Promise<Map<string, PushReceipt>>;
 }

--- a/src/api/src/modules/notifications/push-receipts.scheduler.spec.ts
+++ b/src/api/src/modules/notifications/push-receipts.scheduler.spec.ts
@@ -1,0 +1,191 @@
+import { PushReceiptsScheduler } from './push-receipts.scheduler';
+
+describe('PushReceiptsScheduler', () => {
+  let scheduler: PushReceiptsScheduler;
+  let mockPushTokens: any;
+  let mockProvider: any;
+
+  const delivery = (overrides: Record<string, unknown> = {}) => ({
+    id: 'delivery-1',
+    push_token_id: 'token-1',
+    user_id: 'user-1',
+    provider_ticket_id: 'ticket-1',
+    receipt_attempts: 0,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    mockPushTokens = {
+      getDeliveriesAwaitingReceipt: jest.fn().mockResolvedValue([]),
+      recordReceiptOutcome: jest.fn().mockResolvedValue(undefined),
+      markReceiptUnresolved: jest.fn().mockResolvedValue(undefined),
+      deactivateTokenById: jest.fn().mockResolvedValue(undefined),
+    };
+    mockProvider = {
+      name: 'expo',
+      fetchReceipts: jest.fn().mockResolvedValue(new Map()),
+    };
+    scheduler = new PushReceiptsScheduler(mockPushTokens, mockProvider);
+  });
+
+  it('does not call the provider when nothing is awaiting a receipt', async () => {
+    await scheduler.collectPushReceipts();
+
+    expect(mockProvider.fetchReceipts).not.toHaveBeenCalled();
+  });
+
+  it('confirms a delivered ticket without touching the token', async () => {
+    mockPushTokens.getDeliveriesAwaitingReceipt.mockResolvedValue([delivery()]);
+    mockProvider.fetchReceipts.mockResolvedValue(
+      new Map([['ticket-1', { status: 'OK' }]]),
+    );
+
+    await scheduler.collectPushReceipts();
+
+    expect(mockProvider.fetchReceipts).toHaveBeenCalledWith(['ticket-1']);
+    expect(mockPushTokens.recordReceiptOutcome).toHaveBeenCalledWith(
+      'delivery-1',
+      'OK',
+      'SENT',
+    );
+    expect(mockPushTokens.deactivateTokenById).not.toHaveBeenCalled();
+  });
+
+  it('deactivates the token on DeviceNotRegistered', async () => {
+    mockPushTokens.getDeliveriesAwaitingReceipt.mockResolvedValue([delivery()]);
+    mockProvider.fetchReceipts.mockResolvedValue(
+      new Map([[
+        'ticket-1',
+        {
+          status: 'ERROR',
+          errorCode: 'DeviceNotRegistered',
+          errorMessage: 'device not registered',
+        },
+      ]]),
+    );
+
+    await scheduler.collectPushReceipts();
+
+    expect(mockPushTokens.recordReceiptOutcome).toHaveBeenCalledWith(
+      'delivery-1',
+      'ERROR',
+      'UNREGISTERED',
+      'DeviceNotRegistered',
+      'device not registered',
+    );
+    expect(mockPushTokens.deactivateTokenById).toHaveBeenCalledWith('token-1');
+  });
+
+  it('records a non-device receipt error without deactivating the token', async () => {
+    mockPushTokens.getDeliveriesAwaitingReceipt.mockResolvedValue([delivery()]);
+    mockProvider.fetchReceipts.mockResolvedValue(
+      new Map([[
+        'ticket-1',
+        { status: 'ERROR', errorCode: 'MessageTooBig', errorMessage: 'too big' },
+      ]]),
+    );
+
+    await scheduler.collectPushReceipts();
+
+    expect(mockPushTokens.recordReceiptOutcome).toHaveBeenCalledWith(
+      'delivery-1',
+      'ERROR',
+      'FAILED',
+      'MessageTooBig',
+      'too big',
+    );
+    expect(mockPushTokens.deactivateTokenById).not.toHaveBeenCalled();
+  });
+
+  it('does not deactivate on MessageRateExceeded — the device is fine', async () => {
+    mockPushTokens.getDeliveriesAwaitingReceipt.mockResolvedValue([delivery()]);
+    mockProvider.fetchReceipts.mockResolvedValue(
+      new Map([[
+        'ticket-1',
+        { status: 'ERROR', errorCode: 'MessageRateExceeded' },
+      ]]),
+    );
+
+    await scheduler.collectPushReceipts();
+
+    expect(mockPushTokens.deactivateTokenById).not.toHaveBeenCalled();
+  });
+
+  it('skips deactivation when the delivery has no surviving token row', async () => {
+    mockPushTokens.getDeliveriesAwaitingReceipt.mockResolvedValue([
+      delivery({ push_token_id: null }),
+    ]);
+    mockProvider.fetchReceipts.mockResolvedValue(
+      new Map([['ticket-1', { status: 'ERROR', errorCode: 'DeviceNotRegistered' }]]),
+    );
+
+    await scheduler.collectPushReceipts();
+
+    expect(mockPushTokens.recordReceiptOutcome).toHaveBeenCalled();
+    expect(mockPushTokens.deactivateTokenById).not.toHaveBeenCalled();
+  });
+
+  it('leaves an unresolved ticket pending while it is under the attempt ceiling', async () => {
+    mockPushTokens.getDeliveriesAwaitingReceipt.mockResolvedValue([
+      delivery({ receipt_attempts: 3 }),
+    ]);
+
+    await scheduler.collectPushReceipts();
+
+    expect(mockPushTokens.markReceiptUnresolved).toHaveBeenCalledWith('delivery-1', false);
+    expect(mockPushTokens.recordReceiptOutcome).not.toHaveBeenCalled();
+  });
+
+  it('abandons a ticket that reached the attempt ceiling', async () => {
+    mockPushTokens.getDeliveriesAwaitingReceipt.mockResolvedValue([
+      delivery({ receipt_attempts: 23 }),
+    ]);
+
+    await scheduler.collectPushReceipts();
+
+    expect(mockPushTokens.markReceiptUnresolved).toHaveBeenCalledWith('delivery-1', true);
+  });
+
+  it('resolves each pending delivery independently when one write fails', async () => {
+    mockPushTokens.getDeliveriesAwaitingReceipt.mockResolvedValue([
+      delivery(),
+      delivery({ id: 'delivery-2', provider_ticket_id: 'ticket-2', push_token_id: 'token-2' }),
+    ]);
+    mockProvider.fetchReceipts.mockResolvedValue(
+      new Map([
+        ['ticket-1', { status: 'OK' }],
+        ['ticket-2', { status: 'OK' }],
+      ]),
+    );
+    mockPushTokens.recordReceiptOutcome
+      .mockRejectedValueOnce(new Error('deadlock detected'))
+      .mockResolvedValueOnce(undefined);
+    jest.spyOn((scheduler as any).logger, 'error').mockImplementation();
+
+    await scheduler.collectPushReceipts();
+
+    expect(mockPushTokens.recordReceiptOutcome).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns without writing when the pending query fails', async () => {
+    mockPushTokens.getDeliveriesAwaitingReceipt.mockRejectedValue(new Error('pool exhausted'));
+    const errorSpy = jest.spyOn((scheduler as any).logger, 'error').mockImplementation();
+
+    await scheduler.collectPushReceipts();
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(mockProvider.fetchReceipts).not.toHaveBeenCalled();
+    expect(mockPushTokens.markReceiptUnresolved).not.toHaveBeenCalled();
+  });
+
+  it('leaves every ticket untouched when the provider lookup throws', async () => {
+    mockPushTokens.getDeliveriesAwaitingReceipt.mockResolvedValue([delivery()]);
+    mockProvider.fetchReceipts.mockRejectedValue(new Error('ECONNRESET'));
+    jest.spyOn((scheduler as any).logger, 'error').mockImplementation();
+
+    await scheduler.collectPushReceipts();
+
+    expect(mockPushTokens.markReceiptUnresolved).not.toHaveBeenCalled();
+    expect(mockPushTokens.recordReceiptOutcome).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/src/modules/notifications/push-receipts.scheduler.ts
+++ b/src/api/src/modules/notifications/push-receipts.scheduler.ts
@@ -1,0 +1,125 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { PushTokensService, PendingReceiptDelivery } from './push-tokens.service';
+import { ExpoPushProvider } from './expo-push.provider';
+import { PushReceipt } from './push-provider.interface';
+
+const RECEIPT_BATCH_LIMIT = 500;
+
+// Expo needs time to hand a notification to APNs/FCM and hear back; polling
+// sooner reliably returns nothing.
+const RECEIPT_MIN_AGE_SECONDS = 300;
+
+// Receipts stop being retrievable after roughly 24 hours. At a 5-minute cadence
+// and a 5-minute floor, 24 attempts covers a couple of hours of transient
+// unavailability without polling a ticket that is already unrecoverable.
+const RECEIPT_MAX_ATTEMPTS = 24;
+
+/** The one receipt error that means the device will never accept a push again. */
+const DEVICE_GONE_CODE = 'DeviceNotRegistered';
+
+/**
+ * Phase two of push delivery.
+ *
+ * A send returns a ticket — "accepted", not "delivered". The device-level
+ * verdict (DeviceNotRegistered, MessageTooBig, MessageRateExceeded, …) is only
+ * ever reported by /push/getReceipts, keyed on that ticket id. Without this
+ * sweep a dead device keeps its token forever and every push to it is recorded
+ * as a success.
+ */
+@Injectable()
+export class PushReceiptsScheduler {
+  private readonly logger = new Logger(PushReceiptsScheduler.name);
+
+  constructor(
+    private readonly pushTokens: PushTokensService,
+    private readonly provider: ExpoPushProvider,
+  ) {}
+
+  @Cron('0 */5 * * * *')
+  async collectPushReceipts(): Promise<void> {
+    let pending: PendingReceiptDelivery[];
+    try {
+      pending = await this.pushTokens.getDeliveriesAwaitingReceipt(
+        RECEIPT_BATCH_LIMIT,
+        RECEIPT_MIN_AGE_SECONDS,
+      );
+    } catch (err) {
+      this.logger.error(
+        `Receipt sweep: failed to load pending deliveries: ${err instanceof Error ? err.message : err}`,
+      );
+      return;
+    }
+
+    if (pending.length === 0) return;
+
+    let receipts: Map<string, PushReceipt>;
+    try {
+      receipts = await this.provider.fetchReceipts(
+        pending.map((delivery) => delivery.provider_ticket_id),
+      );
+    } catch (err) {
+      this.logger.error(
+        `Receipt sweep: provider lookup failed: ${err instanceof Error ? err.message : err}`,
+      );
+      return;
+    }
+
+    let confirmed = 0;
+    let failed = 0;
+    let deactivated = 0;
+    let unresolved = 0;
+    let abandoned = 0;
+
+    for (const delivery of pending) {
+      const receipt = receipts.get(delivery.provider_ticket_id);
+
+      try {
+        if (!receipt) {
+          // Absence is "not ready yet", never a failure — until the ticket is
+          // old enough that it never will be.
+          const giveUp = delivery.receipt_attempts + 1 >= RECEIPT_MAX_ATTEMPTS;
+          await this.pushTokens.markReceiptUnresolved(delivery.id, giveUp);
+          if (giveUp) abandoned++;
+          else unresolved++;
+          continue;
+        }
+
+        if (receipt.status === 'OK') {
+          await this.pushTokens.recordReceiptOutcome(delivery.id, 'OK', 'SENT');
+          confirmed++;
+          continue;
+        }
+
+        const deviceGone = receipt.errorCode === DEVICE_GONE_CODE;
+        await this.pushTokens.recordReceiptOutcome(
+          delivery.id,
+          'ERROR',
+          deviceGone ? 'UNREGISTERED' : 'FAILED',
+          receipt.errorCode,
+          receipt.errorMessage,
+        );
+        failed++;
+
+        if (deviceGone && delivery.push_token_id) {
+          this.logger.warn(
+            `Receipt sweep: deactivating unregistered push token ${delivery.push_token_id} for user ${delivery.user_id}`,
+          );
+          await this.pushTokens.deactivateTokenById(delivery.push_token_id);
+          deactivated++;
+        }
+      } catch (err) {
+        this.logger.error(
+          `Receipt sweep: failed to record receipt for delivery ${delivery.id}: ${
+            err instanceof Error ? err.message : err
+          }`,
+        );
+      }
+    }
+
+    this.logger.log(
+      `Receipt sweep: ${confirmed} confirmed, ${failed} failed (${deactivated} token(s) deactivated), ` +
+        `${unresolved} still pending, ${abandoned} abandoned`,
+    );
+  }
+}

--- a/src/api/src/modules/notifications/push-tokens.service.spec.ts
+++ b/src/api/src/modules/notifications/push-tokens.service.spec.ts
@@ -67,4 +67,114 @@ describe('PushTokensService', () => {
       expect(tokens).toEqual([]);
     });
   });
+
+  describe('markDelivery', () => {
+    it('opens the receipt lifecycle when a ticket id was issued', async () => {
+      mockPool.query.mockResolvedValue({ rows: [] });
+
+      await service.markDelivery(
+        'token-1', 'user-1', 'REMINDER', 'Title', 'Body', null,
+        'expo', 'SENT', 'ok', undefined, 'ticket-abc',
+      );
+
+      expect(mockPool.query.mock.calls[0][0]).toContain('provider_ticket_id');
+      expect(mockPool.query.mock.calls[0][1][10]).toBe('ticket-abc');
+    });
+
+    it('records no ticket when the provider did not issue one', async () => {
+      mockPool.query.mockResolvedValue({ rows: [] });
+
+      await service.markDelivery(
+        'token-1', 'user-1', 'REMINDER', 'Title', null, null,
+        'expo', 'FAILED', undefined, 'HTTP 500',
+      );
+
+      expect(mockPool.query.mock.calls[0][1][10]).toBeNull();
+    });
+  });
+
+  describe('getDeliveriesAwaitingReceipt', () => {
+    it('targets pending tickets past the minimum age, oldest first', async () => {
+      mockPool.query.mockResolvedValue({ rows: [] });
+
+      await service.getDeliveriesAwaitingReceipt(500, 300);
+
+      const sql = mockPool.query.mock.calls[0][0];
+      expect(sql).toContain("receipt_status = 'PENDING'");
+      expect(sql).toContain('provider_ticket_id IS NOT NULL');
+      expect(sql).toContain('ORDER BY created_at ASC');
+      expect(mockPool.query.mock.calls[0][1]).toEqual([500, 300]);
+    });
+
+    it('normalizes the attempt counter pg returns as a string', async () => {
+      mockPool.query.mockResolvedValue({
+        rows: [{
+          id: 'd1',
+          push_token_id: 't1',
+          user_id: 'u1',
+          provider_ticket_id: 'ticket-1',
+          receipt_attempts: '4',
+        }],
+      });
+
+      const pending = await service.getDeliveriesAwaitingReceipt(10, 300);
+
+      expect(pending[0].receipt_attempts).toBe(4);
+    });
+  });
+
+  describe('recordReceiptOutcome', () => {
+    it('corrects the delivery status the ticket had claimed', async () => {
+      mockPool.query.mockResolvedValue({ rowCount: 1 });
+
+      await service.recordReceiptOutcome(
+        'd1', 'ERROR', 'UNREGISTERED', 'DeviceNotRegistered', 'gone',
+      );
+
+      expect(mockPool.query.mock.calls[0][0]).toContain('receipt_checked_at = NOW()');
+      expect(mockPool.query.mock.calls[0][1]).toEqual([
+        'd1', 'ERROR', 'DeviceNotRegistered', 'UNREGISTERED', 'gone',
+      ]);
+    });
+
+    it('passes nulls for an OK receipt that carries no error detail', async () => {
+      mockPool.query.mockResolvedValue({ rowCount: 1 });
+
+      await service.recordReceiptOutcome('d1', 'OK', 'SENT');
+
+      expect(mockPool.query.mock.calls[0][1]).toEqual(['d1', 'OK', null, 'SENT', null]);
+    });
+  });
+
+  describe('markReceiptUnresolved', () => {
+    it('keeps the row pending under the ceiling', async () => {
+      mockPool.query.mockResolvedValue({ rowCount: 1 });
+
+      await service.markReceiptUnresolved('d1', false);
+
+      expect(mockPool.query.mock.calls[0][0]).toContain('receipt_attempts = receipt_attempts + 1');
+      expect(mockPool.query.mock.calls[0][1]).toEqual(['d1', false]);
+    });
+
+    it('abandons the row at the ceiling', async () => {
+      mockPool.query.mockResolvedValue({ rowCount: 1 });
+
+      await service.markReceiptUnresolved('d1', true);
+
+      expect(mockPool.query.mock.calls[0][0]).toContain("'UNAVAILABLE'");
+      expect(mockPool.query.mock.calls[0][1]).toEqual(['d1', true]);
+    });
+  });
+
+  describe('deactivateTokenById', () => {
+    it('marks the token row inactive by its primary key', async () => {
+      mockPool.query.mockResolvedValue({ rowCount: 1 });
+
+      await service.deactivateTokenById('token-1');
+
+      expect(mockPool.query.mock.calls[0][0]).toContain('UPDATE push_tokens');
+      expect(mockPool.query.mock.calls[0][0]).toContain('is_active = FALSE');
+      expect(mockPool.query.mock.calls[0][1]).toEqual(['token-1']);
+    });
+  });
 });

--- a/src/api/src/modules/notifications/push-tokens.service.ts
+++ b/src/api/src/modules/notifications/push-tokens.service.ts
@@ -1,6 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { Pool } from 'pg';
 
+export interface PendingReceiptDelivery {
+  id: string;
+  push_token_id: string | null;
+  user_id: string;
+  provider_ticket_id: string;
+  receipt_attempts: number;
+}
+
 @Injectable()
 export class PushTokensService {
   constructor(private readonly pool: Pool) {}
@@ -69,16 +77,101 @@ export class PushTokensService {
     status: string,
     providerResult?: string,
     errorMessage?: string,
+    ticketId?: string,
   ): Promise<void> {
+    // A ticket id is what makes this row resolvable in phase two, so it is also
+    // the only thing that puts the row into the receipt sweep's target set.
     await this.pool.query(
       `INSERT INTO push_deliveries
-        (push_token_id, user_id, notification_type, title, body, payload, provider, status, provider_result, error_message, delivered_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, CASE WHEN $8 IN ('SENT', 'UNREGISTERED') THEN NOW() ELSE NULL END)`,
+        (push_token_id, user_id, notification_type, title, body, payload, provider, status, provider_result, error_message, provider_ticket_id, receipt_status, delivered_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, CASE WHEN $11 IS NULL THEN NULL ELSE 'PENDING' END, CASE WHEN $8 IN ('SENT', 'UNREGISTERED') THEN NOW() ELSE NULL END)`,
       [
         pushTokenId, userId, notificationType, title, body,
         payload ? JSON.stringify(payload) : null,
         provider, status, providerResult ?? null, errorMessage ?? null,
+        ticketId ?? null,
       ],
+    );
+  }
+
+  /**
+   * Tickets still awaiting a verdict, oldest first.
+   *
+   * `minAgeSeconds` keeps the sweep from asking about a ticket Expo has not had
+   * time to resolve — a too-early poll just returns nothing and burns an
+   * attempt against the ceiling.
+   */
+  async getDeliveriesAwaitingReceipt(
+    limit: number,
+    minAgeSeconds: number,
+  ): Promise<PendingReceiptDelivery[]> {
+    const result = await this.pool.query(
+      `SELECT id, push_token_id, user_id, provider_ticket_id, receipt_attempts
+       FROM push_deliveries
+       WHERE receipt_status = 'PENDING'
+         AND provider_ticket_id IS NOT NULL
+         AND created_at < NOW() - ($2 * INTERVAL '1 second')
+       ORDER BY created_at ASC
+       LIMIT $1`,
+      [limit, minAgeSeconds],
+    );
+    return result.rows.map((row: PendingReceiptDelivery) => ({
+      ...row,
+      receipt_attempts: Number(row.receipt_attempts),
+    }));
+  }
+
+  /**
+   * Record a resolved receipt. `deliveryStatus` restates the delivery's own
+   * outcome because a row that read 'SENT' on its ticket may be a failure once
+   * the receipt lands — that correction is the whole point of phase two.
+   */
+  async recordReceiptOutcome(
+    deliveryId: string,
+    receiptStatus: 'OK' | 'ERROR',
+    deliveryStatus: string,
+    errorCode?: string,
+    errorMessage?: string,
+  ): Promise<void> {
+    await this.pool.query(
+      `UPDATE push_deliveries
+       SET receipt_status = $2,
+           receipt_error_code = $3,
+           receipt_checked_at = NOW(),
+           receipt_attempts = receipt_attempts + 1,
+           status = $4,
+           error_message = COALESCE($5, error_message)
+       WHERE id = $1`,
+      [deliveryId, receiptStatus, errorCode ?? null, deliveryStatus, errorMessage ?? null],
+    );
+  }
+
+  /**
+   * No receipt this round. Under the ceiling the row stays PENDING for a later
+   * sweep; at the ceiling it becomes UNAVAILABLE, because Expo drops receipts
+   * after roughly a day and a ticket that old will never resolve.
+   */
+  async markReceiptUnresolved(deliveryId: string, giveUp: boolean): Promise<void> {
+    await this.pool.query(
+      `UPDATE push_deliveries
+       SET receipt_attempts = receipt_attempts + 1,
+           receipt_checked_at = NOW(),
+           receipt_status = CASE WHEN $2 THEN 'UNAVAILABLE' ELSE receipt_status END
+       WHERE id = $1`,
+      [deliveryId, giveUp],
+    );
+  }
+
+  /**
+   * Deactivate by push_tokens id — the receipt path knows which delivery row it
+   * is resolving, not the raw token string that {@link unregisterToken} takes.
+   */
+  async deactivateTokenById(pushTokenId: string): Promise<void> {
+    await this.pool.query(
+      `UPDATE push_tokens
+       SET is_active = FALSE
+       WHERE id = $1`,
+      [pushTokenId],
     );
   }
 }


### PR DESCRIPTION
TKT-P1-006. Today's "delivered" was a send-time **ticket**, not a receipt.

## The defect

Expo's push API is two-phase. `POST /--/api/v2/push/send` returns a *ticket* — "accepted for delivery" — and `expo-push.provider.ts` treated that 200 as final, writing `push_deliveries.status = 'SENT'`. The device-level verdict (`DeviceNotRegistered`, `MessageTooBig`, `MessageRateExceeded`, `InvalidCredentials`) is only ever reported afterwards, by `POST /--/api/v2/push/getReceipts`, keyed on the ticket id.

Consequence: a phone that had uninstalled the app kept an `is_active` row in `push_tokens` forever, and every push to it was recorded as a success.

## What changed

**Migration `069_push_delivery_receipts.sql`** — `push_deliveries` already existed (from `044`), so this extends it rather than adding a table: `provider_ticket_id`, and a receipt lifecycle of its own —

| `receipt_status` | meaning |
|---|---|
| `PENDING` | a ticket exists, no receipt yet |
| `OK` | receipt confirmed delivery |
| `ERROR` | receipt reported a failure; `receipt_error_code` names it |
| `UNAVAILABLE` | Expo never produced a receipt within the poll ceiling |

plus `receipt_error_code`, `receipt_checked_at`, `receipt_attempts`, and a partial index on the sweep's only query. Rows written before this migration keep `NULL` and are never polled — they never had a ticket. `status` needed no constraint change: receipts can only move a row to `FAILED` or `UNREGISTERED`, both already allowed.

**Tickets recorded on send** — `PushResult.ticketId` carries the id out of `send()`; `PushDispatchWorker` passes it to `markDelivery`, and a non-null ticket is what opens `receipt_status = 'PENDING'`. That is the only thing that puts a row into the sweep's target set.

**`ExpoPushProvider.fetchReceipts`** — batches ids 300 at a time (under Expo's 1000 cap) and maps each verdict to `{status, errorCode, errorMessage}`. A ticket absent from the response is "not ready yet", never a failure; a non-200 or a thrown request resolves nothing, so the next sweep asks again.

**`PushReceiptsScheduler`** (`@Cron('0 */5 * * * *')`) — every 5 minutes over tickets at least 5 minutes old (polling sooner reliably returns nothing), oldest first, 500 per pass. Records each outcome, and **deactivates the `push_tokens` row on `DeviceNotRegistered`** — the point of receipts. Unresolved tickets bump `receipt_attempts` and are abandoned as `UNAVAILABLE` at 24 attempts, because Expo drops receipts after roughly a day; that bound mirrors `contracts.reconcile_attempts` in the `068` stuck-contract sweep. Per-delivery `try/catch` so one bad write does not strand the rest of the batch, following `admin.scheduler.ts`.

**One correction found on the way** — `send()` mapped `InvalidCredentials` and `MessageRateExceeded` to `UNREGISTERED`, and `PushDispatchWorker` deactivates the token on `UNREGISTERED`. A rate-limited or misconfigured-credential send was therefore silently unsubscribing *healthy* devices. Only `DeviceNotRegistered` means the device is gone — at send time and at receipt time. `send()` now also reads the structured `details.error` code rather than only substring-matching the human message.

## Wiring

`PushReceiptsScheduler` is a provider of `NotificationsModule`, which `app.module.ts` imports; the module now imports `ScheduleModule.forRoot()` so `@Cron` is discovered — the same pattern `admin.module.ts` and `users.module.ts` already use.

```
$ grep -rn "PushReceiptsScheduler" src/api/src --include=*.ts | grep -v spec
modules/notifications/push-receipts.scheduler.ts:31:export class PushReceiptsScheduler {
modules/notifications/notifications.module.ts:12:import { PushReceiptsScheduler } from "./push-receipts.scheduler";
modules/notifications/notifications.module.ts:23:    PushReceiptsScheduler,
```

## Verification

```
$ npx jest src/modules/notifications
Test Suites: 8 passed, 8 total
Tests:       92 passed, 92 total

$ npx jest database/migrations/migrate.spec.ts
Test Suites: 1 passed, 1 total
Tests:       30 passed, 30 total
```

`npx tsc --noEmit` is clean for every file in this change. It reports one **pre-existing** error, in a file this PR does not touch and which is present on `origin/main`:

```
../shared/libs/waitlist-attribution.spec.ts(1,38): error TS2307: Cannot find module '@jest/globals'
```

**The SQL is not verified by any of that.** Every spec in this repo mocks the `pg` Pool, so `069_push_delivery_receipts.sql` and the five new/changed queries in `push-tokens.service.ts` are reviewed, not executed. The specs assert the query *shapes* and parameter vectors; they cannot tell you the migration applies cleanly against a live database.

New spec coverage for the receipt branches: OK-confirmed, `DeviceNotRegistered` → token deactivated, `MessageTooBig` → `FAILED` with the token left alone, `MessageRateExceeded` → no deactivation, delivery whose `push_token_id` was already nulled by the `ON DELETE SET NULL`, unresolved-under-ceiling, abandoned-at-ceiling, one write failing without stranding the batch, and both early returns (pending query throws, provider lookup throws).

The `// allow-secret` markers added to four lines are `ExponentPushToken[xxx]` / `tok-1` test fixtures the secret scanner reads as assignments.

## Summary by Sourcery

Introduce two-phase push delivery handling by recording Expo tickets on send and asynchronously resolving them via receipt polling, correcting delivery statuses and deactivating dead tokens.

New Features:
- Add support for fetching and interpreting Expo push delivery receipts to drive second-phase verdicts.
- Add a scheduled receipt sweep that polls pending push deliveries, updates their outcomes, and deactivates tokens for unregistered devices.

Bug Fixes:
- Stop treating send-time rate limiting and credential errors as device unregistration, preventing healthy devices from being silently unsubscribed.
- Ensure push tokens for unregistered devices are deactivated based on receipt verdicts so pushes are no longer recorded as successful indefinitely.

Enhancements:
- Extend push delivery persistence to track provider tickets and a dedicated receipt lifecycle with bounded polling.
- Update notification dispatch to propagate provider ticket ids into stored deliveries for later receipt resolution.
- Adjust Expo push provider request/response handling to surface ticket ids, machine-readable error codes, and batch receipt lookups.

Tests:
- Add comprehensive unit tests for Expo receipt handling, push delivery receipt lifecycle, token deactivation behavior, and the new scheduled receipt sweep.