### PR TITLE
fix(fury): a Fury who WINS an appeal now gets the slashed money back

### DIFF
--- a/src/api/database/migrations/069_fury_penalty_ledger_link.sql
+++ b/src/api/database/migrations/069_fury_penalty_ledger_link.sql
@@ -1,0 +1,26 @@
+-- Migration 069: link a Fury penalty to the ledger transaction that charged it.
+--
+-- fury_penalties has carried a `reversed_at` column since migration 021, but no
+-- code ever set it: resolveAppeal's REVERSED branch DELETEd the row instead, and
+-- the money never came back at all. The honeypot slash is posted in
+-- fury.worker.ts via ledger.recordTransaction, entirely outside the case system,
+-- so the appeal flow had nothing to point at even if it had tried to compensate.
+--
+-- These columns are that pointer. A reversal needs the transaction it is
+-- compensating and the account to credit back; without both, "reverse the
+-- penalty" cannot mean anything more than deleting a bookkeeping row.
+
+ALTER TABLE fury_penalties
+  ADD COLUMN IF NOT EXISTS ledger_transaction_id UUID,
+  ADD COLUMN IF NOT EXISTS ledger_debit_account_id UUID,
+  ADD COLUMN IF NOT EXISTS reversal_transaction_id UUID;
+
+CREATE INDEX IF NOT EXISTS idx_fury_penalties_ledger_txn
+  ON fury_penalties(ledger_transaction_id);
+
+COMMENT ON COLUMN fury_penalties.ledger_transaction_id IS
+  'The ledger transaction that took the money. NULL for non-financial penalties (REP_BURN).';
+COMMENT ON COLUMN fury_penalties.ledger_debit_account_id IS
+  'The account the money was taken FROM — the account a reversal credits back.';
+COMMENT ON COLUMN fury_penalties.reversal_transaction_id IS
+  'Set when an appeal is REVERSED and the compensating entry is posted. Its presence is what makes the reversal idempotent.';

--- a/src/api/src/modules/fury/enforcement.controller.spec.ts
+++ b/src/api/src/modules/fury/enforcement.controller.spec.ts
@@ -63,7 +63,11 @@ describe('EnforcementController', () => {
 
       const result = await controller.confirm('case-1', {});
 
-      expect(enforcementService.confirmCase).toHaveBeenCalledWith('case-1', 'REP_BURN', 0);
+      // A missing amount must reach the service AS MISSING. The controller used
+      // to coerce it with `dto.amountCents || 0`, which turned an omitted amount
+      // into a free STAKE_SLASH; the service now derives the real amount (or
+      // rejects a non-positive one) and can only do that if it sees undefined.
+      expect(enforcementService.confirmCase).toHaveBeenCalledWith('case-1', 'REP_BURN', undefined);
       expect(result.status).toBe('PENALTY_APPLIED');
     });
 

--- a/src/api/src/modules/fury/enforcement.controller.ts
+++ b/src/api/src/modules/fury/enforcement.controller.ts
@@ -27,10 +27,13 @@ export class EnforcementController {
     @Param('caseId') caseId: string,
     @Body() dto: { penaltyType?: string; amountCents?: number },
   ) {
+    // `dto.amountCents || 0` silently turned a missing or malformed amount into a
+    // free penalty. A financial penalty type now requires a real amount; the
+    // service derives the default from the auditor stake rather than guessing 0.
     return this.enforcementService.confirmCase(
       caseId,
       dto.penaltyType || 'REP_BURN',
-      dto.amountCents || 0,
+      dto.amountCents,
     );
   }
 

--- a/src/api/src/modules/fury/enforcement.service.spec.ts
+++ b/src/api/src/modules/fury/enforcement.service.spec.ts
@@ -1,18 +1,22 @@
 import { EnforcementService } from './enforcement.service';
 import { TruthLogService } from '../../../services/ledger/truth-log.service';
+import { LedgerService } from '../../../services/ledger/ledger.service';
 import { Pool } from 'pg';
 
 describe('EnforcementService', () => {
   let service: EnforcementService;
   let mockPool: { query: jest.Mock };
   let mockTruthLog: { appendEvent: jest.Mock };
+  let mockLedger: { recordTransaction: jest.Mock };
 
   beforeEach(() => {
     mockPool = { query: jest.fn() };
     mockTruthLog = { appendEvent: jest.fn().mockResolvedValue('log-id') };
+    mockLedger = { recordTransaction: jest.fn().mockResolvedValue('txn-reversal-1') };
     service = new EnforcementService(
       mockPool as unknown as Pool,
       mockTruthLog as unknown as TruthLogService,
+      mockLedger as unknown as LedgerService,
     );
     jest.clearAllMocks();
   });
@@ -57,6 +61,28 @@ describe('EnforcementService', () => {
 
       await expect(service.confirmCase('case-x')).rejects.toThrow('Pending case not found');
     });
+
+    // `dto.amountCents || 0` in the controller turned a missing amount into a
+    // free STAKE_SLASH: the case read as punished while nothing was taken.
+    it('derives a financial penalty amount instead of silently applying $0', async () => {
+      mockPool.query
+        .mockResolvedValueOnce({ rows: [{ id: 'case-1' }] })   // claim
+        .mockResolvedValueOnce({ rows: [{ id: 'penalty-1' }] }) // insert penalty
+        .mockResolvedValueOnce({ rows: [] })                    // update case
+        .mockResolvedValueOnce({ rows: [{ reviewer_id: 'fury-1' }] });
+
+      const result = await service.confirmCase('case-1', 'STAKE_SLASH');
+
+      expect(result.amountCents).toBeGreaterThan(0);
+    });
+
+    it('refuses an explicit non-positive amount on a financial penalty', async () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [{ id: 'case-1' }] });
+
+      await expect(service.confirmCase('case-1', 'STAKE_SLASH', 0)).rejects.toThrow(
+        /requires a positive amountCents/,
+      );
+    });
   });
 
   describe('resolveAppeal', () => {
@@ -74,19 +100,94 @@ describe('EnforcementService', () => {
       );
     });
 
-    it('resolves an appeal as REVERSED and removes penalty', async () => {
-      mockPool.query.mockResolvedValueOnce({
-        rows: [{ id: 'case-1', reviewer_id: 'fury-1' }],
-      });
-      mockPool.query.mockResolvedValueOnce({ rowCount: 1 }); // DELETE penalty
+    // This test used to assert `DELETE FROM fury_penalties` and was named
+    // "removes penalty" — it enshrined the defect. Deleting the bookkeeping row
+    // was the whole reversal, while fury.worker.ts had already charged real money
+    // through the ledger, so a Fury who WON an appeal stayed slashed.
+    it('resolves an appeal as REVERSED and REFUNDS the slashed money', async () => {
+      mockPool.query
+        // claim UPDATE ... RETURNING id, reviewer_id
+        .mockResolvedValueOnce({ rows: [{ id: 'case-1', reviewer_id: 'fury-1' }] })
+        // SELECT the penalty row — carries the ledger leg written at slash time
+        .mockResolvedValueOnce({
+          rows: [{
+            id: 'penalty-1',
+            amount_cents: 500,
+            ledger_transaction_id: 'txn-slash-1',
+            ledger_debit_account_id: 'acct-fury-1',
+            reversal_transaction_id: null,
+          }],
+        })
+        // SELECT SYSTEM_REVENUE
+        .mockResolvedValueOnce({ rows: [{ id: 'acct-revenue' }] })
+        // UPDATE fury_penalties SET reversed_at, reversal_transaction_id
+        .mockResolvedValueOnce({ rows: [] });
 
       const result = await service.resolveAppeal('case-1', 'REVERSED');
 
       expect(result.outcome).toBe('REVERSED');
-      expect(mockPool.query).toHaveBeenCalledWith(
-        expect.stringContaining('DELETE FROM fury_penalties'),
-        ['case-1'],
+      expect(result.refundedCents).toBe(500);
+      // Compensating entry: revenue pays the reviewer back, same amount.
+      expect(mockLedger.recordTransaction).toHaveBeenCalledWith(
+        'acct-revenue',
+        'acct-fury-1',
+        500,
+        undefined,
+        expect.objectContaining({
+          type: 'FURY_PENALTY_REVERSAL',
+          reversesTransactionId: 'txn-slash-1',
+        }),
+        undefined,
+        'fury-appeal-reversal:case-1',
       );
+      // The original charge is NOT deleted — a ledger records what happened.
+      const sqlIssued = mockPool.query.mock.calls.map((c: any[]) => String(c[0]));
+      expect(sqlIssued.some((sql) => /DELETE FROM fury_penalties/.test(sql))).toBe(false);
+      expect(sqlIssued.some((sql) => /reversal_transaction_id = \$2/.test(sql))).toBe(true);
+      expect(mockTruthLog.appendEvent).toHaveBeenCalledWith(
+        'FURY_PENALTY_REVERSED',
+        expect.objectContaining({ amountCents: 500, reversalTransactionId: 'txn-reversal-1' }),
+      );
+    });
+
+    it('never refunds twice — an already-reversed penalty moves no money', async () => {
+      mockPool.query
+        .mockResolvedValueOnce({ rows: [{ id: 'case-1', reviewer_id: 'fury-1' }] })
+        .mockResolvedValueOnce({
+          rows: [{
+            id: 'penalty-1',
+            amount_cents: 500,
+            ledger_transaction_id: 'txn-slash-1',
+            ledger_debit_account_id: 'acct-fury-1',
+            reversal_transaction_id: 'txn-reversal-earlier',
+          }],
+        });
+
+      const result = await service.resolveAppeal('case-1', 'REVERSED');
+
+      expect(result.refundedCents).toBe(500);
+      expect(mockLedger.recordTransaction).not.toHaveBeenCalled();
+    });
+
+    it('reverses a non-financial penalty without touching the ledger', async () => {
+      mockPool.query
+        .mockResolvedValueOnce({ rows: [{ id: 'case-1', reviewer_id: 'fury-1' }] })
+        // REP_BURN: no ledger leg to undo
+        .mockResolvedValueOnce({
+          rows: [{
+            id: 'penalty-1',
+            amount_cents: 0,
+            ledger_transaction_id: null,
+            ledger_debit_account_id: null,
+            reversal_transaction_id: null,
+          }],
+        })
+        .mockResolvedValueOnce({ rows: [] }); // UPDATE reversed_at
+
+      const result = await service.resolveAppeal('case-1', 'REVERSED');
+
+      expect(result.refundedCents).toBe(0);
+      expect(mockLedger.recordTransaction).not.toHaveBeenCalled();
     });
 
     it('throws on invalid outcome', async () => {

--- a/src/api/src/modules/fury/enforcement.service.ts
+++ b/src/api/src/modules/fury/enforcement.service.ts
@@ -1,6 +1,11 @@
 import { Injectable, Logger, NotFoundException, BadRequestException } from '@nestjs/common';
 import { Pool } from 'pg';
 import { TruthLogService } from '../../../services/ledger/truth-log.service';
+import { LedgerService } from '../../../services/ledger/ledger.service';
+import { AUDITOR_STAKE_AMOUNT } from '../../../../shared/libs/integrity';
+
+/** Penalty types that move money, and therefore need a real amount and a reversible ledger leg. */
+const FINANCIAL_PENALTY_TYPES = new Set(['STAKE_SLASH']);
 
 @Injectable()
 export class EnforcementService {
@@ -9,6 +14,10 @@ export class EnforcementService {
   constructor(
     private readonly pool: Pool,
     private readonly truthLog: TruthLogService,
+    // A penalty that took money can only be undone by moving money back. Without
+    // the ledger this service could delete its own bookkeeping and call it a
+    // reversal — which is exactly what it used to do.
+    private readonly ledger: LedgerService,
   ) {}
 
   async evaluateCollusion(proofId: string, flaggedFuries: string[]): Promise<void> {
@@ -40,7 +49,18 @@ export class EnforcementService {
    * Confirms a pending enforcement case after review and applies the penalty.
    * Penalties are never auto-applied before this confirmation step.
    */
-  async confirmCase(caseId: string, penaltyType: string = 'REP_BURN', amountCents: number = 0) {
+  async confirmCase(caseId: string, penaltyType: string = 'REP_BURN', amountCents?: number) {
+    // A STAKE_SLASH with no amount used to become a silent $0 penalty — the case
+    // read as punished while nothing was taken. Derive from the auditor stake
+    // when the caller omits it, and refuse a non-positive explicit amount.
+    const resolvedAmount = FINANCIAL_PENALTY_TYPES.has(penaltyType)
+      ? amountCents ?? AUDITOR_STAKE_AMOUNT
+      : amountCents ?? 0;
+    if (FINANCIAL_PENALTY_TYPES.has(penaltyType) && resolvedAmount <= 0) {
+      throw new BadRequestException(
+        `${penaltyType} is a financial penalty and requires a positive amountCents.`,
+      );
+    }
     // Atomically claim the case (TOCTOU-safe): only the caller that flips
     // PENDING_REVIEW -> PENALTY_APPLIED proceeds, so two concurrent confirmations
     // can't both apply a penalty. The loser matches zero rows and is rejected.
@@ -55,8 +75,8 @@ export class EnforcementService {
       throw new NotFoundException('Pending case not found');
     }
 
-    await this.applyPenalty(caseId, penaltyType, amountCents);
-    return { success: true, caseId, status: 'PENALTY_APPLIED' };
+    await this.applyPenalty(caseId, penaltyType, resolvedAmount);
+    return { success: true, caseId, status: 'PENALTY_APPLIED', amountCents: resolvedAmount };
   }
 
   async applyPenalty(caseId: string, penaltyType: string, amountCents: number = 0) {
@@ -146,12 +166,9 @@ export class EnforcementService {
 
     const { reviewer_id: reviewerId } = claim.rows[0];
 
+    let refundedCents = 0;
     if (outcome === 'REVERSED') {
-      // Remove the penalty if reversed
-      await this.pool.query(
-        `DELETE FROM fury_penalties WHERE case_id = $1`,
-        [caseId],
-      );
+      refundedCents = await this.reversePenalty(caseId, reviewerId);
     }
 
     await this.truthLog.appendEvent('FURY_APPEAL_RESOLVED', {
@@ -159,9 +176,90 @@ export class EnforcementService {
       reviewerId,
       outcome,
       reason: reason || null,
+      refundedCents,
     });
 
-    return { success: true, caseId, outcome };
+    return { success: true, caseId, outcome, refundedCents };
+  }
+
+  /**
+   * Undoes a penalty. Returns the cents actually refunded (0 for a
+   * non-financial penalty such as REP_BURN, which has no ledger effect to undo).
+   *
+   * Compensating entry, not a deletion: the original charge stays on the ledger
+   * and a reversing transaction is posted against it, because a double-entry
+   * ledger records what happened, and the slash did happen. `reversal_transaction_id`
+   * makes this idempotent — re-resolving an already-reversed case refunds nothing
+   * a second time.
+   */
+  private async reversePenalty(caseId: string, reviewerId: string): Promise<number> {
+    const penalty = await this.pool.query(
+      `SELECT id, amount_cents, ledger_transaction_id, ledger_debit_account_id, reversal_transaction_id
+       FROM fury_penalties
+       WHERE case_id = $1`,
+      [caseId],
+    );
+
+    if (penalty.rows.length === 0) return 0;
+    const row = penalty.rows[0];
+
+    if (row.reversal_transaction_id) {
+      // Already refunded by an earlier resolution — do not pay twice.
+      return Number(row.amount_cents ?? 0);
+    }
+
+    const amountCents = Number(row.amount_cents ?? 0);
+    if (!row.ledger_transaction_id || !row.ledger_debit_account_id || amountCents <= 0) {
+      // A penalty with no financial leg (REP_BURN, or a legacy row predating the
+      // ledger link in migration 069). Mark it reversed; there is no money to move.
+      await this.pool.query(
+        `UPDATE fury_penalties SET reversed_at = NOW() WHERE id = $1`,
+        [row.id],
+      );
+      return 0;
+    }
+
+    const revenue = await this.pool.query(
+      `SELECT id FROM accounts WHERE name = 'SYSTEM_REVENUE'`,
+    );
+    if (revenue.rows.length === 0) {
+      throw new BadRequestException(
+        'Cannot reverse a financial penalty: SYSTEM_REVENUE account is missing.',
+      );
+    }
+
+    // Mirror of the original charge: revenue pays the reviewer back.
+    const reversalId = await this.ledger.recordTransaction(
+      revenue.rows[0].id,
+      row.ledger_debit_account_id,
+      amountCents,
+      undefined,
+      {
+        type: 'FURY_PENALTY_REVERSAL',
+        caseId,
+        reviewerId,
+        reversesTransactionId: row.ledger_transaction_id,
+      },
+      undefined,
+      `fury-appeal-reversal:${caseId}`,
+    );
+
+    await this.pool.query(
+      `UPDATE fury_penalties
+       SET reversed_at = NOW(), reversal_transaction_id = $2
+       WHERE id = $1`,
+      [row.id, reversalId],
+    );
+
+    await this.truthLog.appendEvent('FURY_PENALTY_REVERSED', {
+      caseId,
+      reviewerId,
+      amountCents,
+      reversalTransactionId: reversalId,
+      reversesTransactionId: row.ledger_transaction_id,
+    });
+
+    return amountCents;
   }
 }
 

--- a/src/api/src/modules/fury/fury.bounty.spec.ts
+++ b/src/api/src/modules/fury/fury.bounty.spec.ts
@@ -100,12 +100,19 @@ describe('FuryWorker — Bounty Economy', () => {
       mockPool.query.mockResolvedValueOnce({ rows: [{ id: 'revenue-account' }] });
 
       if (isHoneypot) {
-        // For honeypot: look up each flagged Fury's account_id
+        // For honeypot: look up each flagged Fury's account_id, then the three
+        // queries that record the automatic slash AS an appealable enforcement
+        // case (dedupe probe, case insert, penalty insert). Without that record
+        // the appeal flow has no object to reverse and a Fury who wins an appeal
+        // stays slashed.
         for (const furyId of flaggedFuries) {
           const accountId = furyAccountIds[furyId] ?? 'fury-acct-' + furyId;
           mockPool.query.mockResolvedValueOnce({
             rows: [{ account_id: accountId }],
           });
+          mockPool.query.mockResolvedValueOnce({ rows: [] }); // no existing penalty for this txn
+          mockPool.query.mockResolvedValueOnce({ rows: [{ id: `case-${furyId}` }] }); // case insert
+          mockPool.query.mockResolvedValueOnce({ rows: [] }); // penalty insert
         }
       } else {
         // For regular: look up each voter's account_id
@@ -217,6 +224,20 @@ describe('FuryWorker — Bounty Economy', () => {
     });
 
     await worker.checkConsensus('proof-hp-bounty');
+
+    // The automatic slash must land in the case system, carrying the ledger
+    // transaction it charged — otherwise resolveAppeal has nothing to reverse
+    // and a Fury who wins an appeal never gets the money back.
+    const sql = mockPool.query.mock.calls.map((c: any[]) => String(c[0]));
+    expect(sql.some((s) => /INSERT INTO fury_enforcement_cases/.test(s))).toBe(true);
+    const penaltyInsert = mockPool.query.mock.calls.find((c: any[]) =>
+      /INSERT INTO fury_penalties/.test(String(c[0])),
+    );
+    expect(penaltyInsert).toBeDefined();
+    expect(String(penaltyInsert![0])).toMatch(/ledger_transaction_id/);
+    expect(penaltyInsert![1]).toEqual(
+      expect.arrayContaining([AUDITOR_STAKE_AMOUNT, 'acct-corrupt']),
+    );
 
     // Only the flagged Fury gets a penalty
     expect(mockLedger.recordTransaction).toHaveBeenCalled();

--- a/src/api/src/modules/fury/fury.worker.ts
+++ b/src/api/src/modules/fury/fury.worker.ts
@@ -347,8 +347,9 @@ export class FuryWorker implements OnModuleInit {
         if (furyUser.rows.length === 0 || !furyUser.rows[0].account_id) continue;
 
         try {
-          await this.ledger!.recordTransaction(
-            furyUser.rows[0].account_id,
+          const debitAccountId = furyUser.rows[0].account_id;
+          const transactionId = await this.ledger!.recordTransaction(
+            debitAccountId,
             revenueAccountId,
             AUDITOR_STAKE_AMOUNT,
             contractId ?? undefined,
@@ -362,6 +363,20 @@ export class FuryWorker implements OnModuleInit {
             amount: AUDITOR_STAKE_AMOUNT,
             reason: 'honeypot_failure',
           });
+
+          // Record the automatic slash AS an enforcement case with a penalty row
+          // pointing at the ledger transaction. Without this the money moved here
+          // and the appeal flow had no object to reverse: resolveAppeal could only
+          // delete a fury_penalties row that never existed for an automatic slash,
+          // so a Fury who won an appeal stayed slashed. The case is opened already
+          // PENALTY_APPLIED because the charge has, in fact, already happened.
+          await this.recordAutomaticPenaltyCase(
+            furyId,
+            proofId,
+            transactionId,
+            debitAccountId,
+            AUDITOR_STAKE_AMOUNT,
+          );
         } catch (err) {
           this.logger.error(`Failed to charge honeypot penalty for Fury ${furyId}: ${err instanceof Error ? err.message : err}`);
         }
@@ -418,6 +433,57 @@ export class FuryWorker implements OnModuleInit {
       } catch (err) {
         this.logger.error(`Failed to process bounty for Fury ${vote.furyUserId}: ${err instanceof Error ? err.message : err}`);
       }
+    }
+  }
+
+  /**
+   * Records an already-charged automatic slash as an appealable enforcement case.
+   *
+   * Opened directly as PENALTY_APPLIED because the money has already moved — this
+   * is bookkeeping catching up with the ledger, not a decision. Idempotent on the
+   * ledger transaction id so a replayed consensus (the charge itself is
+   * idempotency-keyed) cannot open a second case for the same money.
+   */
+  private async recordAutomaticPenaltyCase(
+    furyId: string,
+    proofId: string,
+    transactionId: string,
+    debitAccountId: string,
+    amountCents: number,
+  ): Promise<void> {
+    try {
+      const existing = await this.pool.query(
+        `SELECT 1 FROM fury_penalties WHERE ledger_transaction_id = $1`,
+        [transactionId],
+      );
+      if (existing.rows.length > 0) return;
+
+      const caseResult = await this.pool.query(
+        `INSERT INTO fury_enforcement_cases (reviewer_id, case_type, confidence, status, evidence_json)
+         VALUES ($1, 'HONEYPOT_FAILURE', 1.0, 'PENALTY_APPLIED', $2)
+         RETURNING id`,
+        [
+          furyId,
+          JSON.stringify({
+            proofId,
+            reason: 'Automatic honeypot slash applied at consensus',
+            automatic: true,
+          }),
+        ],
+      );
+
+      await this.pool.query(
+        `INSERT INTO fury_penalties
+           (case_id, penalty_type, amount_cents, ledger_transaction_id, ledger_debit_account_id)
+         VALUES ($1, 'STAKE_SLASH', $2, $3, $4)`,
+        [caseResult.rows[0].id, amountCents, transactionId, debitAccountId],
+      );
+    } catch (err) {
+      // Never let bookkeeping failure roll back a charge that already succeeded;
+      // surface it loudly instead, because an unrecorded slash is unappealable.
+      this.logger.error(
+        `Charged Fury ${furyId} but FAILED to record the enforcement case for transaction ${transactionId}: ${err instanceof Error ? err.message : err}. This penalty cannot be appealed until reconciled.`,
+      );
     }
   }
 }


### PR DESCRIPTION
The appeal flow moved **no money**. `resolveAppeal`'s `REVERSED` branch ran a single `DELETE FROM fury_penalties` — deleting *bookkeeping* — while the honeypot slash had been charged through the ledger in `fury.worker.ts`, entirely outside the case system. `EnforcementService` did not even import `LedgerService`. A reviewer could appeal, win, and stay slashed.

**1. The slash becomes appealable.** The worker charged `AUDITOR_STAKE_AMOUNT` and walked away — no case, no penalty row, nothing to point at. It now records the charge as a `PENALTY_APPLIED` case with a penalty row carrying the ledger transaction id and debited account (migration 069 adds those, plus `reversal_transaction_id`). Idempotent on the transaction id; a bookkeeping failure logs loudly rather than rolling back a charge that already succeeded.

**2. The reversal moves money.** `REVERSED` posts a compensating transaction — revenue credits the reviewer back — keyed `fury-appeal-reversal:<caseId>`, stamps `reversed_at` + `reversal_transaction_id` (a second resolution refunds nothing), and appends `FURY_PENALTY_REVERSED` to the truth log. The original charge is **not** deleted: a double-entry ledger records what happened, and the slash did happen. `REP_BURN` is marked reversed with no ledger effect.

**3. No more silent $0 penalties.** `dto.amountCents || 0` turned a missing amount into a *free* `STAKE_SLASH` — punished on paper, nothing taken. The amount now reaches the service as `undefined`, which derives it from the auditor stake, and an explicit non-positive amount on a financial penalty is rejected.

Two specs **asserted the defects** and were corrected: "resolves an appeal as REVERSED and removes penalty" (the removal *was* the bug) and the controller's `|| 0` coercion assertion.

Verified: **69/69** fury specs green, api `tsc` clean. Honest caveat: the SQL is mock-tested only (every spec here mocks the pg Pool), so migration 069 and the new queries want a live-DB pass before the real-money rail is ever armed.

Gamma wave of the full-build program (#904).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmP1SLhXcZBmA7g4NM6PTY

## Summary by Sourcery

Make Fury financial penalties truly appealable by linking them to ledger transactions and ensuring reversals refund slashed funds instead of just deleting bookkeeping rows.

New Features:
- Record automatic honeypot slashes as enforcement cases with associated penalty rows linked to the ledger, making them appealable.
- Introduce explicit refund tracking for reversed appeals, returning slashed funds via compensating ledger transactions and exposing refundedCents in resolveAppeal results.

Bug Fixes:
- Prevent missing penalty amounts from becoming silent $0 financial penalties by deriving stake slashes from AUDITOR_STAKE_AMOUNT and rejecting non-positive explicit amounts.
- Ensure reversed Fury penalties do not delete ledger history and cannot be refunded twice, handling non-financial penalties without moving money.
- Stop the enforcement controller from coercing an omitted amountCents into 0 so the service can correctly derive or validate financial penalty amounts.

Enhancements:
- Wire EnforcementService to LedgerService and extend fury_penalties with ledger linkage and reversal metadata to support robust, idempotent financial reversals.
- Add tests around financial penalty amount derivation, appeal reversal refund behavior, and automatic honeypot case creation to assert the corrected semantics.

Tests:
- Expand EnforcementService and FuryWorker specs to cover financial amount validation, proper refunding on appeal reversal, non-double-refund behavior, and automatic case/penalty recording for honeypot slashes.

Chores:
- Add migration 069 to link fury_penalties to the ledger transaction and debit account, and to store reversal transaction IDs for idempotent refunds.