### PR TITLE
fix(contracts): gate the onboarding bonus behind a DR-005 flag, and surface the dead downscaling multiplier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,18 @@ STYX_FEATURE_B2B_HR_UI=false
 STYX_MOBILE_MIN_IOS_VERSION=1.0.0-beta.1
 STYX_MOBILE_MIN_IOS_BUILD=1
 
+# Deferred beta economics (founder decisions of record — see
+# docs/planning/planning--founder-decisions-of-record.md).
+# Both mechanics are DEFERRED, not deleted: the code path stays and the flag
+# reinstates it. Neither can be expressed by zeroing its amount — a zero-amount
+# Stripe authorization is invalid and a non-positive ledger transaction is
+# rejected, so a zeroed price fails the path closed instead of making it free.
+# DR-004: the $5.00 appeal friction fee is removed for the beta cohort.
+STYX_APPEAL_FEE_ENABLED=false
+# DR-005: the $5.00 endowed-progress onboarding bonus is removed for the beta
+# cohort. Off means no ledger credit and no ONBOARDING_BONUS_GRANTED event.
+STYX_ONBOARDING_BONUS_ENABLED=false
+
 # Runtime URLs and ports
 API_PORT=
 STYX_WEB_PORT=

--- a/docs/planning/concentric-circles-execution.md
+++ b/docs/planning/concentric-circles-execution.md
@@ -97,10 +97,12 @@ engineering item and closed one long-standing block:
   off; `STYX_APPEAL_FEE_ENABLED=true` reinstates) — the decisions ledger records it and the
   ledger wins over this doc's earlier "unbuilt" reading. The zero-amount-authorization trap
   still holds: never set `APPEAL_FEE_AMOUNT` to `0`; the flag skips the hold instead.
-- **Open (DR-005).** The onboarding-bonus removal is decided but unbuilt —
-  `grantOnboardingBonus` is still called from `contracts.service.ts`. Q-6's recorded default
-  (keep the mechanic, remove the money, flag-deferred like DR-004) is the Delta-wave item in
-  `planning--full-build-execution--2026-08-15.md`.
+- **Built (DR-005).** The onboarding-bonus removal shipped 2026-08-15 behind
+  `isOnboardingBonusEnabled()` (default off; `STYX_ONBOARDING_BONUS_ENABLED=true` reinstates),
+  gating both `grantOnboardingBonus` call sites in `contracts.service.ts`. Q-6's recorded
+  default — keep the mechanic, remove the money, flag-deferred like DR-004 — is what was
+  built. The zeroing trap is sharper here than for the fee: `recordTransaction` rejects a
+  non-positive amount, so a `$0` bonus throws and dead-letters the contract.
 
 ---
 
@@ -176,13 +178,13 @@ they take real work, not because anyone is still weighing them.
       nothing to capture or cancel. Keep `APPEAL_FEE_AMOUNT` behind a policy gate — DR-004
       explicitly reserves the right to reintroduce the fee if frivolous appeals appear at
       scale.
-- [ ] **No onboarding bonus in the beta cohort (DR-005).** `grantOnboardingBonus` is called
-      from `contracts.service.ts:1045` and `:1675`, each posting a `$5.00` ledger credit.
-      Suppressing the grant is contained, but the pitch deck sells the bonus as the
-      acquisition mechanic and `endowed-progress.service.ts` is built on artificial initial
-      advancement. Removing the money without deciding what happens to endowed progress
-      leaves a behavioral feature half-wired — the exact failure this plan already documented
-      three times.
+- [x] **No onboarding bonus in the beta cohort (DR-005).** Shipped 2026-08-15:
+      `isOnboardingBonusEnabled()` gates both `grantOnboardingBonus` call sites, defaults off,
+      and `STYX_ONBOARDING_BONUS_ENABLED=true` reinstates the credit. The endowed-progress
+      objection did not survive contact with the code — that service grants no money, it only
+      computes a display boost and a read-only downscaling multiplier, so the money decision
+      was never coupled to the behavioral one. The pitch deck still sells the bonus; that is a
+      marketing-copy divergence, not a half-wired feature.
 - [ ] **Ticket price `$4.99` was never decided.** `TICKET_PRICE_BASE` in
       `src/api/services/billing.ts:7` is an engineering default that no business decision
       covers. It was on the worksheet but not on the five-item brief that was actually sent.

--- a/docs/planning/planning--founder-decisions-of-record.md
+++ b/docs/planning/planning--founder-decisions-of-record.md
@@ -144,7 +144,24 @@ The $5.00 endowed-progress onboarding bonus is **removed for the beta cohort**.
 
 Same shape as DR-004: deferred, not deleted.
 
-**Not yet implemented.** See [Open implementation](#open-implementation-of-decided-policy).
+**In force since 2026-08-15.** `isOnboardingBonusEnabled()` in
+`src/api/services/billing.ts` gates the grant at both call sites in
+`contracts.service.ts` — the transactional activation side effects and the
+non-transactional fallback path. It defaults off and
+`STYX_ONBOARDING_BONUS_ENABLED=true` reinstates the $5 credit. With the flag off a
+first contract posts no `ONBOARDING_BONUS` ledger entry and emits no
+`ONBOARDING_BONUS_GRANTED` truth-log event.
+
+The zeroing trap is the same as DR-004's and one step sharper:
+`LedgerService.recordTransaction` rejects a non-positive amount, so setting
+`ONBOARDING_BONUS_AMOUNT` to 0 would throw inside contract-creation side effects
+and dead-letter every first contract to `RECONCILE_REQUIRED`. The flag skips the
+grant instead.
+
+The user-facing `+$5.00` line in `OnboardingWizard.tsx` is gone for the same
+reason DR-004 removed the appeal-fee price from its button label: the client
+cannot see the server flag, so any hardcoded figure is a promise the cohort does
+not receive.
 
 ---
 
@@ -246,8 +263,9 @@ index entry, no strategy attached) was simply corrected.
 
 ## Open implementation of decided policy
 
-DR-005 is decided but not built. It is not a one-line change, which is why it is
-named here rather than quietly deferred.
+Empty as of 2026-08-15: every decision above is now in force in code. The two
+entries below are kept because each estimate was wrong in a way worth more than
+the estimate.
 
 ### ~~DR-004 — free appeals~~ — **built 2026-07-31**
 
@@ -266,15 +284,20 @@ saved Stripe customer, which would have denied free appeals to exactly the peopl
 they were for. Estimating from the service that charges the fee missed the caller
 that gates it.
 
-### DR-005 — no onboarding bonus
+### ~~DR-005 — no onboarding bonus~~ — **built 2026-08-15**
 
-`grantOnboardingBonus` (`src/shared/libs/behavioral-logic.ts:231`) is called from
-two paths in `contracts.service.ts` (`:1045`, `:1675`), each posting a
-`ONBOARDING_BONUS_AMOUNT` ledger credit. Suppressing the grant is contained, but
-it interacts with divergence 2 above and with `endowed-progress.service.ts`, whose
-whole premise is artificial initial advancement. Removing the money without
-deciding what happens to the endowed-progress mechanic leaves a behavioral feature
-half-wired — the failure mode Circle 5 already documented twice.
+What shipped is under DR-005 above. The scoping error worth recording: this was
+held open on the belief that suppressing the grant would leave
+`endowed-progress.service.ts` half-wired, because "its whole premise is artificial
+initial advancement." That service grants no money at all — it computes a display
+boost and a downscaling multiplier, both read-only. The two mechanics share a name
+and nothing else, so the money decision was never coupled to the behavioral one.
+
+The real coupling was elsewhere and was not predicted: `grantOnboardingBonus` is
+called from **two** paths in `contracts.service.ts`, the transactional one and the
+non-transactional fallback, and only one of them is idempotent. A flag wired at a
+single call site would have looked correct in review and still paid the bonus on
+every contract created through a pool that supports `connect()`.
 
 ---
 

--- a/src/api/services/billing.spec.ts
+++ b/src/api/services/billing.spec.ts
@@ -1,4 +1,8 @@
-import { processIAP, TICKET_PRICE_BASE } from './billing';
+import {
+  isOnboardingBonusEnabled,
+  processIAP,
+  TICKET_PRICE_BASE,
+} from './billing';
 
 describe('processIAP', () => {
   let mockPool: { query: jest.Mock };
@@ -128,5 +132,35 @@ describe('processIAP', () => {
 
     expect(mockLedger.recordTransaction).not.toHaveBeenCalled();
     expect(mockTruthLog.appendEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('isOnboardingBonusEnabled', () => {
+  const original = process.env.STYX_ONBOARDING_BONUS_ENABLED;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.STYX_ONBOARDING_BONUS_ENABLED;
+    } else {
+      process.env.STYX_ONBOARDING_BONUS_ENABLED = original;
+    }
+  });
+
+  it('defaults OFF when unset (DR-005 beta cohort)', () => {
+    delete process.env.STYX_ONBOARDING_BONUS_ENABLED;
+
+    expect(isOnboardingBonusEnabled()).toBe(false);
+  });
+
+  it('is reinstated only by an explicit true', () => {
+    process.env.STYX_ONBOARDING_BONUS_ENABLED = 'TRUE';
+    expect(isOnboardingBonusEnabled()).toBe(true);
+
+    // Anything else stays off: a stray or truthy-looking value must not
+    // silently reinstate a grant that moves money.
+    for (const value of ['false', '1', 'yes', '']) {
+      process.env.STYX_ONBOARDING_BONUS_ENABLED = value;
+      expect(isOnboardingBonusEnabled()).toBe(false);
+    }
   });
 });

--- a/src/api/services/billing.ts
+++ b/src/api/services/billing.ts
@@ -35,6 +35,36 @@ export function isAppealFeeEnabled(): boolean {
   return String(process.env.STYX_APPEAL_FEE_ENABLED).toLowerCase() === 'true';
 }
 
+/**
+ * PI-02: Endowed-Progress Onboarding Bonus
+ * A one-time credit posted to a user's account on their first contract, to
+ * create artificial initial advancement (`ONBOARDING_BONUS_AMOUNT` in
+ * src/shared/libs/behavioral-logic.ts).
+ *
+ * DR-005 (decided 2026-03-10 by Jessica, business lead — same source as DR-004):
+ * the $5.00 onboarding bonus is REMOVED for the beta cohort.
+ *
+ *   "We can consider adding credits or bonuses later if we want to improve
+ *    conversion or test additional engagement mechanics."
+ *
+ * Same shape as DR-004: deferred, not deleted. The amount, `grantOnboardingBonus`,
+ * and both grant paths in contracts.service.ts all stay; this flag decides whether
+ * the grant runs.
+ *
+ * And as with the appeal fee, this cannot be expressed by zeroing the amount:
+ * `LedgerService.recordTransaction` rejects a non-positive amount outright, so a
+ * $0 bonus would throw inside contract-creation side effects and dead-letter every
+ * first contract to RECONCILE_REQUIRED. Skipping the grant is the only form that
+ * leaves the mechanism intact.
+ *
+ * Defaults OFF per DR-005; set STYX_ONBOARDING_BONUS_ENABLED=true to reinstate it.
+ */
+export function isOnboardingBonusEnabled(): boolean {
+  return (
+    String(process.env.STYX_ONBOARDING_BONUS_ENABLED).toLowerCase() === 'true'
+  );
+}
+
 export interface IAPResult {
   paymentIntentId: string;
   amount: number;

--- a/src/api/src/modules/contracts/contracts.service.spec.ts
+++ b/src/api/src/modules/contracts/contracts.service.spec.ts
@@ -15,6 +15,7 @@ import { AnomalyService } from "../../../services/anomaly/anomaly.service";
 import { SettlementService } from "../payments/settlement.service";
 import {
   OathCategory,
+  ONBOARDING_BONUS_AMOUNT,
   VerificationMethod,
 } from "../../../../shared/libs/behavioral-logic";
 import { Pool } from "pg";
@@ -666,6 +667,159 @@ describe("ContractsService", () => {
       );
       expect(reconcileUpdateCall).toBeDefined();
       expect(mockStripe.cancelHold).toHaveBeenCalledWith("pi_tx_fail_2");
+    });
+  });
+
+  // ── onboarding bonus (DR-005) ───────────────────────────────────
+
+  describe("onboarding bonus (DR-005)", () => {
+    const onboardingLedgerCalls = () =>
+      (mockLedger.recordTransaction as jest.Mock).mock.calls.filter(
+        ([, , , , metadata]) => metadata?.type === "ONBOARDING_BONUS",
+      );
+
+    const onboardingTruthLogCalls = () =>
+      (mockTruthLog.appendEvent as jest.Mock).mock.calls.filter(
+        ([event]) => event === "ONBOARDING_BONUS_GRANTED",
+      );
+
+    // Prior-contract count 0 throughout: a first contract is the only state in
+    // which the grant is eligible at all, so every assertion below isolates the
+    // flag rather than the eligibility rule.
+    const queueSinglePhaseFirstContract = () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [activeUser] }); // user
+      mockPool.query.mockResolvedValueOnce({ rows: [{ count: 0 }] }); // cool-off
+      mockPool.query.mockResolvedValueOnce({ rows: [{ count: 0 }] }); // total failures
+      mockPool.query.mockResolvedValueOnce({ rows: [{ id: "contract-1" }] }); // INSERT contract
+      mockPool.query.mockResolvedValueOnce({ rows: [] }); // UPDATE contracts ACTIVE
+      mockPool.query.mockResolvedValueOnce({ rows: [{ count: 0 }] }); // prior contracts
+    };
+
+    // The transactional path reaches the grant through
+    // runContractCreationActivationSideEffects instead, so it needs its own
+    // coverage — a flag wired at only one of the two call sites still pays the
+    // bonus on every contract created with a pool that supports connect().
+    const queueTwoPhaseFirstContract = () => {
+      mockPool.connect = jest.fn();
+      mockPool.query.mockResolvedValueOnce({ rows: [activeUser] }); // user
+      mockPool.query.mockResolvedValueOnce({ rows: [{ count: 0 }] }); // cool-off
+      mockPool.query.mockResolvedValueOnce({ rows: [{ count: 0 }] }); // total failures
+      mockPool.query.mockResolvedValueOnce({ rows: [{ count: 0 }] }); // prior contracts
+
+      const phaseAClient = {
+        query: jest
+          .fn()
+          .mockResolvedValueOnce({ rows: [] }) // BEGIN
+          .mockResolvedValueOnce({ rows: [{ id: "contract-tx-1" }] }) // INSERT contract
+          .mockResolvedValueOnce({ rows: [] }), // COMMIT
+        release: jest.fn(),
+      };
+
+      const phaseBClient = {
+        query: jest
+          .fn()
+          .mockResolvedValueOnce({ rows: [] }) // BEGIN
+          .mockResolvedValueOnce({
+            rows: [
+              {
+                id: "contract-tx-1",
+                status: "PENDING_STAKE",
+                payment_intent_id: null,
+              },
+            ],
+          }) // SELECT FOR UPDATE
+          .mockResolvedValueOnce({ rows: [] }) // finalize UPDATE
+          .mockResolvedValueOnce({ rows: [] }), // COMMIT
+        release: jest.fn(),
+      };
+
+      (mockPool.connect as jest.Mock)
+        .mockResolvedValueOnce(phaseAClient)
+        .mockResolvedValueOnce(phaseBClient);
+
+      (mockStripe.holdStake as jest.Mock).mockResolvedValueOnce({
+        id: "pi_tx_bonus_1",
+      });
+    };
+
+    afterEach(() => {
+      delete process.env.STYX_ONBOARDING_BONUS_ENABLED;
+    });
+
+    it("grants nothing on a first contract while the bonus is deferred", async () => {
+      queueSinglePhaseFirstContract();
+
+      await service.createContract(validDto);
+
+      expect(onboardingLedgerCalls()).toHaveLength(0);
+      expect(onboardingTruthLogCalls()).toHaveLength(0);
+    });
+
+    it("grants the full bonus when the bonus is reinstated", async () => {
+      process.env.STYX_ONBOARDING_BONUS_ENABLED = "true";
+      queueSinglePhaseFirstContract();
+      mockPool.query.mockResolvedValueOnce({ rows: [{ id: "escrow-acct" }] }); // SYSTEM_ESCROW
+
+      await service.createContract(validDto);
+
+      expect(onboardingLedgerCalls()).toEqual([
+        [
+          "escrow-acct",
+          "acct-1",
+          ONBOARDING_BONUS_AMOUNT,
+          "contract-1",
+          { type: "ONBOARDING_BONUS", userId: "user-1" },
+        ],
+      ]);
+      expect(onboardingTruthLogCalls()).toEqual([
+        [
+          "ONBOARDING_BONUS_GRANTED",
+          {
+            userId: "user-1",
+            amount: ONBOARDING_BONUS_AMOUNT,
+            contractId: "contract-1",
+          },
+        ],
+      ]);
+    });
+
+    it("grants nothing on the transactional path while the bonus is deferred", async () => {
+      queueTwoPhaseFirstContract();
+
+      await service.createContract(validDto);
+
+      expect(onboardingLedgerCalls()).toHaveLength(0);
+      expect(onboardingTruthLogCalls()).toHaveLength(0);
+    });
+
+    it("grants the full bonus on the transactional path when reinstated", async () => {
+      process.env.STYX_ONBOARDING_BONUS_ENABLED = "true";
+      queueTwoPhaseFirstContract();
+
+      await service.createContract(validDto);
+
+      expect(onboardingLedgerCalls()).toEqual([
+        [
+          "escrow-acct",
+          "acct-1",
+          ONBOARDING_BONUS_AMOUNT,
+          "contract-tx-1",
+          expect.objectContaining({
+            type: "ONBOARDING_BONUS",
+            userId: "user-1",
+          }),
+        ],
+      ]);
+      expect(onboardingTruthLogCalls()).toEqual([
+        [
+          "ONBOARDING_BONUS_GRANTED",
+          expect.objectContaining({
+            userId: "user-1",
+            amount: ONBOARDING_BONUS_AMOUNT,
+            contractId: "contract-tx-1",
+          }),
+        ],
+      ]);
     });
   });
 

--- a/src/api/src/modules/contracts/contracts.service.ts
+++ b/src/api/src/modules/contracts/contracts.service.ts
@@ -22,7 +22,10 @@ import { StripeFBOService as RealStripeFBOService } from "../payments/stripe-fbo
 import { SettlementService } from "../payments/settlement.service";
 import { buildSettlementQuote } from "../payments/settlement-quote";
 import { DisputeService } from "../../../services/escrow/dispute.service";
-import { isAppealFeeEnabled } from "../../../services/billing";
+import {
+  isAppealFeeEnabled,
+  isOnboardingBonusEnabled,
+} from "../../../services/billing";
 import { FuryRouterService } from "../../../services/fury-router/fury-router.service";
 import { AegisProtocolService } from "../../../services/health/aegis.service";
 import { RecoveryProtocolService } from "../../../services/health/recovery-protocol.service";
@@ -1074,10 +1077,16 @@ export class ContractsService {
     );
     const escrowAccountId = escrowResult.rows[0]?.id ?? null;
 
+    // DR-005: the onboarding bonus is deferred for the beta cohort. When the
+    // flag is off every money-shaped step below is skipped rather than run at a
+    // zero amount — recordTransaction rejects a non-positive amount, so a zeroed
+    // bonus would throw here and dead-letter every first contract to
+    // RECONCILE_REQUIRED. See isOnboardingBonusEnabled.
+    const bonusEnabled = isOnboardingBonusEnabled();
     const bonus = grantOnboardingBonus(
       Number(priorContracts.rows[0]?.count ?? 0),
     );
-    if (bonus.granted && user.account_id && escrowAccountId) {
+    if (bonusEnabled && bonus.granted && user.account_id && escrowAccountId) {
       const bonusLedgerKey = `${baseKey}:ledger:onboarding-bonus`;
       if (
         !(await this.hasContractLedgerSideEffect(contractId, bonusLedgerKey))
@@ -1763,13 +1772,15 @@ export class ContractsService {
       );
     }
 
-    // 7. Check for onboarding bonus (first contract)
+    // 7. Check for onboarding bonus (first contract). Deferred for the beta
+    //    cohort by DR-005 — same skip-the-grant treatment as the two-phase path
+    //    above; see isOnboardingBonusEnabled.
     const priorContracts = await this.pool.query(
       `SELECT COUNT(*) as count FROM contracts WHERE user_id = $1 AND id != $2`,
       [dto.userId, contractId],
     );
     const bonus = grantOnboardingBonus(Number(priorContracts.rows[0].count));
-    if (bonus.granted && user.account_id) {
+    if (isOnboardingBonusEnabled() && bonus.granted && user.account_id) {
       const escrowCheck = await this.pool.query(
         `SELECT id FROM accounts WHERE name = 'SYSTEM_ESCROW' LIMIT 1`,
       );

--- a/src/web/app/contracts/new/page.test.tsx
+++ b/src/web/app/contracts/new/page.test.tsx
@@ -22,6 +22,9 @@ jest.mock('../../../services/api-client', () => ({
   api: {
     createContract: jest.fn().mockResolvedValue({ id: 'new-id' }),
     getUserContracts: jest.fn().mockResolvedValue([]),
+    getEndowedProgress: jest.fn().mockResolvedValue({
+      downscaling: { multiplier: 1, reason: 'no downscaling applied' },
+    }),
   },
 }));
 

--- a/src/web/app/contracts/new/page.tsx
+++ b/src/web/app/contracts/new/page.tsx
@@ -2,12 +2,17 @@
 
 import React, { Suspense, useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Flame, ArrowLeft, Loader2, ShieldCheck, TriangleAlert } from 'lucide-react';
+import { Flame, ArrowLeft, Info, Loader2, ShieldCheck, TriangleAlert } from 'lucide-react';
 import Link from 'next/link';
 import { api } from '../../../services/api-client';
 import { useAuth } from '../../../contexts/AuthContext';
 import { getAllowedTiers, getDisplayTier, getTierMaxStake } from '../../../../shared/libs/integrity';
 import { getRealmBySlug } from '../../../../shared/libs/realm-registry';
+import {
+  deriveStakeGuidance,
+  findMostRecentActiveContract,
+  type DownscalingSignal,
+} from '../../../lib/stake-guidance';
 
 const OATH_CATEGORIES = [
   // { value: 'BIOLOGICAL_WEIGHT', label: 'Weight Management', stream: 'Biological' },
@@ -116,6 +121,7 @@ function NewContractPageContent() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [failureCount, setFailureCount] = useState<number | null>(null);
+  const [downscaling, setDownscaling] = useState<DownscalingSignal | null>(null);
 
   // Recovery stream fields
   const [apEmail, setApEmail] = useState('');
@@ -152,6 +158,9 @@ function NewContractPageContent() {
   const totalEntryUsd = selectedStakeUsd + platformFeeUsd;
   const requiresKyc = selectedStakeUsd > 0 && requiresCreateContractKyc(selectedStakeUsd);
   const canStake = maxStakeUsd >= MIN_STAKE_USD;
+  // Read-only: the behavioral engine's downscale is shown next to the amount,
+  // never applied to it. See lib/stake-guidance.ts for why.
+  const stakeGuidance = deriveStakeGuidance(downscaling, selectedStakeUsd);
   const displayTier = getDisplayTier(integrityScore).replace(/_/g, ' ');
   const failureLimitCopy = effectiveFailureCount == null
     ? 'Server checks failure history again at submit.'
@@ -169,9 +178,23 @@ function NewContractPageContent() {
 
     api.getUserContracts()
       .then((contracts) => {
-        if (cancelled) return;
+        if (cancelled) return undefined;
         const failedContracts = contracts.filter((contract) => contract.status === 'FAILED').length;
         setFailureCount(failedContracts);
+
+        // The endowed-progress downscale is contract-scoped, so guidance for
+        // this new contract is read off the one the user is currently running.
+        const activeContract = findMostRecentActiveContract(contracts);
+        if (!activeContract) return undefined;
+
+        return api.getEndowedProgress(activeContract.id)
+          .then((progress) => {
+            if (!cancelled) setDownscaling(progress.downscaling);
+          })
+          .catch(() => {
+            // Guidance is advisory: losing it must not disturb the failure-count
+            // fallback below, which is a real safety limit.
+          });
       })
       .catch(() => {
         if (!cancelled) {
@@ -390,6 +413,23 @@ function NewContractPageContent() {
                 </span>
               </label>
             </div>
+
+            {stakeGuidance && (
+              <div className="flex items-start gap-3 rounded-lg border border-sky-900 bg-sky-950/30 p-3">
+                <Info size={16} className="mt-0.5 shrink-0 text-sky-400" />
+                <div className="text-xs text-sky-200">
+                  <p className="font-bold uppercase tracking-widest text-sky-300">Behavioral guidance</p>
+                  <p className="mt-1">
+                    Your active contract is carrying a {stakeGuidance.reductionPercent}% downscale
+                    ({stakeGuidance.reason}). At that factor this stake would be{' '}
+                    {formatMoney(stakeGuidance.suggestedStakeUsd)}.
+                  </p>
+                  <p className="mt-1 text-sky-400">
+                    Guidance only — you stake {formatMoney(selectedStakeUsd)} unless you change it yourself.
+                  </p>
+                </div>
+              </div>
+            )}
 
             <div className="flex flex-col gap-3 border-t border-neutral-800 pt-4 sm:flex-row sm:items-center sm:justify-between">
               <p className="text-xs text-neutral-500">

--- a/src/web/components/OnboardingWizard.tsx
+++ b/src/web/components/OnboardingWizard.tsx
@@ -334,10 +334,11 @@ export function OnboardingWizard({ onComplete, onSkip }: OnboardingWizardProps) 
                   <span className="text-neutral-500 text-sm">Perceived Loss</span>
                   <span className="font-bold text-neutral-300">${perceivedLoss}</span>
                 </div>
-                <div className="flex justify-between items-center">
-                  <span className="text-neutral-500 text-sm">Onboarding Bonus</span>
-                  <span className="font-bold text-green-400">+$5.00</span>
-                </div>
+                {/* No onboarding-bonus row: DR-005 defers the $5.00 grant for
+                    the beta cohort, and the client cannot see whether the
+                    STYX_ONBOARDING_BONUS_ENABLED escape hatch is on, so a
+                    hardcoded "+$5.00" promised money that is not credited. The
+                    wallet ledger reports what was actually granted. */}
               </div>
 
               <p className="text-sm text-neutral-500">

--- a/src/web/lib/stake-guidance.test.ts
+++ b/src/web/lib/stake-guidance.test.ts
@@ -1,0 +1,98 @@
+import {
+  deriveStakeGuidance,
+  findMostRecentActiveContract,
+} from './stake-guidance';
+
+const contract = (id: string, status: string, created_at: string) => ({
+  id,
+  status,
+  created_at,
+});
+
+describe('findMostRecentActiveContract', () => {
+  it('returns the newest ACTIVE contract', () => {
+    const result = findMostRecentActiveContract([
+      contract('c-old', 'ACTIVE', '2026-01-01T00:00:00Z'),
+      contract('c-new', 'ACTIVE', '2026-03-01T00:00:00Z'),
+      contract('c-mid', 'ACTIVE', '2026-02-01T00:00:00Z'),
+    ]);
+
+    expect(result?.id).toBe('c-new');
+  });
+
+  it('ignores contracts that are not ACTIVE', () => {
+    const result = findMostRecentActiveContract([
+      contract('c-failed', 'FAILED', '2026-04-01T00:00:00Z'),
+      contract('c-completed', 'COMPLETED', '2026-03-01T00:00:00Z'),
+      contract('c-active', 'ACTIVE', '2026-01-01T00:00:00Z'),
+    ]);
+
+    expect(result?.id).toBe('c-active');
+  });
+
+  it('returns null when the user holds no active contract', () => {
+    expect(findMostRecentActiveContract([])).toBeNull();
+    expect(
+      findMostRecentActiveContract([
+        contract('c-1', 'PENDING_STAKE', '2026-01-01T00:00:00Z'),
+      ]),
+    ).toBeNull();
+  });
+});
+
+describe('deriveStakeGuidance', () => {
+  it('derives a suggested stake and a whole-percent reduction', () => {
+    const guidance = deriveStakeGuidance(
+      { multiplier: 0.85, reason: 'weekend vulnerability in final 30%' },
+      30,
+    );
+
+    expect(guidance).toEqual({
+      multiplier: 0.85,
+      reason: 'weekend vulnerability in final 30%',
+      suggestedStakeUsd: 25.5,
+      reductionPercent: 15,
+    });
+  });
+
+  it('rounds the suggested stake to whole cents', () => {
+    const guidance = deriveStakeGuidance(
+      { multiplier: 0.765, reason: '2 prior violation(s); weekend' },
+      33,
+    );
+
+    expect(guidance?.suggestedStakeUsd).toBe(25.25);
+  });
+
+  it('returns null when no downscaling applies', () => {
+    expect(
+      deriveStakeGuidance(
+        { multiplier: 1, reason: 'no downscaling applied' },
+        30,
+      ),
+    ).toBeNull();
+    expect(deriveStakeGuidance(null, 30)).toBeNull();
+    expect(deriveStakeGuidance(undefined, 30)).toBeNull();
+  });
+
+  it('returns null for a multiplier the service could not have meant', () => {
+    // A multiplier above 1 would be an UPSCALE — advising a user to raise a
+    // stake is a different product decision entirely, so it is refused here
+    // rather than rendered.
+    expect(
+      deriveStakeGuidance({ multiplier: 1.4, reason: 'bad signal' }, 30),
+    ).toBeNull();
+    expect(
+      deriveStakeGuidance({ multiplier: 0, reason: 'bad signal' }, 30),
+    ).toBeNull();
+    expect(
+      deriveStakeGuidance({ multiplier: Number.NaN, reason: 'bad signal' }, 30),
+    ).toBeNull();
+  });
+
+  it('returns null when no stake has been chosen yet', () => {
+    expect(
+      deriveStakeGuidance({ multiplier: 0.9, reason: '1 prior violation(s)' }, 0),
+    ).toBeNull();
+  });
+});

--- a/src/web/lib/stake-guidance.ts
+++ b/src/web/lib/stake-guidance.ts
@@ -1,0 +1,81 @@
+/**
+ * Endowed-progress dynamic downscaling, surfaced as stake-selection guidance.
+ *
+ * `EndowedProgressService.applyDynamicDownscaling` derives a multiplier below 1
+ * when a user carries prior violations, or is inside the weekend stretch of the
+ * final 30% of a contract. It is returned by
+ * GET /behavioral/retention/endowed-progress/:contractId.
+ *
+ * The multiplier is deliberately NOT applied to the stake. Doing so would change
+ * what is actually held on a user's card, and this repo has no decision of record
+ * covering stake pricing at all — five monetization models are live in shipped
+ * code and pricing is a joint founder call under DR-007. So the signal is
+ * rendered as advice next to the amount the user chooses, and the number they
+ * submit is the number they picked.
+ */
+
+export interface DownscalingSignal {
+  multiplier: number;
+  reason: string;
+}
+
+export interface StakeGuidance {
+  /** The downscale factor the behavioral engine derived, e.g. 0.9. */
+  multiplier: number;
+  /** Human-readable cause, straight from the service ("2 prior violation(s)"). */
+  reason: string;
+  /** What the selected stake would be if the multiplier were applied. */
+  suggestedStakeUsd: number;
+  /** Whole-percent reduction, for copy that reads as guidance rather than math. */
+  reductionPercent: number;
+}
+
+/** A contract row as `api.getUserContracts()` returns it. */
+export interface ContractSummary {
+  id: string;
+  status: string;
+  created_at: string;
+}
+
+/**
+ * The downscaling signal is contract-scoped, so guidance for a NEW contract is
+ * read off the user's current one. Most recent by created_at, since a user may
+ * hold several.
+ */
+export function findMostRecentActiveContract<T extends ContractSummary>(
+  contracts: T[],
+): T | null {
+  const active = contracts.filter((contract) => contract.status === 'ACTIVE');
+  if (active.length === 0) return null;
+
+  return active.reduce((latest, contract) =>
+    Date.parse(contract.created_at) > Date.parse(latest.created_at)
+      ? contract
+      : latest,
+  );
+}
+
+/**
+ * Returns null when there is nothing worth saying — no signal, a multiplier of
+ * 1.0 ("no downscaling applied"), a non-finite or out-of-range value, or a stake
+ * of zero. Callers render nothing rather than an empty advisory panel.
+ */
+export function deriveStakeGuidance(
+  downscaling: DownscalingSignal | null | undefined,
+  selectedStakeUsd: number,
+): StakeGuidance | null {
+  if (!downscaling) return null;
+
+  const { multiplier, reason } = downscaling;
+  if (!Number.isFinite(multiplier) || multiplier <= 0 || multiplier >= 1) {
+    return null;
+  }
+  if (!Number.isFinite(selectedStakeUsd) || selectedStakeUsd <= 0) return null;
+
+  return {
+    multiplier,
+    reason,
+    suggestedStakeUsd: Math.round(selectedStakeUsd * multiplier * 100) / 100,
+    reductionPercent: Math.round((1 - multiplier) * 100),
+  };
+}

--- a/src/web/services/api-client.test.ts
+++ b/src/web/services/api-client.test.ts
@@ -165,6 +165,31 @@ describe('Web API client', () => {
     });
   });
 
+  describe('getEndowedProgress()', () => {
+    it('reads the retention endpoint for one contract and returns its downscaling', async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonOk({
+          contractId: 'c1',
+          realProgress: 0.75,
+          endowedBoost: 0.02,
+          displayProgress: 0.77,
+          currentTier: 'Mastery',
+          nextTierAt: 0.9,
+          motivation: 'This is who you are now.',
+          downscaling: { multiplier: 0.85, reason: 'weekend vulnerability in final 30%' },
+        }),
+      );
+
+      const result = await api.getEndowedProgress('c1');
+
+      expect(mockFetch.mock.calls[0][0]).toContain('/behavioral/retention/endowed-progress/c1');
+      expect(result.downscaling).toEqual({
+        multiplier: 0.85,
+        reason: 'weekend vulnerability in final 30%',
+      });
+    });
+  });
+
   describe('submitProof()', () => {
     it('sends to correct contract path', async () => {
       mockFetch.mockResolvedValueOnce(jsonOk({ proofId: 'p1', jobId: 'j1' }));

--- a/src/web/services/api-client.ts
+++ b/src/web/services/api-client.ts
@@ -366,6 +366,20 @@ export const api = {
       grace_days_max: number;
     }>(`/contracts/${id}`),
 
+  // `downscaling.multiplier` is advisory only — it is rendered as stake guidance
+  // and never applied to a submitted amount (see lib/stake-guidance.ts).
+  getEndowedProgress: (contractId: string) =>
+    request<{
+      contractId: string;
+      realProgress: number;
+      endowedBoost: number;
+      displayProgress: number;
+      currentTier: string;
+      nextTierAt: number;
+      motivation: string;
+      downscaling: { multiplier: number; reason: string };
+    }>(`/behavioral/retention/endowed-progress/${contractId}`),
+
   createContract: (dto: CreateContractDto | Record<string, unknown>) =>
     request<{ contractId: string; paymentIntentId: string }>("/contracts", {
       method: "POST",


### PR DESCRIPTION
## TKT-P1-010 — DR-005 onboarding bonus, and the dead downscaling multiplier

### Part A — the decision-of-record divergence

DR-005 (decided 2026-03-10) removed the $5.00 endowed-progress onboarding bonus for the beta cohort and **kept the mechanic**, exactly as DR-004 kept the appeal fee. The decision never reached the code: every first contract still posted a $5.00 `ONBOARDING_BONUS` ledger credit and an `ONBOARDING_BONUS_GRANTED` truth-log event.

Mirrored DR-004's shipped pattern:

| DR-004 | DR-005 (this PR) |
|---|---|
| `isAppealFeeEnabled()` in `src/api/services/billing.ts` | `isOnboardingBonusEnabled()`, same file, adjacent |
| `STYX_APPEAL_FEE_ENABLED`, defaults off | `STYX_ONBOARDING_BONUS_ENABLED`, defaults off |
| Skips the hold, never zeroes `APPEAL_FEE_AMOUNT` | Skips the grant, never zeroes `ONBOARDING_BONUS_AMOUNT` |
| Price removed from the dispute button label | `+$5.00` row removed from `OnboardingWizard.tsx` |

**Both call sites are gated.** `grantOnboardingBonus` is reached from two paths in `contracts.service.ts`: `runContractCreationActivationSideEffects` (the transactional path, idempotent via `sideEffectKey`) and the non-transactional fallback inside `createContract` (not idempotent). A flag wired at one site reviews as correct and still pays the bonus on every contract created through a pool that supports `connect()` — which is production. Both are covered by their own specs.

**The amount is not zeroed, and here the reason is sharper than DR-004's.** `LedgerService.recordTransaction` throws on a non-positive amount, so a `$0` bonus would throw inside contract-creation side effects → contract marked `RECONCILE_REQUIRED`, hold cancelled, `500` to the user. Every first contract would break. DR-004's note recorded the Stripe form of this trap; this is the ledger form.

**UI.** The wizard's hardcoded `+$5.00` promised money the cohort does not receive, and the client cannot see the server flag — the same reasoning that removed the appeal-fee price from the dispute button (`src/web/app/contracts/[id]/page.tsx`). The row is gone; the wallet ledger reports what was actually granted.

`.env.example` gains a "deferred beta economics" block declaring both flags. `STYX_APPEAL_FEE_ENABLED` was never documented there — it is added alongside, documenting existing behavior without changing it.

### Part B — `applyDynamicDownscaling` was dead telemetry

**Chose read-only surfacing, not the write path.** Applying the multiplier would change what is actually held on a user's card. This repo's own decisions ledger records that pricing has **no** `DR-NNN` at all — five monetization models live in shipped code, and pricing is both Jessica's remit and a joint founder decision under DR-007. Silently shrinking a stake by 15% because it is a weekend is precisely the money behavior that needs a decision of record first. Additionally the multiplier is *contract-scoped*: a write path would mean one contract's strike history quietly reducing a different contract's stake.

So the signal is now rendered as guidance beside the amount on `/contracts/new` — "your active contract is carrying a 15% downscale (weekend vulnerability in final 30%); at that factor this stake would be $25.50" — with an explicit note that the submitted amount is unchanged. Derivation lives in `src/web/lib/stake-guidance.ts` as pure functions (`findMostRecentActiveContract`, `deriveStakeGuidance`) with their own spec; `api.getEndowedProgress()` is the new client call, also spec'd. The guidance fetch has its own `catch` so losing it cannot disturb the failure-count fallback next to it, which is a real safety limit.

If a founder later rules that the downscale should bind, the write path is one line from here — the number is already on the form.

### Verification

Scoped, per the touched specs. Exit codes read bare, not through a pipeline.

```
src/api $ npx jest src/modules/contracts/contracts.service.spec.ts services/billing.spec.ts \
           src/modules/behavioral/endowed-progress.service.spec.ts \
           src/modules/behavioral/retention.controller.spec.ts --coverage=false
  Test Suites: 4 passed, 4 total
  Tests:       172 passed, 172 total

src/api $ npx tsc --noEmit          → exit 0

src/web $ npx jest lib/stake-guidance.test.ts services/api-client.test.ts \
           app/contracts/new/page.test.tsx components/OnboardingWizard.test.tsx --coverage=false
  Test Suites: 4 passed, 4 total
  Tests:       45 passed, 45 total

src/web $ npx tsc --noEmit          → exit 0

$ node scripts/validation/07-claim-drift-check.js
  Claim drift check passed (65 inline code references scanned).
```

**No SQL is verified by any of this.** Every spec here mocks the `pg` Pool. No query text changed in this diff — the guard is a boolean in front of an existing ledger/truth-log call pair — but the green tests are evidence about control flow, not about the database.

The new API specs are real gates in both directions: the flag-on cases assert the exact `recordTransaction` and `appendEvent` argument lists, so they fail if the guard swallows a grant it should allow; the flag-off cases fail on `origin/main`'s behavior.

### Documentation

`planning--founder-decisions-of-record.md` moves DR-005 from "Not yet implemented" to "In force since 2026-08-15", and its Open-implementation entry is struck like DR-004's — with the scoping error recorded, because it was wrong in a useful way. DR-005 was held open on the belief that removing the bonus would leave `endowed-progress.service.ts` half-wired. That service grants no money; it computes a display boost and a read-only multiplier. The two mechanics share a name and nothing else. The real coupling was the two call sites, which nobody predicted.

### Known residual (not in this PR)

`src/pitch/src/data/slides.ts` still sells the bonus to investors — "the $5 onboarding bonus means trying Styx is literally free". That is a marketing-copy divergence against a beta-cohort deferral, on an investor surface rather than a user one, and it wants a founder's call on framing rather than an engineering edit. Named in `concentric-circles-execution.md` rather than silently changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmP1SLhXcZBmA7g4NM6PTY

## Summary by Sourcery

Gate the onboarding bonus behind a configurable DR-005 flag and surface endowed-progress downscaling as read-only stake guidance on new contracts.

New Features:
- Expose endowed-progress downscaling via a web API client call and render it as behavioral stake guidance beside the stake selector on the new-contract page.

Bug Fixes:
- Stop automatically granting the $5 onboarding bonus for first contracts by default, aligning behavior with DR-005 for the beta cohort.

Enhancements:
- Introduce an `isOnboardingBonusEnabled` billing flag that consistently gates onboarding bonus grants across both contract creation paths without zeroing the bonus amount.

Documentation:
- Update founder decision and execution planning docs to record DR-005 as implemented, describe the onboarding bonus flag behavior, and correct earlier scoping assumptions.

Tests:
- Add unit tests for the onboarding bonus flag behavior, for both contract creation paths, for the new endowed-progress API client call, and for stake-guidance derivation and contract selection logic.