### PR TITLE
feat(dashboard): consume the leaderboard SSE stream and the progress endpoint

### DIFF
--- a/src/api/guards/auth.guard.spec.ts
+++ b/src/api/guards/auth.guard.spec.ts
@@ -2,6 +2,7 @@ import { AuthGuard } from './auth.guard';
 import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import * as jwt from 'jsonwebtoken';
 import { deriveApiKeyVerifier, deriveCsrfToken } from '../src/modules/auth/auth.service';
+import { issueSseTicket } from './sse-ticket.store';
 
 // Tokens must be signed with the same secret the guard verifies against. The
 // guard resolves it via getJwtSecret() which reads process.env.JWT_SECRET
@@ -13,9 +14,11 @@ function createMockContext(input?: {
   cookie?: string;
   method?: string;
   extraHeaders?: Record<string, string>;
+  originalUrl?: string;
 }): ExecutionContext {
   const request: any = {
     method: input?.method || 'GET',
+    originalUrl: input?.originalUrl,
     headers: {
       authorization: input?.authHeader,
       cookie: input?.cookie,
@@ -313,5 +316,47 @@ describe('AuthGuard', () => {
     const request = context.switchToHttp().getRequest() as any;
     expect(request.user.id).toBe('user-api-4');
     expect(request.authSource).toBe('api_key');
+  });
+
+  describe('SSE stream tickets', () => {
+    it('accepts a leaderboard ticket cookie on the leaderboard stream', () => {
+      const { ticket } = issueSseTicket('leaderboard-user', 'leaderboard');
+
+      const context = createMockContext({
+        originalUrl: '/dashboard/leaderboard/stream?limit=10&period=weekly',
+        cookie: `styx_leaderboard_sse_ticket=${ticket}`,
+      });
+
+      expect(guard.canActivate(context)).toBe(true);
+
+      const request = context.switchToHttp().getRequest() as any;
+      expect(request.user.id).toBe('leaderboard-user');
+      // AU9: a ticket principal never carries privilege.
+      expect(request.user.role).toBe('USER');
+    });
+
+    it('rejects a notifications ticket presented on the leaderboard stream', () => {
+      const { ticket } = issueSseTicket('cross-scope-user', 'notifications');
+
+      const context = createMockContext({
+        originalUrl: '/dashboard/leaderboard/stream',
+        cookie: `styx_leaderboard_sse_ticket=${ticket}`,
+      });
+
+      expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+    });
+
+    it('does not treat the leaderboard cookie as valid on the fury stream', () => {
+      const { ticket } = issueSseTicket('fury-target', 'leaderboard');
+
+      // The fury stream looks up its OWN cookie name, so a leaderboard cookie is
+      // simply absent there — it must not be picked up by a fallthrough.
+      const context = createMockContext({
+        originalUrl: '/fury/stream',
+        cookie: `styx_leaderboard_sse_ticket=${ticket}`,
+      });
+
+      expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+    });
   });
 });

--- a/src/api/guards/auth.guard.ts
+++ b/src/api/guards/auth.guard.ts
@@ -21,6 +21,34 @@ import { consumeSseTicket, SseTicketScope } from './sse-ticket.store';
 
 export const IS_PUBLIC_KEY = 'isPublic';
 
+interface SseStreamRoute {
+  pathSuffix: string;
+  scope: SseTicketScope;
+  cookieName: string;
+}
+
+// One table for every ticket-bearing SSE route. The previous two-scope form
+// derived the cookie name from a ternary, so any third scope would silently
+// have been looked up under the fury cookie — a lookup that fails open into
+// the query-param path rather than reporting the mistake.
+const SSE_STREAM_ROUTES: readonly SseStreamRoute[] = [
+  {
+    pathSuffix: '/notifications/stream',
+    scope: 'notifications',
+    cookieName: 'styx_notifications_sse_ticket',
+  },
+  {
+    pathSuffix: '/fury/stream',
+    scope: 'fury',
+    cookieName: 'styx_fury_sse_ticket',
+  },
+  {
+    pathSuffix: '/dashboard/leaderboard/stream',
+    scope: 'leaderboard',
+    cookieName: 'styx_leaderboard_sse_ticket',
+  },
+];
+
 @Injectable()
 export class AuthGuard implements CanActivate {
   constructor(
@@ -212,8 +240,8 @@ export class AuthGuard implements CanActivate {
   }
 
   private consumeSseTicketForRequest(request: Request): string | null {
-    const scope = this.getSseStreamScope(request);
-    if (!scope) {
+    const route = this.getSseStreamRoute(request);
+    if (!route) {
       return null;
     }
 
@@ -223,30 +251,21 @@ export class AuthGuard implements CanActivate {
     // the query param, which is retained because the EventSource clients that cannot
     // attach an Authorization header still rely on /…/stream-ticket. Single-use +
     // 60s TTL bounds the exposure of any leaked query-param ticket.
-    const cookieName = scope === 'notifications'
-      ? 'styx_notifications_sse_ticket'
-      : 'styx_fury_sse_ticket';
-    const cookieTicketPreferred = this.getCookieValue(request, cookieName);
+    const cookieTicketPreferred = this.getCookieValue(request, route.cookieName);
     if (cookieTicketPreferred) {
-      return consumeSseTicket(cookieTicketPreferred, scope);
+      return consumeSseTicket(cookieTicketPreferred, route.scope);
     }
 
     if (request.query && typeof request.query.ticket === 'string') {
-      return consumeSseTicket(request.query.ticket, scope);
+      return consumeSseTicket(request.query.ticket, route.scope);
     }
 
     return null;
   }
 
-  private getSseStreamScope(request: Request): SseTicketScope | null {
+  private getSseStreamRoute(request: Request): SseStreamRoute | null {
     const rawPath = (request.originalUrl || request.path || '').split('?')[0];
-    if (rawPath.endsWith('/notifications/stream')) {
-      return 'notifications';
-    }
-    if (rawPath.endsWith('/fury/stream')) {
-      return 'fury';
-    }
-    return null;
+    return SSE_STREAM_ROUTES.find((route) => rawPath.endsWith(route.pathSuffix)) ?? null;
   }
 
   private getCookieValue(request: Request, name: string): string | null {

--- a/src/api/guards/sse-ticket.store.spec.ts
+++ b/src/api/guards/sse-ticket.store.spec.ts
@@ -36,4 +36,12 @@ describe('sse-ticket.store', () => {
   it('returns null for an unknown ticket', () => {
     expect(consumeSseTicket('does-not-exist', 'fury')).toBeNull();
   });
+
+  it('keeps the leaderboard scope isolated from the other streams', () => {
+    const { ticket } = issueSseTicket('user-4', 'leaderboard');
+
+    expect(consumeSseTicket(ticket, 'notifications')).toBeNull();
+    expect(consumeSseTicket(ticket, 'fury')).toBeNull();
+    expect(consumeSseTicket(ticket, 'leaderboard')).toBe('user-4');
+  });
 });

--- a/src/api/guards/sse-ticket.store.ts
+++ b/src/api/guards/sse-ticket.store.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'crypto';
 
-export type SseTicketScope = 'notifications' | 'fury';
+export type SseTicketScope = 'notifications' | 'fury' | 'leaderboard';
 
 interface SseTicketRecord {
   userId: string;

--- a/src/api/src/modules/dashboard/dashboard.controller.spec.ts
+++ b/src/api/src/modules/dashboard/dashboard.controller.spec.ts
@@ -1,0 +1,138 @@
+import { firstValueFrom } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './dashboard.service';
+import { UsersService } from '../users/users.service';
+
+jest.mock('../../../guards/sse-ticket.store', () => ({
+  issueSseTicket: jest.fn().mockReturnValue({
+    ticket: 'leaderboard-ticket-abc',
+    expiresInSeconds: 60,
+  }),
+}));
+
+import { issueSseTicket } from '../../../guards/sse-ticket.store';
+
+describe('DashboardController', () => {
+  let controller: DashboardController;
+  let dashboardService: jest.Mocked<
+    Pick<DashboardService, 'getProgress' | 'getStreakChain' | 'getMetrics'>
+  >;
+  let usersService: jest.Mocked<Pick<UsersService, 'getLeaderboard'>>;
+
+  const user = { id: 'user-001' };
+
+  beforeEach(() => {
+    dashboardService = {
+      getProgress: jest.fn(),
+      getStreakChain: jest.fn(),
+      getMetrics: jest.fn(),
+    };
+    usersService = {
+      getLeaderboard: jest.fn(),
+    };
+    controller = new DashboardController(
+      dashboardService as unknown as DashboardService,
+      usersService as unknown as UsersService,
+    );
+    jest.clearAllMocks();
+    // Re-arm after clearAllMocks — jest.mock is hoisted above the assignment.
+    (issueSseTicket as jest.Mock).mockReturnValue({
+      ticket: 'leaderboard-ticket-abc',
+      expiresInSeconds: 60,
+    });
+  });
+
+  describe('getProgress', () => {
+    it('returns goal-gradient telemetry for the current user', async () => {
+      const progress = {
+        activeContracts: [
+          {
+            id: 'c-1',
+            oath_category: 'NO_CONTACT',
+            status: 'ACTIVE',
+            stake_amount: '25.00',
+            duration_days: 30,
+            started_at: '2026-08-01T00:00:00Z',
+            ends_at: '2026-08-31T00:00:00Z',
+            streak: '7',
+          },
+        ],
+        protectedVaultBalanceCents: 1500,
+        summary: { totalActiveStakeUsd: 25, longestStreak: 7 },
+      };
+      dashboardService.getProgress.mockResolvedValue(progress);
+
+      const result = await controller.getProgress(user);
+
+      expect(result).toEqual(progress);
+      expect(dashboardService.getProgress).toHaveBeenCalledWith('user-001');
+    });
+  });
+
+  describe('streamLeaderboard', () => {
+    it('emits the leaderboard rows on the first tick', async () => {
+      const rows = [
+        {
+          id: 'u-1',
+          email: 'a@styx.protocol',
+          integrity_score: 91,
+          created_at: '2026-01-01T00:00:00Z',
+        },
+      ];
+      usersService.getLeaderboard.mockResolvedValue(rows);
+
+      const event = await firstValueFrom(
+        controller.streamLeaderboard().pipe(take(1)),
+      );
+
+      expect(event).toEqual({ data: rows });
+    });
+
+    it('honors the period so a subscriber is not pinned to the all-time board', async () => {
+      usersService.getLeaderboard.mockResolvedValue([]);
+
+      await firstValueFrom(
+        controller.streamLeaderboard('5', 'weekly').pipe(take(1)),
+      );
+
+      expect(usersService.getLeaderboard).toHaveBeenCalledWith(5, 'weekly');
+    });
+
+    it('falls back to the default size for a missing or unusable limit', async () => {
+      usersService.getLeaderboard.mockResolvedValue([]);
+
+      await firstValueFrom(controller.streamLeaderboard().pipe(take(1)));
+      expect(usersService.getLeaderboard).toHaveBeenLastCalledWith(10, undefined);
+
+      await firstValueFrom(
+        controller.streamLeaderboard('not-a-number').pipe(take(1)),
+      );
+      expect(usersService.getLeaderboard).toHaveBeenLastCalledWith(10, undefined);
+
+      await firstValueFrom(controller.streamLeaderboard('0').pipe(take(1)));
+      expect(usersService.getLeaderboard).toHaveBeenLastCalledWith(10, undefined);
+    });
+  });
+
+  describe('issueLeaderboardStreamCookie', () => {
+    it('sets an HttpOnly cookie scoped to the stream path', () => {
+      const mockRes = { cookie: jest.fn() } as any;
+
+      const result = controller.issueLeaderboardStreamCookie(user, mockRes);
+
+      expect(result).toEqual({ expiresInSeconds: 60 });
+      expect(issueSseTicket).toHaveBeenCalledWith('user-001', 'leaderboard');
+      expect(mockRes.cookie).toHaveBeenCalledWith(
+        'styx_leaderboard_sse_ticket',
+        'leaderboard-ticket-abc',
+        expect.objectContaining({
+          httpOnly: true,
+          sameSite: 'lax',
+          path: '/dashboard/leaderboard/stream',
+          maxAge: 60000,
+        }),
+      );
+    });
+  });
+});

--- a/src/api/src/modules/dashboard/dashboard.controller.ts
+++ b/src/api/src/modules/dashboard/dashboard.controller.ts
@@ -1,11 +1,20 @@
-import { Controller, Get, UseGuards, Sse, MessageEvent } from '@nestjs/common';
+import { Controller, Get, Post, Query, Res, UseGuards, Sse, MessageEvent } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import type { Response } from 'express';
 import { Observable, timer } from 'rxjs';
 import { map, concatMap } from 'rxjs/operators';
 import { AuthGuard } from '../../../guards/auth.guard';
+import { issueSseTicket } from '../../../guards/sse-ticket.store';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { DashboardService } from './dashboard.service';
 import { UsersService } from '../users/users.service';
+
+const LEADERBOARD_STREAM_INTERVAL_MS = 30_000;
+const LEADERBOARD_STREAM_COOKIE = 'styx_leaderboard_sse_ticket';
+// Must match the suffix AuthGuard matches this stream on, so the browser only
+// ever attaches the ticket cookie to the stream request itself.
+const LEADERBOARD_STREAM_PATH = '/dashboard/leaderboard/stream';
+const LEADERBOARD_DEFAULT_LIMIT = 10;
 
 @ApiTags('Dashboard')
 @ApiBearerAuth()
@@ -37,11 +46,41 @@ export class DashboardController {
 
   @Sse('leaderboard/stream')
   @ApiOperation({ summary: 'Stream live leaderboard rank updates via SSE' })
-  streamLeaderboard(@CurrentUser() user: { id: string }): Observable<MessageEvent> {
-    return timer(0, 30000).pipe(
-      concatMap(() => this.usersService.getLeaderboard(10, 'all-time')),
+  streamLeaderboard(
+    @Query('limit') limit?: string,
+    @Query('period') period?: string,
+  ): Observable<MessageEvent> {
+    // The stream mirrors GET /users/leaderboard, so a subscriber that switches
+    // period gets the same rows it would have polled for — without the switch
+    // silently downgrading it to the hardcoded all-time board.
+    const parsedLimit = Number.parseInt(limit ?? '', 10);
+    const size = Number.isFinite(parsedLimit) && parsedLimit > 0
+      ? parsedLimit
+      : LEADERBOARD_DEFAULT_LIMIT;
+
+    return timer(0, LEADERBOARD_STREAM_INTERVAL_MS).pipe(
+      concatMap(() => this.usersService.getLeaderboard(size, period)),
       map((data) => ({ data } as MessageEvent)),
     );
   }
-}
 
+  // Cookie only, no query-string twin: EventSource cannot set an Authorization
+  // header, and a ticket in the URL leaks into proxy logs and Referer headers
+  // (AU8). Nothing in this repo consumes a leaderboard ticket any other way.
+  @Post('leaderboard/stream-cookie')
+  @ApiOperation({ summary: 'Issue a short-lived HttpOnly cookie for leaderboard SSE subscription' })
+  issueLeaderboardStreamCookie(
+    @CurrentUser() user: { id: string },
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const issued = issueSseTicket(user.id, 'leaderboard');
+    res.cookie(LEADERBOARD_STREAM_COOKIE, issued.ticket, {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      path: LEADERBOARD_STREAM_PATH,
+      maxAge: issued.expiresInSeconds * 1000,
+    });
+    return { expiresInSeconds: issued.expiresInSeconds };
+  }
+}

--- a/src/web/app/dashboard/page.test.tsx
+++ b/src/web/app/dashboard/page.test.tsx
@@ -1,5 +1,8 @@
+/** @jest-environment jsdom */
+
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
+import { render, screen, waitFor } from '@testing-library/react';
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
@@ -16,6 +19,7 @@ jest.mock('next/link', () => {
 });
 
 jest.mock('../../services/api-client', () => ({
+  ApiError: class ApiError extends Error {},
   api: {
     getBalance: jest.fn().mockResolvedValue({
       userId: '1',
@@ -28,6 +32,8 @@ jest.mock('../../services/api-client', () => ({
     getHistory: jest.fn().mockResolvedValue({ transactions: [] }),
     getUserContracts: jest.fn().mockResolvedValue([]),
     getLeaderboard: jest.fn().mockResolvedValue([]),
+    getStreakChain: jest.fn().mockResolvedValue(null),
+    getDashboardProgress: jest.fn().mockResolvedValue(null),
     getNotifications: jest.fn().mockResolvedValue([]),
     getUnreadCount: jest.fn().mockResolvedValue({ count: 0 }),
     issueNotificationStreamCookie: jest.fn(),
@@ -49,6 +55,37 @@ jest.mock('../../contexts/AuthContext', () => ({
 jest.mock('../../components/Leaderboard.css', () => ({}));
 
 import IdentityDashboard from './page';
+import { api } from '../../services/api-client';
+
+const mockApi = api as unknown as {
+  getUserContracts: jest.Mock;
+  getDashboardProgress: jest.Mock;
+};
+
+const ACTIVE_CONTRACT = {
+  id: 'c-1',
+  oath_category: 'NO_CONTACT',
+  stake_amount: '25.00',
+  status: 'ACTIVE',
+  ends_at: '2026-09-01T00:00:00Z',
+};
+
+const PROGRESS = {
+  activeContracts: [
+    {
+      id: 'c-1',
+      oath_category: 'NO_CONTACT',
+      status: 'ACTIVE',
+      stake_amount: '25.00',
+      duration_days: 30,
+      started_at: '2026-08-01T00:00:00Z',
+      ends_at: '2026-09-01T00:00:00Z',
+      streak: '9',
+    },
+  ],
+  protectedVaultBalanceCents: 1250,
+  summary: { totalActiveStakeUsd: 25, longestStreak: 9 },
+};
 
 describe('Dashboard Page', () => {
   it('renders the loading state initially', () => {
@@ -70,5 +107,40 @@ describe('Dashboard Page', () => {
     // These appear in the loading state because the header renders immediately
     // Actually the loading state is a separate branch. Let's verify the loading UI elements.
     expect(html).toContain('Loading Recovery Dashboard');
+  });
+
+  describe('goal gradient', () => {
+    beforeEach(() => {
+      mockApi.getUserContracts.mockResolvedValue([ACTIVE_CONTRACT]);
+      mockApi.getDashboardProgress.mockResolvedValue(PROGRESS);
+    });
+
+    afterEach(() => {
+      mockApi.getUserContracts.mockResolvedValue([]);
+      mockApi.getDashboardProgress.mockResolvedValue(null);
+    });
+
+    it('renders vault balance and per-contract completion from /dashboard/progress', async () => {
+      render(<IdentityDashboard />);
+
+      expect(await screen.findByText('GOAL GRADIENT')).toBeDefined();
+      expect(mockApi.getDashboardProgress).toHaveBeenCalled();
+      // 1250 cents of PROTECTED_VAULT hold — not derivable from the ledger balance.
+      expect(screen.getByText('TEST-$12.50')).toBeDefined();
+      // 9 attested days of a 30-day oath.
+      expect(screen.getByText(/9\/30 days/)).toBeDefined();
+      expect(screen.getByText(/30%/)).toBeDefined();
+      expect(screen.getByText(/Longest streak 9 days/)).toBeDefined();
+    });
+
+    it('omits the section — without breaking the page — when progress is unavailable', async () => {
+      mockApi.getDashboardProgress.mockRejectedValue(new Error('offline'));
+
+      render(<IdentityDashboard />);
+
+      expect(await screen.findByText('TRUTH LOG')).toBeDefined();
+      await waitFor(() => expect(mockApi.getDashboardProgress).toHaveBeenCalled());
+      expect(screen.queryByText('GOAL GRADIENT')).toBeNull();
+    });
   });
 });

--- a/src/web/app/dashboard/page.tsx
+++ b/src/web/app/dashboard/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import { Activity, ShieldCheck, Flame, History, User, Loader2, LogOut, Bell, Settings, ScrollText, HelpCircle } from 'lucide-react';
+import { Activity, ShieldCheck, Flame, History, User, Loader2, LogOut, Bell, Settings, ScrollText, HelpCircle, Target } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { api, ApiError } from '../../services/api-client';
+import { api, ApiError, DashboardProgress } from '../../services/api-client';
 import { useAuth } from '../../contexts/AuthContext';
 import Leaderboard from '../../components/Leaderboard';
 import NotificationPanel from '../../components/NotificationPanel';
@@ -45,6 +45,7 @@ export default function IdentityDashboard() {
   const [contracts, setContracts] = useState<Contract[]>([]);
   const [streakData, setStreakData] = useState<any>(null);
   const [streakLoading, setStreakLoading] = useState(true);
+  const [progress, setProgress] = useState<DashboardProgress | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const [showOnboarding, setShowOnboarding] = useState(false);
@@ -53,7 +54,7 @@ export default function IdentityDashboard() {
     if (authLoading || !authUser) return;
     async function load() {
       try {
-        const [balanceData, historyData, contractData, streakChain] = await Promise.all([
+        const [balanceData, historyData, contractData, streakChain, progressData] = await Promise.all([
           api.getBalance() as any,
           api.getHistory(10) as any,
           // A jurisdiction block is a deliberate product state, not an empty
@@ -66,11 +67,15 @@ export default function IdentityDashboard() {
             return [];
           }),
           api.getStreakChain().catch(() => null),
+          // Goal-gradient telemetry is a supplement, not a load-bearing panel:
+          // its failure must not blank the ledger the way a balance failure does.
+          api.getDashboardProgress().catch(() => null),
         ]);
         setBalance(balanceData);
         setTransactions(historyData.transactions);
         setContracts(contractData);
         if (streakChain) setStreakData(streakChain);
+        if (progressData) setProgress(progressData);
         if (contractData.length === 0) setShowOnboarding(true);
       } catch (err) {
         setError(err instanceof Error ? err : new Error('Failed to load dashboard'));
@@ -197,6 +202,62 @@ export default function IdentityDashboard() {
             penaltyMultiplier={streakData?.penaltyMultiplier ?? 1}
             loading={streakLoading}
           />
+
+          {/* Goal Gradient — how far each active oath has actually come, and the
+              vault those days are filling.  Neither number is derivable from what
+              the rest of this page loads: /contracts carries no attestation count
+              and /balance is the spendable ledger, not the PROTECTED_VAULT hold. */}
+          {progress && (progress.activeContracts.length > 0 || progress.protectedVaultBalanceCents > 0) && (
+            <div className="p-8 bg-neutral-900 border border-neutral-800 rounded-3xl">
+              <div className="flex items-center gap-3 mb-6">
+                <Target className="text-neutral-500" size={20} />
+                <h2 className="text-neutral-500 font-bold tracking-widest text-sm">GOAL GRADIENT</h2>
+              </div>
+
+              <div className="mb-6">
+                <p className="text-xs text-neutral-500 uppercase tracking-widest mb-1">Protected Vault</p>
+                <p className="text-3xl font-black text-white">
+                  TEST-${(progress.protectedVaultBalanceCents / 100).toFixed(2)}
+                </p>
+              </div>
+
+              {progress.activeContracts.length === 0 ? (
+                <p className="text-neutral-500 text-sm">No active oath in progress.</p>
+              ) : (
+                <div className="space-y-4">
+                  {progress.activeContracts.map((c) => {
+                    const totalDays = Number(c.duration_days) || 0;
+                    const attestedDays = Number(c.streak) || 0;
+                    const pct = totalDays > 0
+                      ? Math.min(100, Math.round((attestedDays / totalDays) * 100))
+                      : 0;
+                    return (
+                      <div key={c.id}>
+                        <div className="flex justify-between items-baseline mb-1">
+                          <span className="text-sm font-bold">
+                            {(c.oath_category || 'CONTRACT').replace(/_/g, ' ')}
+                          </span>
+                          <span className="text-xs text-neutral-500">
+                            {attestedDays}/{totalDays} days &bull; {pct}%
+                          </span>
+                        </div>
+                        <div className="h-2 bg-black rounded-full overflow-hidden border border-neutral-800">
+                          <div
+                            className="h-full bg-red-600 rounded-full transition-all duration-500"
+                            style={{ width: `${pct}%` }}
+                          />
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+
+              <p className="text-[10px] text-neutral-600 uppercase tracking-widest mt-6">
+                Longest streak {progress.summary.longestStreak} days
+              </p>
+            </div>
+          )}
 
           {/* Leaderboard hidden in Phase 1 Beta */}
           {/* <Leaderboard /> */}

--- a/src/web/components/Leaderboard.test.tsx
+++ b/src/web/components/Leaderboard.test.tsx
@@ -1,42 +1,190 @@
+/** @jest-environment jsdom */
+
 import React from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
+import { act, render, screen, waitFor } from '@testing-library/react';
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  url: string;
+  withCredentials: boolean;
+  closed = false;
+
+  constructor(url: string, init?: { withCredentials?: boolean }) {
+    this.url = url;
+    this.withCredentials = init?.withCredentials ?? false;
+    MockEventSource.instances.push(this);
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  simulateOpen() {
+    this.onopen?.();
+  }
+
+  simulateMessage(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) });
+  }
+
+  simulateError() {
+    this.onerror?.();
+  }
+}
 
 jest.mock('../services/api-client', () => ({
   api: {
     getLeaderboard: jest.fn().mockResolvedValue([]),
+    issueLeaderboardStreamCookie: jest.fn().mockResolvedValue({ expiresInSeconds: 60 }),
   },
+  getAuthToken: jest.fn().mockReturnValue('session-token'),
 }));
 
 jest.mock('./Leaderboard.css', () => ({}));
 
 import Leaderboard from './Leaderboard';
+import { api, getAuthToken } from '../services/api-client';
+
+const mockApi = api as unknown as {
+  getLeaderboard: jest.Mock;
+  issueLeaderboardStreamCookie: jest.Mock;
+};
+const mockGetAuthToken = getAuthToken as unknown as jest.Mock;
+
+const ROW = {
+  id: 'u-1',
+  email: 'valkyrie@styx.protocol',
+  integrity_score: 93,
+  created_at: '2026-01-02T00:00:00Z',
+};
 
 describe('Leaderboard', () => {
-  it('renders the component with the header', () => {
-    const html = renderToStaticMarkup(<Leaderboard />);
-
-    expect(html).toContain('Tavern Board');
+  beforeEach(() => {
+    jest.clearAllMocks();
+    MockEventSource.instances = [];
+    (global as any).EventSource = MockEventSource;
+    mockApi.getLeaderboard.mockResolvedValue([]);
+    mockApi.issueLeaderboardStreamCookie.mockResolvedValue({ expiresInSeconds: 60 });
+    mockGetAuthToken.mockReturnValue('session-token');
   });
 
-  it('renders period filter buttons', () => {
-    const html = renderToStaticMarkup(<Leaderboard />);
-
-    expect(html).toContain('weekly');
-    expect(html).toContain('monthly');
-    expect(html).toContain('All Time');
+  afterEach(() => {
+    delete (global as any).EventSource;
   });
 
-  it('shows loading spinner on initial render', () => {
-    const html = renderToStaticMarkup(<Leaderboard />);
+  it('renders the header and the period filters', async () => {
+    render(<Leaderboard />);
 
-    // Initial state has loading=true which renders a spinner div
-    expect(html).toContain('animate-spin');
+    expect(screen.getByText(/Tavern Board/)).toBeDefined();
+    expect(screen.getByText('weekly')).toBeDefined();
+    expect(screen.getByText('monthly')).toBeDefined();
+    expect(screen.getByText('All Time')).toBeDefined();
+
+    await waitFor(() => expect(mockApi.getLeaderboard).toHaveBeenCalled());
   });
 
-  it('renders the alltime period as selected by default', () => {
-    const html = renderToStaticMarkup(<Leaderboard />);
+  it('opens an SSE subscription after issuing the stream cookie', async () => {
+    render(<Leaderboard />);
 
-    // The alltime button should have active styling (red)
-    expect(html).toContain('All Time');
+    await waitFor(() => expect(MockEventSource.instances).toHaveLength(1));
+
+    expect(mockApi.issueLeaderboardStreamCookie).toHaveBeenCalled();
+    const source = MockEventSource.instances[0];
+    expect(source.url).toBe('/api/dashboard/leaderboard/stream?limit=10');
+    expect(source.withCredentials).toBe(true);
+  });
+
+  it('renders rows pushed over the stream', async () => {
+    render(<Leaderboard />);
+
+    await waitFor(() => expect(MockEventSource.instances).toHaveLength(1));
+
+    await act(async () => {
+      MockEventSource.instances[0].simulateMessage([ROW]);
+    });
+
+    // The name appears twice: the ranked row and the Fury of the Week spotlight.
+    expect(screen.getAllByText('valkyrie')).toHaveLength(2);
+    expect(screen.getByText('Fury of the Week')).toBeDefined();
+  });
+
+  it('ignores a malformed stream message instead of blanking the board', async () => {
+    render(<Leaderboard />);
+
+    await waitFor(() => expect(MockEventSource.instances).toHaveLength(1));
+
+    await act(async () => {
+      MockEventSource.instances[0].simulateMessage([ROW]);
+    });
+    await act(async () => {
+      MockEventSource.instances[0].onmessage?.({ data: 'not-json' });
+      MockEventSource.instances[0].simulateMessage({ notAnArray: true });
+    });
+
+    expect(screen.getAllByText('valkyrie').length).toBeGreaterThan(0);
+  });
+
+  it('falls back to polling when the stream errors', async () => {
+    jest.useFakeTimers();
+    try {
+      render(<Leaderboard />);
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const source = MockEventSource.instances[0];
+      expect(source).toBeDefined();
+
+      mockApi.getLeaderboard.mockResolvedValue([ROW]);
+      const callsBeforeError = mockApi.getLeaderboard.mock.calls.length;
+
+      await act(async () => {
+        source.simulateError();
+      });
+      expect(source.closed).toBe(true);
+
+      await act(async () => {
+        jest.advanceTimersByTime(30000);
+      });
+
+      expect(mockApi.getLeaderboard.mock.calls.length).toBeGreaterThan(callsBeforeError);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('polls without opening a stream when there is no session token', async () => {
+    mockGetAuthToken.mockReturnValue('');
+
+    render(<Leaderboard />);
+
+    await waitFor(() => expect(mockApi.getLeaderboard).toHaveBeenCalled());
+    expect(MockEventSource.instances).toHaveLength(0);
+    expect(mockApi.issueLeaderboardStreamCookie).not.toHaveBeenCalled();
+  });
+
+  it('polls without opening a stream when EventSource is unavailable', async () => {
+    delete (global as any).EventSource;
+
+    render(<Leaderboard />);
+
+    await waitFor(() => expect(mockApi.getLeaderboard).toHaveBeenCalled());
+    expect(mockApi.issueLeaderboardStreamCookie).not.toHaveBeenCalled();
+  });
+
+  it('closes the stream on unmount', async () => {
+    const { unmount } = render(<Leaderboard />);
+
+    await waitFor(() => expect(MockEventSource.instances).toHaveLength(1));
+    const source = MockEventSource.instances[0];
+
+    unmount();
+
+    expect(source.closed).toBe(true);
   });
 });

--- a/src/web/components/Leaderboard.tsx
+++ b/src/web/components/Leaderboard.tsx
@@ -1,10 +1,15 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
-import { api, LeaderboardEntry } from '../services/api-client';
+import React, { useCallback, useEffect, useState } from 'react';
+import { api, getAuthToken, LeaderboardEntry } from '../services/api-client';
 import './Leaderboard.css';
 
 type Period = 'weekly' | 'monthly' | 'alltime';
+
+const BOARD_SIZE = 10;
+// Matches the server's SSE tick, so the fallback path is no staler than the stream.
+const POLL_INTERVAL_MS = 30000;
+const SSE_RECONNECT_MS = 5000;
 
 interface TierInfo {
   name: string;
@@ -41,17 +46,120 @@ export default function Leaderboard() {
   const [period, setPeriod] = useState<Period>('alltime');
   const [furyOfWeek, setFuryOfWeek] = useState<LeaderboardEntry | null>(null);
 
+  const applyBoard = useCallback((data: LeaderboardEntry[]) => {
+    setLeaders(data);
+    // Fury of the Week = highest integrity score (first in sorted list)
+    if (data.length > 0) setFuryOfWeek(data[0]);
+  }, []);
+
   useEffect(() => {
     setLoading(true);
-    api.getLeaderboard(10, period === 'alltime' ? undefined : period)
-      .then((data) => {
-        setLeaders(data);
-        // Fury of the Week = highest integrity score (first in sorted list)
-        if (data.length > 0) setFuryOfWeek(data[0]);
-      })
-      .catch(() => setLeaders([]))
-      .finally(() => setLoading(false));
-  }, [period]);
+
+    // Route through the Next.js /api rewrite so the SSE request is same-origin
+    // and carries the HttpOnly stream ticket cookie.
+    const API_BASE = '/api';
+    const apiPeriod = period === 'alltime' ? undefined : period;
+    let eventSource: EventSource | null = null;
+    let pollInterval: ReturnType<typeof setInterval> | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let stopped = false;
+
+    const loadBoard = async () => {
+      try {
+        const data = await api.getLeaderboard(BOARD_SIZE, apiPeriod);
+        if (stopped) return;
+        applyBoard(data);
+      } catch {
+        if (!stopped) setLeaders([]);
+      } finally {
+        if (!stopped) setLoading(false);
+      }
+    };
+
+    const startPolling = () => {
+      if (pollInterval) return;
+      pollInterval = setInterval(() => {
+        void loadBoard();
+      }, POLL_INTERVAL_MS);
+    };
+
+    const stopPolling = () => {
+      if (!pollInterval) return;
+      clearInterval(pollInterval);
+      pollInterval = null;
+    };
+
+    const scheduleReconnect = () => {
+      if (stopped || reconnectTimer) return;
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        void connectStream();
+      }, SSE_RECONNECT_MS);
+    };
+
+    const connectStream = async () => {
+      if (stopped) return;
+
+      // The stream is guarded; an anonymous viewer and any runtime without
+      // EventSource (SSR, older embedded webviews) stay on the polling path.
+      const token = getAuthToken(); // allow-secret
+      if (!token || typeof EventSource === 'undefined') {
+        startPolling();
+        return;
+      }
+
+      try {
+        await api.issueLeaderboardStreamCookie();
+        if (stopped) return;
+
+        const params = new URLSearchParams({ limit: String(BOARD_SIZE) });
+        if (apiPeriod) params.set('period', apiPeriod);
+
+        const source = new EventSource(
+          `${API_BASE}/dashboard/leaderboard/stream?${params.toString()}`,
+          { withCredentials: true },
+        );
+        eventSource = source;
+
+        source.onopen = () => {
+          stopPolling();
+        };
+
+        source.onmessage = (event) => {
+          try {
+            const data = JSON.parse(event.data);
+            if (!Array.isArray(data)) return;
+            applyBoard(data as LeaderboardEntry[]);
+            setLoading(false);
+          } catch {
+            // Invalid message — ignore
+          }
+        };
+
+        source.onerror = () => {
+          source.close();
+          if (eventSource === source) {
+            eventSource = null;
+          }
+          startPolling();
+          scheduleReconnect();
+        };
+      } catch {
+        // SSE not available — use polling
+        startPolling();
+      }
+    };
+
+    void loadBoard();
+    void connectStream();
+
+    return () => {
+      stopped = true;
+      eventSource?.close();
+      stopPolling();
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+    };
+  }, [period, applyBoard]);
 
   return (
     <div className="bg-black border border-gray-800 p-6 rounded-lg text-white">

--- a/src/web/services/api-client.ts
+++ b/src/web/services/api-client.ts
@@ -298,6 +298,31 @@ export interface ContractDangerStatus {
   recommendations: ProtectionRecommendation[];
 }
 
+/**
+ * One ACTIVE contract as GET /dashboard/progress reports it. `stake_amount` and
+ * `streak` arrive as strings: Postgres serializes NUMERIC and COUNT(*) (BIGINT)
+ * as text to preserve precision the JSON number type would lose.
+ */
+export interface ActiveContractProgress {
+  id: string;
+  oath_category: string;
+  status: string;
+  stake_amount: string;
+  duration_days: number;
+  started_at: string;
+  ends_at: string;
+  streak: string;
+}
+
+export interface DashboardProgress {
+  activeContracts: ActiveContractProgress[];
+  protectedVaultBalanceCents: number;
+  summary: {
+    totalActiveStakeUsd: number;
+    longestStreak: number;
+  };
+}
+
 export const api = {
   health: () => request<{ status: string }>("/health"),
   getMobileBootstrap: () =>
@@ -825,6 +850,19 @@ export const api = {
       totalRewardCents: number;
       rewards: ReferralReward[];
     }>("/referrals/rewards"),
+
+  issueLeaderboardStreamCookie: () =>
+    request<{ expiresInSeconds: number }>(
+      "/dashboard/leaderboard/stream-cookie",
+      {
+        method: "POST",
+        credentials: "include",
+      },
+    ),
+
+  // Goal gradient
+  getDashboardProgress: () =>
+    request<DashboardProgress>("/dashboard/progress"),
 
   // Streak Chain
   getStreakChain: () =>


### PR DESCRIPTION
## TKT-P1-018 — live-but-unconsumed leaderboard stream + dashboard progress

Two endpoints were live, guarded, and reached by nothing. Both are now consumed.

### 1. `@Sse('leaderboard/stream')` → `Leaderboard.tsx`

The SSE endpoint had **zero** `EventSource` consumers while the component fetched once per period change and never refreshed. It now uses the proven `NotificationPanel.tsx` transport, step for step:

- `api.issueLeaderboardStreamCookie()` first, then `new EventSource(url, { withCredentials: true })`
- `onopen` stops polling; `onerror` closes, restarts polling, and schedules a 5s reconnect
- polling stays the fallback for: SSE error, **no session token**, and **no `EventSource` in the runtime**
- full teardown (`stopped` flag, close, clear interval + reconnect timer) on unmount and on period change

**Transport bug found while wiring it:** the stream hardcoded `getLeaderboard(10, 'all-time')`. A subscriber switching to weekly/monthly would have been silently pinned to the all-time board — the filter would appear to work while the stream fed the wrong rows. It now reads `limit` and `period`, mirroring `GET /users/leaderboard`.

### 2. Ticket plumbing

`SseTicketScope` gains `'leaderboard'`, and `AuthGuard`'s path → scope → cookie mapping moves from a two-branch ternary to one table. The ternary derived the cookie name as `scope === 'notifications' ? … : fury`, so any third scope would have looked itself up under the **fury** cookie — finding nothing and failing open to the query-param path rather than reporting the mistake.

Only a `stream-cookie` route was added — **no query-string ticket twin**. Nothing in the repo consumes a leaderboard ticket that way, and a ticket in a URL leaks into proxy logs, history, and `Referer` (the AU8 note already in the guard). The existing `stream-ticket` routes on notifications/fury are untouched.

### 3. `GET /dashboard/progress` → Goal Gradient panel

Consumed on `src/web/app/dashboard/page.tsx`. **Not redundant with what the page already fetches:**

| Field | Why nothing else supplies it |
|---|---|
| per-contract `streak` | `GET /contracts` returns no attestation count, so per-oath completion (`streak`/`duration_days`) was not derivable client-side |
| `protectedVaultBalanceCents` | `/balance` is the spendable ledger balance; this is the `PROTECTED_VAULT` hold, a different account |

The fetch is failure-tolerant (`.catch(() => null)`) — the panel disappears rather than blanking the ledger, which is what an un-caught failure in that `Promise.all` would have done.

### 4. Scope lock — untouched

`{/* <Leaderboard /> */}` on the dashboard **stays commented out**. This PR changes the transport, not the Phase-1 beta exposure.

### What I did NOT verify

**No SQL was changed, and nothing here is evidence about queries.** The new `DashboardController` spec mocks `UsersService` and `DashboardService` outright, as every spec in this repo mocks the pg Pool. `getProgress` and `getLeaderboard` SQL is untouched and still unexercised against a real Postgres — including the `protectedVaultBalanceCents` and `streak` columns the new panel renders.

The cookie is set with `path: /dashboard/leaderboard/stream` while the browser requests it through the Next `/api` rewrite, so in the deployed shape the request authenticates on the session cookie and the ticket cookie is belt-and-braces. That mismatch is pre-existing and identical for notifications and fury; I matched the pattern rather than diverging from it here.

### Verification (scoped; exit codes read bare, not through a pipe)

```
src/api $ npx jest src/modules/dashboard guards
          -> 9 suites, 78 tests passed
src/api $ npx tsc --noEmit                       -> exit 0
src/web $ npx jest components/Leaderboard.test.tsx \
            app/dashboard/page.test.tsx components/NotificationPanel.test.tsx
          -> 3 suites, 17 tests passed
src/web $ npx tsc --noEmit                       -> exit 0
```

Also re-ran `src/api $ npx jest src/modules/fury src/modules/users guards` (24 suites, 209 tests passed) because `AuthGuard` is shared.

### Specs added

- `src/api/src/modules/dashboard/dashboard.controller.spec.ts` (new) — progress delegation, first-tick emission, period/limit pass-through, limit fallbacks, cookie attributes
- `src/api/guards/auth.guard.spec.ts` — leaderboard cookie accepted on its own stream; a notifications ticket in the leaderboard cookie is rejected; a leaderboard cookie is not honored on `/fury/stream`
- `src/api/guards/sse-ticket.store.spec.ts` — leaderboard scope isolation
- `src/web/components/Leaderboard.test.tsx` — rewritten to jsdom + `MockEventSource`: stream URL/credentials, rows rendered from a pushed message, malformed messages ignored, poll fallback on error, no stream without a token or without `EventSource`, close on unmount
- `src/web/app/dashboard/page.test.tsx` — Goal Gradient renders vault + completion; hidden without breaking the page when progress fails

## Summary by Sourcery

Integrate the dashboard leaderboard SSE stream and progress endpoint into the web app while tightening SSE ticket handling and adding coverage.

New Features:
- Consume the dashboard leaderboard SSE stream in the Leaderboard component with live updates and polling fallback.
- Display a Goal Gradient panel on the dashboard using data from the new /dashboard/progress API.

Bug Fixes:
- Ensure the leaderboard SSE stream respects client-provided limit and period instead of always streaming the all-time board.
- Prevent cross-scope misuse of SSE tickets by isolating the new leaderboard scope and mapping cookies per-stream path.

Enhancements:
- Refine AuthGuard SSE handling with a centralized route-to-scope-and-cookie mapping for all ticketed streams.
- Extend the web API client with leaderboard stream cookie issuance and dashboard progress retrieval helpers.

Tests:
- Expand frontend tests for the Leaderboard to cover SSE behavior, fallbacks, and teardown, and add tests for the dashboard Goal Gradient panel.
- Add backend tests for DashboardController leaderboard and progress endpoints, AuthGuard SSE ticket behavior, and leaderboard scope isolation in the SSE ticket store.