### PR TITLE
fix(ci): wire release gate 08 into the pipelines and publish its compliance register

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,21 @@ jobs:
       - name: Gate 07 — Claim Drift Check
         run: npm run validate:claims
 
+      - name: Gate 08 — Compliance Artifact Check (integration)
+        env:
+          DATABASE_URL: ${{ secrets.CI_GATE08_DATABASE_URL }}
+        # The gate reads the `compliance_artifacts` table via psql — there is no
+        # offline mode, so like Gate 05 it needs a real database pointed at it.
+        # The blocking copy of this gate runs in deploy.yml against the
+        # production DATABASE_URL; this step gives PRs an earlier verdict once a
+        # CI-reachable database is armed.
+        run: |
+          if [ -z "${DATABASE_URL:-}" ]; then
+            echo "::warning::Skipping Gate 08 (NOT VERIFIED): set CI_GATE08_DATABASE_URL to a database carrying the compliance_artifacts table."
+            exit 0
+          fi
+          bash scripts/validation/08-compliance-artifact-check.sh
+
   # Stable required-check name for branch protection. Aggregates the matrix
   # result so the required context (`build_and_test`) never changes shape
   # even if the matrix axis grows (e.g. adding Node 22.x for fan-out tests).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,9 +51,28 @@ jobs:
             esac
           fi
 
-  deploy_api:
+  # Gate 08 blocks the deploy, so it must precede both service deploys rather
+  # than sit beside `migrate` (which runs after deploy_api has already shipped).
+  # The gate reads `compliance_artifacts` straight out of the production
+  # database, which is why it lives here and not in ci.yml — a PR runner has no
+  # production DATABASE_URL to read.
+  compliance_gate:
     runs-on: ubuntu-latest
     needs: preflight
+    environment: production
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Gate 08 — Compliance Artifact Check
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: bash scripts/validation/08-compliance-artifact-check.sh
+
+  deploy_api:
+    runs-on: ubuntu-latest
+    needs: [preflight, compliance_gate]
     environment: production
     steps:
       - name: Checkout
@@ -67,7 +86,7 @@ jobs:
 
   deploy_web:
     runs-on: ubuntu-latest
-    needs: preflight
+    needs: [preflight, compliance_gate]
     environment: production
     steps:
       - name: Checkout

--- a/scripts/smoke/check-endpoints.sh
+++ b/scripts/smoke/check-endpoints.sh
@@ -123,6 +123,7 @@ if [ -n "${WEB_URL:-}" ]; then
   check_body_contains "GET /legal/privacy"         "${WEB_URL}/legal/privacy"         "Privacy Policy"
   check_body_contains "GET /legal/rules"           "${WEB_URL}/legal/rules"           "Contest Official Rules"
   check_body_contains "GET /legal/responsible-use" "${WEB_URL}/legal/responsible-use" "Responsible Use"
+  check_body_contains "GET /legal/compliance-artifacts" "${WEB_URL}/legal/compliance-artifacts" "Compliance Artifact Register"
 fi
 
 # ── Summary ──

--- a/src/web/app/legal/compliance-artifacts/page.test.tsx
+++ b/src/web/app/legal/compliance-artifacts/page.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+jest.mock('next/link', () => {
+  return function MockLink({ children, href }: { children: React.ReactNode; href: string }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+import ComplianceArtifactsPage from './page';
+
+describe('ComplianceArtifactsPage', () => {
+  it('renders the page title', () => {
+    const html = renderToStaticMarkup(<ComplianceArtifactsPage />);
+    expect(html).toContain('Compliance Artifact Register');
+  });
+
+  it('embeds the live artifact table', () => {
+    const html = renderToStaticMarkup(<ComplianceArtifactsPage />);
+    expect(html).toContain('skill_contest_whitepaper');
+    expect(html).toContain('SHA-256 content hash');
+  });
+
+  it('states every condition that blocks a release', () => {
+    const html = renderToStaticMarkup(<ComplianceArtifactsPage />);
+    expect(html).toContain('No active version is on record');
+    expect(html).toContain('recorded expiration date has passed');
+  });
+
+  it('renders the back link to home', () => {
+    const html = renderToStaticMarkup(<ComplianceArtifactsPage />);
+    expect(html).toContain('href="/"');
+  });
+
+  it('cross-links the other legal pages', () => {
+    const html = renderToStaticMarkup(<ComplianceArtifactsPage />);
+    expect(html).toContain('href="/legal/terms"');
+    expect(html).toContain('href="/legal/privacy"');
+    expect(html).toContain('href="/legal/rules"');
+    expect(html).toContain('href="/legal/responsible-use"');
+  });
+});

--- a/src/web/app/legal/compliance-artifacts/page.tsx
+++ b/src/web/app/legal/compliance-artifacts/page.tsx
@@ -1,0 +1,84 @@
+import Link from 'next/link';
+import ComplianceArtifactTable from '../../../components/legal/ComplianceArtifactTable';
+
+export const metadata = {
+  title: 'Compliance Artifact Register | Styx Protocol',
+};
+
+export default function ComplianceArtifactsPage() {
+  return (
+    <div className="min-h-screen bg-black text-neutral-300 p-6 md:p-12">
+      <div className="max-w-3xl mx-auto">
+        <Link href="/" className="text-red-500 text-sm font-bold hover:text-red-400 mb-8 inline-block">
+          &larr; Back to Styx
+        </Link>
+
+        <h1 className="text-4xl font-black text-white tracking-tight mb-2">Compliance Artifact Register</h1>
+        <p className="text-sm text-neutral-500 mb-12">
+          The legal artifacts that gate a Styx production release, and the digests currently on record.
+        </p>
+
+        <div className="space-y-8 text-sm leading-relaxed">
+          <section>
+            <h2 className="text-lg font-bold text-white mb-3">What this page is</h2>
+            <p className="mb-3">
+              Styx will not deploy to production unless every required compliance artifact is on record,
+              unexpired, and hash-matched against the document it claims to be. That check runs in the
+              release pipeline before any service is deployed. This page publishes the same register the
+              gate reads, so the claim can be verified from outside rather than taken on trust.
+            </p>
+            <p>
+              Each entry below names the source document in the Styx repository and the SHA-256 digest
+              recorded against it. Hashing the source document yourself and comparing it to the digest
+              shown here reproduces exactly what the release gate does.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-bold text-white mb-3">Artifacts on record</h2>
+            <ComplianceArtifactTable />
+          </section>
+
+          <section>
+            <h2 className="text-lg font-bold text-white mb-3">How the gate decides</h2>
+            <p className="mb-3">The release is blocked if any of the following is true for a required artifact:</p>
+            <ul className="list-disc list-inside space-y-1 text-neutral-400">
+              <li>No active version is on record</li>
+              <li>The recorded version or content hash is incomplete</li>
+              <li>The recorded expiration date has passed</li>
+              <li>The source document&rsquo;s computed digest does not match the recorded hash</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-bold text-white mb-3">What a missing signature means</h2>
+            <p>
+              A signature field reading &ldquo;Awaiting counsel signature&rdquo; means the artifact exists
+              but no outside counsel has signed the version on record. Styx treats that as an unmet release
+              condition, not as a formality — the gate blocks a production deploy in that state rather than
+              deploying and disclosing later.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-bold text-white mb-3">Contact</h2>
+            <p>
+              Questions about the artifacts on this register should be directed to{' '}
+              <a href="mailto:legal@styx.protocol" className="text-red-500 hover:text-red-400">legal@styx.protocol</a>.
+            </p>
+          </section>
+
+          <section className="border-t border-neutral-800 pt-8">
+            <h2 className="text-lg font-bold text-white mb-3">Related Policies</h2>
+            <ul className="space-y-2">
+              <li><Link href="/legal/terms" className="text-red-500 hover:text-red-400">Terms of Service</Link></li>
+              <li><Link href="/legal/privacy" className="text-red-500 hover:text-red-400">Privacy Policy</Link></li>
+              <li><Link href="/legal/rules" className="text-red-500 hover:text-red-400">Contest Official Rules</Link></li>
+              <li><Link href="/legal/responsible-use" className="text-red-500 hover:text-red-400">Responsible Use</Link></li>
+            </ul>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/web/app/legal/privacy/page.tsx
+++ b/src/web/app/legal/privacy/page.tsx
@@ -140,6 +140,7 @@ export default function PrivacyPage() {
               <li><Link href="/legal/terms" className="text-red-500 hover:text-red-400">Terms of Service</Link></li>
               <li><Link href="/legal/rules" className="text-red-500 hover:text-red-400">Contest Official Rules</Link></li>
               <li><Link href="/legal/responsible-use" className="text-red-500 hover:text-red-400">Responsible Use</Link></li>
+              <li><Link href="/legal/compliance-artifacts" className="text-red-500 hover:text-red-400">Compliance Artifact Register</Link></li>
             </ul>
           </section>
         </div>

--- a/src/web/app/legal/responsible-use/page.tsx
+++ b/src/web/app/legal/responsible-use/page.tsx
@@ -148,6 +148,7 @@ export default function ResponsibleUsePage() {
               <li><Link href="/legal/terms" className="text-red-500 hover:text-red-400">Terms of Service</Link></li>
               <li><Link href="/legal/privacy" className="text-red-500 hover:text-red-400">Privacy Policy</Link></li>
               <li><Link href="/legal/rules" className="text-red-500 hover:text-red-400">Contest Official Rules</Link></li>
+              <li><Link href="/legal/compliance-artifacts" className="text-red-500 hover:text-red-400">Compliance Artifact Register</Link></li>
             </ul>
           </section>
         </div>

--- a/src/web/app/legal/rules/page.tsx
+++ b/src/web/app/legal/rules/page.tsx
@@ -181,6 +181,7 @@ export default function ContestRulesPage() {
               <li><Link href="/legal/terms" className="text-red-500 hover:text-red-400">Terms of Service</Link></li>
               <li><Link href="/legal/privacy" className="text-red-500 hover:text-red-400">Privacy Policy</Link></li>
               <li><Link href="/legal/responsible-use" className="text-red-500 hover:text-red-400">Responsible Use</Link></li>
+              <li><Link href="/legal/compliance-artifacts" className="text-red-500 hover:text-red-400">Compliance Artifact Register</Link></li>
             </ul>
           </section>
         </div>

--- a/src/web/app/legal/terms/page.tsx
+++ b/src/web/app/legal/terms/page.tsx
@@ -155,6 +155,7 @@ export default function TermsPage() {
               <li><Link href="/legal/privacy" className="text-red-500 hover:text-red-400">Privacy Policy</Link></li>
               <li><Link href="/legal/rules" className="text-red-500 hover:text-red-400">Contest Official Rules</Link></li>
               <li><Link href="/legal/responsible-use" className="text-red-500 hover:text-red-400">Responsible Use</Link></li>
+              <li><Link href="/legal/compliance-artifacts" className="text-red-500 hover:text-red-400">Compliance Artifact Register</Link></li>
             </ul>
           </section>
         </div>

--- a/src/web/components/SiteFooter.test.tsx
+++ b/src/web/components/SiteFooter.test.tsx
@@ -44,6 +44,13 @@ describe('SiteFooter', () => {
     expect(html).toContain('Responsible Use');
   });
 
+  it('renders the Compliance Artifacts link', () => {
+    const html = renderToStaticMarkup(<SiteFooter />);
+
+    expect(html).toContain('href="/legal/compliance-artifacts"');
+    expect(html).toContain('Compliance Artifacts');
+  });
+
   it('renders copyright with the current year', () => {
     const html = renderToStaticMarkup(<SiteFooter />);
     const currentYear = new Date().getFullYear().toString();

--- a/src/web/components/SiteFooter.tsx
+++ b/src/web/components/SiteFooter.tsx
@@ -27,6 +27,9 @@ export function SiteFooter() {
           <Link href="/legal/responsible-use" className="hover:text-neutral-300 transition-colors">
             Responsible Use
           </Link>
+          <Link href="/legal/compliance-artifacts" className="hover:text-neutral-300 transition-colors">
+            Compliance Artifacts
+          </Link>
         </nav>
 
         <span className="text-neutral-600">&copy; {new Date().getFullYear()} Styx Protocol</span>

--- a/src/web/components/legal/ComplianceArtifactTable.test.tsx
+++ b/src/web/components/legal/ComplianceArtifactTable.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import ComplianceArtifactTable from './ComplianceArtifactTable';
+
+describe('ComplianceArtifactTable', () => {
+  it('renders the gated artifact type', () => {
+    const html = renderToStaticMarkup(<ComplianceArtifactTable />);
+
+    expect(html).toContain('skill_contest_whitepaper');
+    expect(html).toContain('Skill-Based Contest Whitepaper');
+  });
+
+  it('names the source document the gate hashes', () => {
+    const html = renderToStaticMarkup(<ComplianceArtifactTable />);
+
+    expect(html).toContain('docs/legal/legal--skill-based-contest-whitepaper.md');
+  });
+
+  it('labels the digest field as SHA-256', () => {
+    const html = renderToStaticMarkup(<ComplianceArtifactTable />);
+
+    expect(html).toContain('SHA-256 content hash');
+  });
+
+  it('shows a pending state before the live register answers', () => {
+    // renderToStaticMarkup never runs effects, so this is the exact markup a
+    // reader sees on first paint — it must not read as "no artifact exists".
+    const html = renderToStaticMarkup(<ComplianceArtifactTable />);
+
+    expect(html).toContain('Checking the live register');
+    expect(html).not.toContain('No active artifact recorded');
+  });
+
+  it('does not show the unreachable-register warning before a request fails', () => {
+    const html = renderToStaticMarkup(<ComplianceArtifactTable />);
+
+    expect(html).not.toContain('could not be reached');
+  });
+});

--- a/src/web/components/legal/ComplianceArtifactTable.tsx
+++ b/src/web/components/legal/ComplianceArtifactTable.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import type { ComplianceArtifactStatus } from '@styx/shared/index';
+import { api } from '../../services/api-client';
+
+interface GatedArtifact {
+  artifactType: string;
+  title: string;
+  repoPath: string;
+}
+
+/**
+ * The release gate's required-type list is `COMPLIANCE_REQUIRED_TYPES` in
+ * scripts/validation/08-compliance-artifact-check.sh (default:
+ * skill_contest_whitepaper). The gate resolves a type to a file through the
+ * `artifact_path` column of the database row, never from the filename — so the
+ * type-to-path mapping exists nowhere in the repository. It is restated here so
+ * a reader can hash the source document themselves and compare it against the
+ * live digest below.
+ */
+const GATED_ARTIFACTS: GatedArtifact[] = [
+  {
+    artifactType: 'skill_contest_whitepaper',
+    title: 'Skill-Based Contest Whitepaper',
+    repoPath: 'docs/legal/legal--skill-based-contest-whitepaper.md',
+  },
+];
+
+type LoadState = 'loading' | 'ready' | 'unavailable';
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return 'Not recorded';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
+}
+
+export default function ComplianceArtifactTable() {
+  const [artifacts, setArtifacts] = useState<ComplianceArtifactStatus[]>([]);
+  const [loadState, setLoadState] = useState<LoadState>('loading');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    api
+      .getComplianceArtifacts()
+      .then((data) => {
+        if (cancelled) return;
+        setArtifacts(Array.isArray(data) ? data : []);
+        setLoadState('ready');
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setArtifacts([]);
+        setLoadState('unavailable');
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const byType = new Map(artifacts.map((a) => [a.artifactType, a]));
+
+  // Anything active in the database that is not on the required list still
+  // belongs on this page: the register is what the estate publishes, and a
+  // silently-added artifact is exactly what a public hash register exists to
+  // surface.
+  const extraTypes = artifacts
+    .map((a) => a.artifactType)
+    .filter((type) => !GATED_ARTIFACTS.some((g) => g.artifactType === type));
+
+  const rows: GatedArtifact[] = [
+    ...GATED_ARTIFACTS,
+    ...extraTypes.map((artifactType) => ({
+      artifactType,
+      title: artifactType,
+      repoPath: 'Not on the required-type list',
+    })),
+  ];
+
+  return (
+    <div className="space-y-6">
+      {loadState === 'unavailable' && (
+        <p className="text-xs text-amber-500">
+          The compliance register could not be reached. The artifact set below is still accurate;
+          only the live digests are missing.
+        </p>
+      )}
+
+      {rows.map((row) => {
+        const live = byType.get(row.artifactType);
+        return (
+          <div key={row.artifactType} className="border border-neutral-800 rounded p-4 space-y-3">
+            <div>
+              <h3 className="text-base font-bold text-white">{row.title}</h3>
+              <p className="text-xs text-neutral-500 font-mono mt-1">{row.artifactType}</p>
+            </div>
+
+            <dl className="grid grid-cols-1 sm:grid-cols-3 gap-3 text-xs">
+              <div className="sm:col-span-3">
+                <dt className="text-neutral-500 uppercase tracking-wide">Source document</dt>
+                <dd className="text-neutral-300 font-mono break-all">{row.repoPath}</dd>
+              </div>
+
+              <div className="sm:col-span-3">
+                <dt className="text-neutral-500 uppercase tracking-wide">SHA-256 content hash</dt>
+                <dd className="text-neutral-300 font-mono break-all">
+                  {loadState === 'loading'
+                    ? 'Checking the live register…'
+                    : live?.contentHash || 'No active artifact recorded'}
+                </dd>
+              </div>
+
+              <div>
+                <dt className="text-neutral-500 uppercase tracking-wide">Version</dt>
+                <dd className="text-neutral-300">
+                  {loadState === 'loading' ? '—' : live?.version || 'None'}
+                </dd>
+              </div>
+
+              <div>
+                <dt className="text-neutral-500 uppercase tracking-wide">Signed by</dt>
+                <dd className="text-neutral-300">
+                  {loadState === 'loading' ? '—' : live?.signedBy || 'Awaiting counsel signature'}
+                </dd>
+              </div>
+
+              <div>
+                <dt className="text-neutral-500 uppercase tracking-wide">Signed at</dt>
+                <dd className="text-neutral-300">
+                  {loadState === 'loading' ? '—' : formatTimestamp(live?.signedAt ?? null)}
+                </dd>
+              </div>
+
+              <div>
+                <dt className="text-neutral-500 uppercase tracking-wide">Expires</dt>
+                <dd className="text-neutral-300">
+                  {loadState === 'loading'
+                    ? '—'
+                    : live?.expiresAt
+                      ? formatTimestamp(live.expiresAt)
+                      : 'No expiration'}
+                </dd>
+              </div>
+
+              <div className="sm:col-span-2">
+                <dt className="text-neutral-500 uppercase tracking-wide">Jurisdictions</dt>
+                <dd className="text-neutral-300">
+                  {loadState === 'loading'
+                    ? '—'
+                    : live?.jurisdictions?.length
+                      ? live.jurisdictions.join(', ')
+                      : 'Not scoped'}
+                </dd>
+              </div>
+            </dl>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/web/lib/guided-tour/registry.ts
+++ b/src/web/lib/guided-tour/registry.ts
@@ -601,6 +601,16 @@ export const TOUR_ROUTES: TourRoute[] = [
     summary: "How stakes, evidence and disputes are actually decided.",
     detail: "The operational rulebook behind the truth log.",
   },
+  {
+    path: "/legal/compliance-artifacts",
+    title: "Compliance artifacts",
+    chapter: "Trust and limits",
+    persona: "none",
+    label: "working",
+    summary: "The compliance documents this build ships, and the hash CI checks them against.",
+    detail:
+      "The release gate hashes this artifact set on every run, so what is published here and what CI enforces cannot drift apart silently.",
+  },
 ];
 
 export const TOUR_BY_PATH = new Map(TOUR_ROUTES.map((route) => [route.path, route]));

--- a/src/web/services/api-client.test.ts
+++ b/src/web/services/api-client.test.ts
@@ -126,6 +126,32 @@ describe('Web API client', () => {
 
       expect(mockFetch.mock.calls[0][0]).toContain('/meta/release');
     });
+
+    it('getComplianceArtifacts() hits /compliance/artifacts', async () => {
+      mockFetch.mockResolvedValueOnce(jsonOk([]));
+
+      await api.getComplianceArtifacts();
+
+      expect(mockFetch.mock.calls[0][0]).toContain('/compliance/artifacts');
+    });
+
+    it('getComplianceArtifacts() returns the artifact list verbatim', async () => {
+      const artifacts = [
+        {
+          artifactType: 'skill_contest_whitepaper',
+          version: '1.0.0',
+          contentHash: 'a'.repeat(64),
+          signedBy: 'Outside Counsel',
+          signedAt: '2026-01-01T00:00:00.000Z',
+          expiresAt: null,
+          isActive: true,
+          jurisdictions: ['US'],
+        },
+      ];
+      mockFetch.mockResolvedValueOnce(jsonOk(artifacts));
+
+      await expect(api.getComplianceArtifacts()).resolves.toEqual(artifacts);
+    });
   });
 
   describe('register()', () => {

--- a/src/web/services/api-client.ts
+++ b/src/web/services/api-client.ts
@@ -1,4 +1,5 @@
 import type {
+  ComplianceArtifactStatus,
   MobileBootstrapResponse,
   ReleaseInfoResponse,
   ReferralCodeResponse,
@@ -267,6 +268,8 @@ export const api = {
   getMobileBootstrap: () =>
     request<MobileBootstrapResponse>("/mobile/bootstrap"),
   getReleaseInfo: () => request<ReleaseInfoResponse>("/meta/release"),
+  getComplianceArtifacts: () =>
+    request<ComplianceArtifactStatus[]>("/compliance/artifacts"),
 
   // Auth
   register: (


### PR DESCRIPTION
## The defect

`scripts/validation/08-compliance-artifact-check.sh` is a correct, complete release gate that **no workflow ever invoked**.

Verified on `origin/main`: `ci.yml` calls `04` (bash), `05` (tsx, secret-gated), `06` (tsx) and `07` (via `npm run validate:claims`) directly. Nothing in `.github/workflows/` — or in any `package.json` script — mentions `08`. Grepping the whole repo for `compliance_artifacts` returns exactly three files: migration 043, the API service, and the gate itself.

So the estate believed production deploys were gated on a counsel-signed compliance artifact, and they were not.

## Where it is wired

The gate reads the `compliance_artifacts` table through `psql` and has no offline mode, so it is wired in the two places a database actually exists.

**`deploy.yml` — the blocking copy.** A new `compliance_gate` job sits between `preflight` and both service deploys, reading `secrets.DATABASE_URL` under `environment: production`. `deploy_api` and `deploy_web` now `needs: [preflight, compliance_gate]`. It deliberately does *not* live beside the existing `migrate` job — `migrate` runs after `deploy_api` has already shipped, which is too late for a gate whose failure message is "Deploy blocked."

**`ci.yml` — the early verdict.** A Gate 08 step following the Gate 05 precedent word for word: `DATABASE_URL: ${{ secrets.CI_GATE08_DATABASE_URL }}`, and a loud `::warning::Skipping Gate 08 (NOT VERIFIED)` when the secret is unset. A PR runner has no production database, so this is the honest shape — the unverified state is *visible in the CI log* rather than silently absent, and the gate starts blocking PRs the moment a CI-reachable database is armed.

## Local run — the gate's real output

Exercised end to end against a scratch postgres with migration 043 applied and then dropped.

Row present, `artifact_path` pointing at the whitepaper, `content_hash` = the file's real digest:

```
Checking compliance artifact: skill_contest_whitepaper
OK: 'skill_contest_whitepaper' version 1.0.0 — hash verified, no expiration

All compliance artifact checks passed. Deploy may proceed.
EXIT=0
```

Same database, table emptied:

```
Checking compliance artifact: skill_contest_whitepaper
FAIL: No active compliance artifact found for 'skill_contest_whitepaper'. Deploy blocked.
EXIT=1
```

The gate works. Both findings below come from that run.

## Finding 1 — the gate will FAIL on the production database today. That is correct, and it needs counsel.

Nothing in this repository ever inserts a row into `compliance_artifacts`. Migration 043 creates the table; `src/api/database/seed.sql` and `scripts/demo/*.sql` never touch it; no service method writes to it — `ComplianceArtifactService` is read-only (three `SELECT`s, no `INSERT`). So the production table is empty, and the second run above is exactly what the production DB will produce.

**I have not silenced this and I have not fabricated a row.** The columns the gate reads include `signed_by` and `signed_at`, whose own migration comments read *"Counsel or authority who signed off on this version"* and *"Must match the signature document."* Authoring a row means asserting that outside counsel signed a skill-contest whitepaper on a given date. That is not an artifact I can legitimately author — it is a counsel action, and inventing it would convert a working gate into a lie that passes.

**Consequence to be aware of before merging:** the next `v*` tag or manual production deploy will stop at `compliance_gate` until a real signed row exists. That is the gate performing its stated purpose. If the intent is to land the wiring without arming the block yet, revert the `deploy.yml` hunk only — the `ci.yml` hunk is inert until `CI_GATE08_DATABASE_URL` is set.

Unblocking it requires, in order: counsel signs a version of `docs/legal/legal--skill-based-contest-whitepaper.md`; that version, its `sha256sum`, its `artifact_path`, `signed_by`, `signed_at` and `jurisdictions` are inserted with `is_active = true`. No code change needed once the signature exists.

## Finding 2 — the `ARTIFACT_DIR` filename fallback can never resolve the default required type

When the database row carries no usable `artifact_path`, the gate falls back to scanning `ARTIFACT_DIR` (default `./docs/legal`) for a filename matching the artifact type:

```bash
if echo "$f" | grep -qi "${type}" 2>/dev/null; then
```

The default type is `skill_contest_whitepaper` (underscores). The real file is `docs/legal/legal--skill-based-contest-whitepaper.md` (hyphens, and "skill-based-contest" rather than "skill-contest"). `ls ./docs/legal | grep -i skill_contest_whitepaper` returns nothing — confirmed locally.

The failure mode is quiet rather than loud: with no file resolved, the gate prints `WARN: … artifact file not found on disk. Hash check skipped` and **still exits 0**. So a database row with a bad `artifact_path` and a wrong hash passes the gate silently. The `artifact_path` column is therefore load-bearing, not a convenience.

I left the script byte-identical. Changing a release gate's hash-resolution semantics is a separate change with its own blast radius, and it should not ride along in a wiring PR. Recording it here so it is not rediscovered.

## Second half — `/legal/compliance-artifacts`

A public register so the gate's claim can be checked from outside instead of taken on trust.

- `src/web/app/legal/compliance-artifacts/page.tsx` — server component, follows `legal/rules/page.tsx` exactly (same shell, `metadata` export, back-link, `Related Policies` block). Explains what blocks a release and what an unsigned artifact means.
- `src/web/components/legal/ComplianceArtifactTable.tsx` — client component. Renders the gated artifact set immediately (type + the source document the gate hashes), then fills in the **live** SHA-256, version, `signedBy`, `signedAt`, expiry and jurisdictions from `GET /compliance/artifacts` — the already-`@Public()` endpoint on `ComplianceController`, which returns `ComplianceArtifactService.getAllActiveArtifacts()`. Nothing new on the API side. Any active artifact the API returns that is *not* on the required list is rendered too, since a silently-added artifact is precisely what a public register exists to surface.
- `src/web/services/api-client.ts` — one new method, `getComplianceArtifacts()`, typed with the existing shared `ComplianceArtifactStatus`.

The `skill_contest_whitepaper` → `docs/legal/legal--skill-based-contest-whitepaper.md` mapping is written down in the component with a comment explaining why: per Finding 2 the mapping exists nowhere in the repo, and the page is the first place it is stated. A reader can now run `sha256sum` on the named document and compare it to the published digest, which reproduces what the gate does.

**Wiring proof** (`grep` over `src` and `scripts`, excluding `node_modules`/`.next`): the component is imported and rendered by the page; `/legal/compliance-artifacts` is linked from `SiteFooter.tsx` and from the `Related Policies` list of all four existing legal pages (terms, privacy, rules, responsible-use); and `scripts/smoke/check-endpoints.sh` now probes the route beside the other four legal pages.

## Verification

Scoped, from `src/web`:

```
npx jest app/legal/compliance-artifacts/page.test.tsx \
         components/legal/ComplianceArtifactTable.test.tsx \
         components/SiteFooter.test.tsx \
         services/api-client.test.ts \
         app/legal/terms/page.test.tsx \
         app/legal/rules/page.test.tsx
→ Test Suites: 6 passed, 6 total | Tests: 49 passed, 49 total

npx tsc --noEmit  → clean (this workspace's `npm run lint` IS `tsc --noEmit`)
```

Repo root:

```
npm run validate:claims  → Claim drift check passed (65 inline code references scanned)
bash -n scripts/smoke/check-endpoints.sh  → clean
python3 -c "yaml.safe_load(...)" on both workflows → parse, jobs enumerate as expected
```

Each exit code was read from the command itself, not through a pipe.

**Nothing here is proved by a green unit test that touches SQL.** No query was added or modified — the API side is untouched. The gate's own SQL was exercised for real against a live postgres, as shown above; the web tests mock `fetch` and prove routing and first-paint markup only. The first-paint assertion is deliberate: `renderToStaticMarkup` runs no effects, so the pre-fetch markup must read "Checking the live register…" and must not read "No active artifact recorded" — a register that renders "no artifact" while still loading would be worse than one that renders nothing.

No full build and no full suite were run, per the scoped-verification rule. No pre-existing failures were encountered on the specs touched.

## Summary by Sourcery

Wire the previously unused compliance artifact release gate into CI and production deploy workflows and expose a public web register for the gated legal artifacts.

New Features:
- Add a public /legal/compliance-artifacts page and table showing required compliance artifacts and their live hashes and signature metadata, sourced from the existing compliance artifacts API.

Enhancements:
- Extend the web API client with a getComplianceArtifacts() helper for consuming the compliance artifacts endpoint.
- Link the Compliance Artifact Register from the site footer and all existing legal policy pages, and include the route in smoke endpoint checks.

CI:
- Add Gate 08 compliance artifact validation to the CI workflow using an optional CI gate database secret, emitting a visible warning when not configured.

Deployment:
- Insert a blocking compliance_gate job into the production deploy workflow that runs the compliance artifact check against the production database before deploying API and web services.

Tests:
- Add unit tests covering the new compliance artifacts API client helper, the Compliance Artifact Register page and table, and the updated footer and legal page cross-links.