### PR TITLE
feat(mobile): proof processing-state UI (TKT-P1-013)

### DIFF
--- a/src/mobile/components/CameraModule.spec.tsx
+++ b/src/mobile/components/CameraModule.spec.tsx
@@ -4,12 +4,14 @@ import { Alert } from 'react-native';
 import { CameraModule } from './CameraModule';
 import { UploadService } from '../services/UploadService';
 import { ApiClient } from '../services/ApiClient';
+import type { ProofProcessingStatus } from '../services/ApiClient';
 
 jest.mock('../services/UploadService', () => ({
   UploadService: {
     requestPreSignedUrl: jest.fn(),
     uploadVideoBuffer: jest.fn(),
     confirmUpload: jest.fn(),
+    pollProcessingStatus: jest.fn(),
   },
 }));
 
@@ -33,7 +35,31 @@ describe('CameraModule', () => {
       proofId: 'proof_123',
       jobId: 'job_123',
     });
+    mockPoll([{ proofId: 'proof_123', overallStatus: 'COMPLETED', jobs: [] }]);
   });
+
+  /**
+   * Replays a scripted sequence of pipeline readings through the component's
+   * onUpdate callback, then resolves with the last one — the shape
+   * UploadService.pollProcessingStatus has. Its own backoff/deadline logic is
+   * covered in services/UploadService.spec.ts.
+   */
+  function mockPoll(readings: ProofProcessingStatus[]) {
+    (UploadService.pollProcessingStatus as jest.Mock).mockImplementation(
+      async (_proofId: string, onUpdate: (s: ProofProcessingStatus) => void) => {
+        readings.forEach(onUpdate);
+        return readings[readings.length - 1];
+      },
+    );
+  }
+
+  function submitCapture(contractId = 'contract-1') {
+    const view = render(<CameraModule contractId={contractId} />);
+    fireEvent.click(view.getByRole('button')); // start recording
+    fireEvent.click(view.getByRole('button')); // stop recording
+    fireEvent.click(view.getByText('SUBMIT TO FURY').closest('button') as HTMLElement);
+    return view;
+  }
 
   it('renders initial camera ready state', () => {
     const { container } = render(<CameraModule contractId="contract-1" />);
@@ -42,7 +68,6 @@ describe('CameraModule', () => {
   });
 
   it('records, uploads, and submits proof to contracts endpoint', async () => {
-    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
     const { getByRole, getByText, container } = render(<CameraModule contractId="contract-1" />);
 
     fireEvent.click(getByRole('button')); // start recording
@@ -71,11 +96,93 @@ describe('CameraModule', () => {
       expect(ApiClient.submitProof).toHaveBeenCalledWith('contract-1', {
         mediaUri: 'proofs/proof_123/video.mp4',
       });
-      expect(alertSpy).toHaveBeenCalledWith(
-        'Beta Proof Secured',
-        'Your recording has been sent to the Fury Router for validation. NOTE: This is a synthetic capture path for the Phase 1 Beta pilot.',
+      expect(UploadService.pollProcessingStatus).toHaveBeenCalledWith(
+        'proof_123',
+        expect.any(Function),
+        expect.objectContaining({ isCancelled: expect.any(Function) }),
       );
     });
+  });
+
+  it('renders the pipeline stage while the proof is still processing', async () => {
+    mockPoll([
+      { proofId: 'proof_123', overallStatus: 'NOT_STARTED', jobs: [] },
+      {
+        proofId: 'proof_123',
+        overallStatus: 'PROCESSING',
+        jobs: [
+          { stage: 'REDACT', status: 'IN_PROGRESS', error: null, updated_at: '2026-08-15T00:00:02Z' },
+          { stage: 'TRANSCODE', status: 'COMPLETED', error: null, updated_at: '2026-08-15T00:00:01Z' },
+        ],
+      },
+    ]);
+
+    const { container } = submitCapture();
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('PROOF PROCESSING');
+      expect(container.textContent).toContain('Processing your proof...');
+      // jobs[0] is the newest stage — the one the worker is on right now.
+      expect(container.textContent).toContain('Stage: REDACT — IN_PROGRESS');
+    });
+  });
+
+  it('renders the success state when the pipeline reports COMPLETED', async () => {
+    const { container } = submitCapture();
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('Processing Complete');
+      expect(container.textContent).toContain('queued with the Fury Router');
+    });
+  });
+
+  it('renders the failed stage error with a retry that re-polls', async () => {
+    mockPoll([
+      {
+        proofId: 'proof_123',
+        overallStatus: 'FAILED',
+        jobs: [
+          { stage: 'VALIDATE', status: 'FAILED', error: 'Source video is not decodable', updated_at: 'now' },
+        ],
+      },
+    ]);
+
+    const { container, getByText } = submitCapture();
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('Processing Failed');
+      expect(container.textContent).toContain('Source video is not decodable');
+      expect(container.textContent).toContain('Failed at stage: VALIDATE');
+    });
+
+    fireEvent.click(getByText('RETRY').closest('button') as HTMLElement);
+
+    await waitFor(() => {
+      expect(UploadService.pollProcessingStatus).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('surfaces a poll that gave up at the deadline as a failure', async () => {
+    (UploadService.pollProcessingStatus as jest.Mock).mockRejectedValue(
+      new Error('Proof is still processing after 300s.'),
+    );
+
+    const { container } = submitCapture();
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('Processing Failed');
+      expect(container.textContent).toContain('Proof is still processing after 300s.');
+    });
+  });
+
+  it('returns to the capture view when the processing view is dismissed', async () => {
+    const { container, getByText } = submitCapture();
+
+    await waitFor(() => expect(container.textContent).toContain('Processing Complete'));
+
+    fireEvent.click(getByText('DONE').closest('button') as HTMLElement);
+
+    expect(container.textContent).toContain('Camera Ready (Gallery Disabled)');
   });
 
   it('blocks submission when contract id is missing', async () => {

--- a/src/mobile/components/CameraModule.tsx
+++ b/src/mobile/components/CameraModule.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, ActivityIndicator, Alert } from 'react-native';
 import { UploadService } from '../services/UploadService';
 import { ApiClient } from '../services/ApiClient';
+import type { ProofProcessingStatus } from '../services/ApiClient';
 import { createCameraWatermark, createSyntheticCaptureSession } from '../utils/proof-media';
 
 /**
@@ -18,6 +19,63 @@ export const CameraModule = ({ contractId }: { contractId?: string }) => {
   const [watermark, setWatermark] = useState<string | null>(null);
   const [captureStartedAt, setCaptureStartedAt] = useState<number | null>(null);
   const [captureLabel, setCaptureLabel] = useState<string | null>(null);
+
+  // Backend pipeline state, deliberately separate from isUploading: that flag
+  // tracks the raw R2 PUT, which is already finished when any of this begins.
+  const [processingProofId, setProcessingProofId] = useState<string | null>(null);
+  const [processingStatus, setProcessingStatus] = useState<ProofProcessingStatus | null>(null);
+  const [processingError, setProcessingError] = useState<string | null>(null);
+  const [isPolling, setIsPolling] = useState(false);
+
+  // A poll outlives the render that started it, so it needs a channel the running
+  // loop can read: refs, not state. The generation counter orphans a superseded
+  // poll (dismiss, or a retry started while the previous round is mid-sleep) —
+  // a single boolean cannot, because clearing it to re-arm would also un-cancel
+  // the loop it was meant to stop.
+  const unmountedRef = useRef(false);
+  const pollGenerationRef = useRef(0);
+  useEffect(() => {
+    return () => {
+      unmountedRef.current = true;
+    };
+  }, []);
+
+  const watchProcessing = async (proofId: string) => {
+    const generation = ++pollGenerationRef.current;
+    const isStale = () => unmountedRef.current || pollGenerationRef.current !== generation;
+
+    setProcessingProofId(proofId);
+    setProcessingStatus(null);
+    setProcessingError(null);
+    setIsPolling(true);
+    try {
+      await UploadService.pollProcessingStatus(
+        proofId,
+        (status) => {
+          if (!isStale()) {
+            setProcessingStatus(status);
+          }
+        },
+        { isCancelled: isStale },
+      );
+    } catch (error: any) {
+      if (!isStale()) {
+        setProcessingError(error.message);
+      }
+    } finally {
+      if (!isStale()) {
+        setIsPolling(false);
+      }
+    }
+  };
+
+  const dismissProcessing = () => {
+    pollGenerationRef.current += 1;
+    setProcessingProofId(null);
+    setProcessingStatus(null);
+    setProcessingError(null);
+    setIsPolling(false);
+  };
 
   const toggleRecording = () => {
     if (isRecording) {
@@ -71,21 +129,102 @@ export const CameraModule = ({ contractId }: { contractId?: string }) => {
         mediaUri: storageKey,
       });
 
-      Alert.alert(
-        'Beta Proof Secured',
-        'Your recording has been sent to the Fury Router for validation. NOTE: This is a synthetic capture path for the Phase 1 Beta pilot.',
-      );
       setVideoUri(null);
       setCaptureHash(null);
       setWatermark(null);
       setCaptureStartedAt(null);
       setCaptureLabel(null);
+      setIsUploading(false);
+      // The upload is only half the story: transcode/redact runs on a worker and
+      // the proof is not reviewable until it lands. Hold the user on a live
+      // processing view instead of the old terminal "secured" alert, which
+      // claimed completion the pipeline had not reached.
+      await watchProcessing(proofId);
     } catch (error: any) {
       Alert.alert('Upload Failed', error.message);
     } finally {
       setIsUploading(false);
     }
   };
+
+  if (processingProofId) {
+    // The API orders proof_processing_jobs newest-first, so jobs[0] is the stage
+    // the worker is on right now.
+    const latestJob = processingStatus?.jobs?.[0] || null;
+    const failedJob = processingStatus?.jobs?.find((job) => job.status === 'FAILED') || null;
+    const overallStatus = processingStatus?.overallStatus || 'NOT_STARTED';
+    const hasFailed = overallStatus === 'FAILED' || processingError !== null;
+    const hasCompleted = overallStatus === 'COMPLETED' && !processingError;
+
+    return (
+      <View style={styles.container}>
+        <View style={styles.betaBanner}>
+          <Text style={styles.betaBannerText}>PROOF PROCESSING</Text>
+        </View>
+
+        <View style={styles.processingPanel}>
+          {hasFailed ? (
+            <>
+              <Text style={styles.processingFailedTitle}>Processing Failed</Text>
+              <Text style={styles.processingDetail}>
+                {processingError ||
+                  failedJob?.error ||
+                  'The processing pipeline could not finish this proof.'}
+              </Text>
+              {failedJob ? (
+                <Text style={styles.processingStage}>Failed at stage: {failedJob.stage}</Text>
+              ) : null}
+              <View style={styles.actionRow}>
+                <TouchableOpacity
+                  style={styles.discardButton}
+                  onPress={dismissProcessing}
+                >
+                  <Text style={styles.discardText}>RECORD ANOTHER</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={styles.submitButton}
+                  onPress={() => watchProcessing(processingProofId)}
+                >
+                  <Text style={styles.submitText}>RETRY</Text>
+                </TouchableOpacity>
+              </View>
+            </>
+          ) : hasCompleted ? (
+            <>
+              <Text style={styles.processingDoneTitle}>Processing Complete</Text>
+              <Text style={styles.processingDetail}>
+                Your proof is redacted and queued with the Fury Router for validation.
+              </Text>
+              <TouchableOpacity style={styles.submitButton} onPress={dismissProcessing}>
+                <Text style={styles.submitText}>DONE</Text>
+              </TouchableOpacity>
+            </>
+          ) : (
+            <>
+              {isPolling ? <ActivityIndicator size="large" color="#FF3B30" /> : null}
+              <Text style={styles.processingTitle}>
+                {overallStatus === 'NOT_STARTED'
+                  ? 'Waiting for the processing worker...'
+                  : 'Processing your proof...'}
+              </Text>
+              <Text style={styles.processingStage}>
+                {latestJob
+                  ? `Stage: ${latestJob.stage} — ${latestJob.status}`
+                  : 'No pipeline stage reported yet.'}
+              </Text>
+              <Text style={styles.processingDetail}>
+                Transcoding and identity redaction run on a background worker. You can leave this
+                screen; processing continues either way.
+              </Text>
+              <TouchableOpacity style={styles.discardButton} onPress={dismissProcessing}>
+                <Text style={styles.discardText}>RUN IN BACKGROUND</Text>
+              </TouchableOpacity>
+            </>
+          )}
+        </View>
+      </View>
+    );
+  }
 
   return (
     <View style={styles.container}>
@@ -186,5 +325,11 @@ const styles = StyleSheet.create({
   captureMeta: { alignItems: 'center', paddingBottom: 10 },
   captureMetaText: { color: '#888', fontSize: 12 },
   betaBanner: { backgroundColor: '#20150d', padding: 8, borderBottomWidth: 1, borderBottomColor: '#4a2a16' },
+  processingPanel: { flex: 1, justifyContent: 'center', alignItems: 'center', paddingHorizontal: 30 },
+  processingTitle: { color: '#FFF', fontSize: 18, fontWeight: 'bold', marginTop: 20, textAlign: 'center' },
+  processingDoneTitle: { color: '#34C759', fontSize: 20, fontWeight: '900', textAlign: 'center' },
+  processingFailedTitle: { color: '#FF3B30', fontSize: 20, fontWeight: '900', textAlign: 'center' },
+  processingStage: { color: '#FFB26B', fontFamily: 'monospace', fontSize: 12, marginTop: 12, textAlign: 'center' },
+  processingDetail: { color: '#888', fontSize: 13, marginTop: 12, marginBottom: 20, textAlign: 'center' },
   betaBannerText: { color: '#ffb26b', fontSize: 10, fontWeight: '800', textAlign: 'center', letterSpacing: 1 },
 });

--- a/src/mobile/services/ApiClient.ts
+++ b/src/mobile/services/ApiClient.ts
@@ -3,6 +3,25 @@ import type { MobileBootstrapResponse, ReleaseInfoResponse } from '@styx/shared/
 
 let authToken: string | null = null;
 
+/** One row of `proof_processing_jobs`, newest first as the API orders them. */
+export interface ProofProcessingJob {
+  stage: string;
+  status: string;
+  error: string | null;
+  updated_at: string;
+}
+
+export interface ProofProcessingStatus {
+  proofId: string;
+  /**
+   * Mirrors `proofs.processing_status`. Terminal values are COMPLETED and FAILED;
+   * NOT_STARTED (the column default, also returned when the row is missing the
+   * value) and PROCESSING are in-flight.
+   */
+  overallStatus: string;
+  jobs: ProofProcessingJob[];
+}
+
 const MOBILE_APP_VERSION = process.env.EXPO_PUBLIC_STYX_MOBILE_VERSION || '0.0.0-dev';
 const MOBILE_APP_BUILD = process.env.EXPO_PUBLIC_STYX_MOBILE_BUILD || 'dev';
 
@@ -175,6 +194,9 @@ getContracts: () =>
       method: 'POST',
       body: JSON.stringify(data),
     }),
+
+  getProcessingStatus: (proofId: string) =>
+    request<ProofProcessingStatus>(`/proofs/${proofId}/processing-status`),
 
   useGraceDay: (contractId: string) =>
     request<{ success: boolean; graceDaysRemaining: number }>(`/contracts/${contractId}/grace-day`, {

--- a/src/mobile/services/UploadService.spec.ts
+++ b/src/mobile/services/UploadService.spec.ts
@@ -1,4 +1,11 @@
-import { UploadService } from './UploadService';
+import {
+  UploadService,
+  PROCESSING_POLL_INITIAL_MS,
+  PROCESSING_POLL_MAX_MS,
+  PROCESSING_POLL_DEADLINE_MS,
+} from './UploadService';
+import { ApiClient } from './ApiClient';
+import type { ProofProcessingStatus } from './ApiClient';
 
 jest.mock('./SessionService', () => ({
   SessionService: {
@@ -6,11 +13,43 @@ jest.mock('./SessionService', () => ({
   },
 }));
 
+jest.mock('./ApiClient', () => ({
+  ApiClient: {
+    getProcessingStatus: jest.fn(),
+  },
+}));
+
+function status(
+  overallStatus: string,
+  jobs: ProofProcessingStatus['jobs'] = [],
+): ProofProcessingStatus {
+  return { proofId: 'proof_123', overallStatus, jobs };
+}
+
+/**
+ * Drives the poll without real timers: `sleep` advances a virtual clock that
+ * `now` reads, so a 5-minute deadline resolves in microseconds and every
+ * recorded delay is exactly what the backoff asked for.
+ */
+function createVirtualClock() {
+  let current = 0;
+  const slept: number[] = [];
+  return {
+    slept,
+    now: () => current,
+    sleep: async (ms: number) => {
+      slept.push(ms);
+      current += ms;
+    },
+  };
+}
+
 const mockFetch = jest.fn();
 (globalThis as any).fetch = mockFetch;
 
 beforeEach(() => {
   mockFetch.mockReset();
+  (ApiClient.getProcessingStatus as jest.Mock).mockReset();
 });
 
 describe('UploadService', () => {
@@ -115,5 +154,129 @@ describe('UploadService', () => {
     const ok = await UploadService.confirmUpload('proof_123', 'proofs/proof_123/video.mp4');
 
     expect(ok).toBe(false);
+  });
+
+  it('getProcessingStatus() rehydrates the session token and delegates to ApiClient', async () => {
+    (ApiClient.getProcessingStatus as jest.Mock).mockResolvedValueOnce(status('PROCESSING'));
+
+    const result = await UploadService.getProcessingStatus('proof_123');
+
+    expect(result).toEqual(status('PROCESSING'));
+    expect(ApiClient.getProcessingStatus).toHaveBeenCalledWith('proof_123');
+  });
+});
+
+describe('UploadService.pollProcessingStatus()', () => {
+  it('reports every reading and resolves on COMPLETED', async () => {
+    const clock = createVirtualClock();
+    (ApiClient.getProcessingStatus as jest.Mock)
+      .mockResolvedValueOnce(status('NOT_STARTED'))
+      .mockResolvedValueOnce(
+        status('PROCESSING', [
+          { stage: 'TRANSCODE', status: 'IN_PROGRESS', error: null, updated_at: 't1' },
+        ]),
+      )
+      .mockResolvedValueOnce(status('COMPLETED'));
+
+    const seen: string[] = [];
+    const final = await UploadService.pollProcessingStatus(
+      'proof_123',
+      (s) => seen.push(s.overallStatus),
+      { now: clock.now, sleep: clock.sleep },
+    );
+
+    expect(seen).toEqual(['NOT_STARTED', 'PROCESSING', 'COMPLETED']);
+    expect(final?.overallStatus).toBe('COMPLETED');
+    expect(ApiClient.getProcessingStatus).toHaveBeenCalledTimes(3);
+  });
+
+  it('stops on FAILED without polling again', async () => {
+    const clock = createVirtualClock();
+    (ApiClient.getProcessingStatus as jest.Mock).mockResolvedValueOnce(
+      status('FAILED', [
+        { stage: 'VALIDATE', status: 'FAILED', error: 'Source video is not decodable', updated_at: 't1' },
+      ]),
+    );
+
+    const final = await UploadService.pollProcessingStatus('proof_123', () => {}, {
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+
+    expect(final?.overallStatus).toBe('FAILED');
+    expect(ApiClient.getProcessingStatus).toHaveBeenCalledTimes(1);
+    expect(clock.slept).toEqual([]);
+  });
+
+  it('backs off exponentially from 2s and caps at 30s', async () => {
+    const clock = createVirtualClock();
+    (ApiClient.getProcessingStatus as jest.Mock).mockResolvedValue(status('PROCESSING'));
+
+    await expect(
+      UploadService.pollProcessingStatus('proof_123', () => {}, {
+        now: clock.now,
+        sleep: clock.sleep,
+      }),
+    ).rejects.toThrow('Proof is still processing after 300s.');
+
+    expect(clock.slept.slice(0, 5)).toEqual([2_000, 4_000, 8_000, 16_000, 30_000]);
+    expect(Math.max(...clock.slept)).toBe(PROCESSING_POLL_MAX_MS);
+    expect(clock.slept[0]).toBe(PROCESSING_POLL_INITIAL_MS);
+    // Each sleep is clamped to the time left, so the loop lands exactly on the
+    // deadline instead of overshooting it by up to a full backoff interval.
+    expect(clock.slept.reduce((a, b) => a + b, 0)).toBe(PROCESSING_POLL_DEADLINE_MS);
+  });
+
+  it('retries through a transient request failure and still completes', async () => {
+    const clock = createVirtualClock();
+    (ApiClient.getProcessingStatus as jest.Mock)
+      .mockRejectedValueOnce(new Error('Network request failed'))
+      .mockResolvedValueOnce(status('COMPLETED'));
+
+    const seen: string[] = [];
+    const final = await UploadService.pollProcessingStatus(
+      'proof_123',
+      (s) => seen.push(s.overallStatus),
+      { now: clock.now, sleep: clock.sleep },
+    );
+
+    expect(seen).toEqual(['COMPLETED']);
+    expect(final?.overallStatus).toBe('COMPLETED');
+    expect(clock.slept).toEqual([2_000]);
+  });
+
+  it('surfaces the last request error when the deadline passes without a reading', async () => {
+    const clock = createVirtualClock();
+    (ApiClient.getProcessingStatus as jest.Mock).mockRejectedValue(new Error('API 503'));
+
+    await expect(
+      UploadService.pollProcessingStatus('proof_123', () => {}, {
+        now: clock.now,
+        sleep: clock.sleep,
+        deadlineMs: 10_000,
+      }),
+    ).rejects.toThrow('Could not reach the processing pipeline: API 503');
+  });
+
+  it('resolves null and stops polling once the caller cancels', async () => {
+    const clock = createVirtualClock();
+    let cancelled = false;
+    (ApiClient.getProcessingStatus as jest.Mock).mockImplementation(async () => {
+      cancelled = true;
+      return status('PROCESSING');
+    });
+
+    const onUpdate = jest.fn();
+    const final = await UploadService.pollProcessingStatus('proof_123', onUpdate, {
+      now: clock.now,
+      sleep: clock.sleep,
+      isCancelled: () => cancelled,
+    });
+
+    expect(final).toBeNull();
+    // Cancellation is checked before the reading is published, so a view that
+    // has already unmounted never receives a state update.
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(ApiClient.getProcessingStatus).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/mobile/services/UploadService.ts
+++ b/src/mobile/services/UploadService.ts
@@ -4,7 +4,33 @@
  */
 
 import { SessionService } from './SessionService';
+import { ApiClient } from './ApiClient';
+import type { ProofProcessingStatus } from './ApiClient';
 import { API_BASE } from '../config/api';
+
+/** First gap between processing-status polls. */
+export const PROCESSING_POLL_INITIAL_MS = 2_000;
+/** Ceiling the exponential backoff settles at. */
+export const PROCESSING_POLL_MAX_MS = 30_000;
+/** Total wall-clock budget before the client stops asking and surfaces a retry. */
+export const PROCESSING_POLL_DEADLINE_MS = 300_000;
+
+const TERMINAL_PROCESSING_STATUSES = ['COMPLETED', 'FAILED'];
+
+function isTerminalProcessingStatus(overallStatus: string): boolean {
+  return TERMINAL_PROCESSING_STATUSES.includes(overallStatus);
+}
+
+export interface ProcessingPollOptions {
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  deadlineMs?: number;
+  /** Injected in tests so the poll runs without real timers. */
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+  /** Polled between rounds so an unmounting view can stop the loop. */
+  isCancelled?: () => boolean;
+}
 
 export class UploadService {
   /**
@@ -96,5 +122,80 @@ export class UploadService {
     }
 
     return true;
+  }
+
+  /**
+   * Reads the backend video-processing pipeline state for one proof.
+   *
+   * Routed through ApiClient rather than a bare fetch so the caller gets the
+   * shared error-envelope parsing (request_id, error_code). `getToken()` is
+   * awaited for its side effect: it rehydrates ApiClient's in-memory auth token
+   * after a cold start, where only AsyncStorage still holds the session.
+   */
+  static async getProcessingStatus(proofId: string): Promise<ProofProcessingStatus> {
+    await SessionService.getToken();
+    return ApiClient.getProcessingStatus(proofId);
+  }
+
+  /**
+   * Polls the processing pipeline until it reaches a terminal state, reporting
+   * every reading through `onUpdate` so a view can render progress live.
+   *
+   * Backs off exponentially from 2s to a 30s ceiling under a 5-minute budget:
+   * transcode + redact runs on a BullMQ worker with its own retries, so a tight
+   * poll would hammer the API for minutes with nothing new to say.
+   *
+   * Resolves with the terminal reading, or `null` if `isCancelled` went true.
+   * Rejects only when the deadline passes without a terminal state — a fetch
+   * failure mid-poll is transient (the worker is unaffected) and is retried
+   * until that same deadline.
+   */
+  static async pollProcessingStatus(
+    proofId: string,
+    onUpdate: (status: ProofProcessingStatus) => void,
+    options: ProcessingPollOptions = {},
+  ): Promise<ProofProcessingStatus | null> {
+    const initialDelayMs = options.initialDelayMs ?? PROCESSING_POLL_INITIAL_MS;
+    const maxDelayMs = options.maxDelayMs ?? PROCESSING_POLL_MAX_MS;
+    const deadlineMs = options.deadlineMs ?? PROCESSING_POLL_DEADLINE_MS;
+    const now = options.now ?? (() => Date.now());
+    const sleep =
+      options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+    const isCancelled = options.isCancelled ?? (() => false);
+
+    const startedAt = now();
+    let delayMs = initialDelayMs;
+    let lastError: string | null = null;
+
+    while (!isCancelled()) {
+      try {
+        const status = await UploadService.getProcessingStatus(proofId);
+        lastError = null;
+        if (isCancelled()) {
+          return null;
+        }
+        onUpdate(status);
+        if (isTerminalProcessingStatus(status.overallStatus)) {
+          return status;
+        }
+      } catch (e: any) {
+        lastError = e?.message || String(e);
+        console.warn(`UploadService: Processing-status poll failed for ${proofId}: ${lastError}`);
+      }
+
+      const remainingMs = deadlineMs - (now() - startedAt);
+      if (remainingMs <= 0) {
+        throw new Error(
+          lastError
+            ? `Could not reach the processing pipeline: ${lastError}`
+            : `Proof is still processing after ${Math.round(deadlineMs / 1000)}s.`,
+        );
+      }
+
+      await sleep(Math.min(delayMs, remainingMs));
+      delayMs = Math.min(delayMs * 2, maxDelayMs);
+    }
+
+    return null;
   }
 }


### PR DESCRIPTION
## The gap

`GET /proofs/:id/processing-status` has existed since migration 020, `proof_processing_jobs` is populated by `VideoProcessingWorker` (self-starting via `OnModuleInit`), and **no client called it**. The live capture path — `CameraModule.submitProof`, the one wired into `App.tsx` — closed with a terminal `Alert.alert('Beta Proof Secured', …)` fired the instant `confirmUpload` returned.

That alert claimed completion the pipeline had not reached. At that moment the proof is only in R2; `DOWNLOAD → VALIDATE → TRANSCODE → REDACT → STORE → FINALIZE` are all still ahead of it, and a proof whose redaction fails stays unreviewable (the Fury queue fails closed on missing masked media) while the user has been told it was secured.

**No backend change in this PR.** No SQL was written or modified.

## What this adds

| Layer | Change |
|---|---|
| `services/ApiClient.ts` | `getProcessingStatus(proofId)` + exported `ProofProcessingStatus` / `ProofProcessingJob` types for the endpoint's `{proofId, overallStatus, jobs[]}` response. |
| `services/UploadService.ts` | `getProcessingStatus` (delegates to ApiClient; awaits `SessionService.getToken()` for its rehydrate side effect so a cold start still carries auth) and `pollProcessingStatus`. |
| `components/CameraModule.tsx` | Post-upload processing view replacing the terminal alert. |

### Polling contract

- Backoff **2s → doubling → 30s ceiling**, under a **5-minute** budget; each sleep is clamped to the time remaining so the loop lands exactly on the deadline instead of overshooting by up to a full interval.
- A **request failure mid-poll is transient** — the BullMQ worker is unaffected by the client losing the API for a moment — so it is retried until the deadline. Only a deadline crossing rejects, carrying the last error if there was one.
- **Cancellable** (`isCancelled`), checked before a reading is published, so an unmounted view never receives a state update.

### UI states, off `overallStatus`

- `NOT_STARTED` → "Waiting for the processing worker…"; `PROCESSING` → "Processing your proof…", both showing `jobs[0]` as `Stage: REDACT — IN_PROGRESS` (the API orders `created_at DESC`, so `jobs[0]` is the stage the worker is on now), plus a "run in background" escape.
- `COMPLETED` → success + DONE.
- `FAILED` (or a poll that gave up) → the failed job's `error`, the stage it died at, and **RETRY** (re-polls) / **RECORD ANOTHER**.

`isUploading` / `videoUri` are untouched: they track the raw R2 PUT, a different phase with a different failure mode.

### One design note

Cancellation is a **generation counter**, not a boolean. Dismiss has to orphan an in-flight poll *without* un-cancelling it when the next poll starts — a single flag that gets cleared to re-arm would cancel the wrong loop.

## Merge-ordering note for the coordinator

Another agent is concurrently rewriting **CameraModule's capture half** (expo-camera). This diff was deliberately confined to the **post-upload half**:

- the processing view is an **early return placed above the existing camera JSX** — the viewfinder / record button / DISCARD-SUBMIT row are byte-identical to `origin/main`;
- the only edits inside the shared region are new `useState`/`useRef` lines at the top of the component, the replaced tail of `submitProof`, and appended `StyleSheet` entries.

The five capture-reset setters in `submitProof` were left inline (not extracted into a shared helper with the DISCARD handler) precisely to avoid touching the capture half. Conflicts should be limited to the hook block and the import line.

`CameraModule.spec.tsx`'s existing "records, uploads, and submits" test asserted the removed alert; it now asserts `pollProcessingStatus` is invoked instead. If the expo-camera PR also edits that spec, it wins on the capture assertions and this PR's post-upload assertions need to be replayed on top.

## Verification

```
$ cd src/mobile && npx jest services/UploadService.spec.ts components/CameraModule.spec.tsx services/ApiClient.spec.ts
Test Suites: 3 passed, 3 total
Tests:       42 passed, 42 total

$ npx tsc --noEmit      # this package's own `lint` and `build` script
(clean, exit 0)
```

Wiring proof — `grep -rn "getProcessingStatus\|pollProcessingStatus" src`:
`CameraModule.tsx:60` → `UploadService.pollProcessingStatus` → `UploadService.getProcessingStatus` → `ApiClient.getProcessingStatus` → `GET /proofs/:id/processing-status`. Nothing added here is unreachable.

New tests: 6 for the polling algorithm (reading sequence, terminal FAILED short-circuit, the exact backoff ladder `[2000, 4000, 8000, 16000, 30000]` summing to exactly 300000ms, transient-failure recovery, deadline error propagation, cancellation) driven by a virtual clock so no real timers are involved; 5 for the component's rendered states.

## Summary by Sourcery

Add client-side polling and UI to surface backend proof processing status after video upload in the mobile camera module.

New Features:
- Introduce UploadService.getProcessingStatus and pollProcessingStatus to query and track proof processing pipeline state with exponential backoff and cancellation.
- Display a dedicated proof processing screen in the camera flow that shows current pipeline stage, success, failure, and background-running options after upload completes.

Enhancements:
- Extend ApiClient with typed ProofProcessingStatus and ProofProcessingJob models and a getProcessingStatus endpoint helper.
- Ensure session rehydration before processing-status requests so polling works after cold starts.

Tests:
- Add unit tests for UploadService processing-status polling behavior, including backoff schedule, terminal states, transient failures, deadline handling, and cancellation.
- Update and expand CameraModule tests to cover integration with processing-status polling and the new processing UI states (in-progress, completed, failed, retry, dismiss).