### PR TITLE
feat(partner): give the accountability partner protocol a reachable surface (TKT-P1-017)

### DIFF
--- a/src/api/src/modules/contracts/contracts.controller.spec.ts
+++ b/src/api/src/modules/contracts/contracts.controller.spec.ts
@@ -1,6 +1,6 @@
 import { ContractsController } from "./contracts.controller";
 import { ContractsService } from "./contracts.service";
-import { GUARDS_METADATA } from "@nestjs/common/constants";
+import { GUARDS_METADATA, PATH_METADATA } from "@nestjs/common/constants";
 import { DisputeService } from "../../../services/escrow/dispute.service";
 import { validate } from "class-validator";
 import { plainToInstance } from "class-transformer";
@@ -31,6 +31,10 @@ const mockContractsService = {
   recordSelfReportedRelapse: jest.fn(),
   submitWhoopScoredState: jest.fn(),
   claimBounty: jest.fn(),
+  getPendingInvitations: jest.fn(),
+  getPartnerships: jest.fn(),
+  respondToInvite: jest.fn(),
+  vetoRecoveryBreak: jest.fn(),
 } as unknown as ContractsService;
 
 const mockDisputeService = {} as unknown as DisputeService;
@@ -527,6 +531,91 @@ describe("ContractsController", () => {
         "link-abc",
         "r2://evidence.jpg",
         "10.0.0.1",
+      );
+    });
+  });
+
+  describe("accountability partner routes", () => {
+    // Nest registers handlers in declaration order and Express serves the
+    // first match, so a single-segment literal declared after @Get(":id") is
+    // unreachable — GET /contracts/invitations was resolving to findOne().
+    const declarationOrder = () =>
+      Object.getOwnPropertyNames(ContractsController.prototype).filter(
+        (name) => name !== "constructor",
+      );
+
+    const pathOf = (handler: string) =>
+      Reflect.getMetadata(
+        PATH_METADATA,
+        (ContractsController.prototype as any)[handler],
+      );
+
+    it("declares every single-segment literal GET before the :id wildcard", () => {
+      const order = declarationOrder();
+      const wildcardIndex = order.indexOf("findOne");
+      expect(pathOf("findOne")).toBe(":id");
+
+      for (const handler of ["getInvitations", "getPartnerships"]) {
+        const path = pathOf(handler);
+        expect(path).not.toContain("/");
+        expect(order.indexOf(handler)).toBeLessThan(wildcardIndex);
+      }
+    });
+
+    it("GET /contracts/invitations delegates to getPendingInvitations", async () => {
+      const invitations = [{ id: "ap-1", contract_id: "c1" }];
+      (mockContractsService.getPendingInvitations as jest.Mock).mockResolvedValue(
+        invitations,
+      );
+
+      const result = await controller.getInvitations(testUser);
+
+      expect(mockContractsService.getPendingInvitations).toHaveBeenCalledWith(
+        "user-1",
+      );
+      expect(result).toEqual(invitations);
+    });
+
+    it("GET /contracts/partnerships delegates to getPartnerships", async () => {
+      const partnerships = [{ id: "ap-2", contract_id: "c2", status: "ACTIVE" }];
+      (mockContractsService.getPartnerships as jest.Mock).mockResolvedValue(
+        partnerships,
+      );
+
+      const result = await controller.getPartnerships(testUser);
+
+      expect(mockContractsService.getPartnerships).toHaveBeenCalledWith("user-1");
+      expect(result).toEqual(partnerships);
+    });
+
+    it("POST /contracts/:id/recovery/veto-break passes the acting partner", async () => {
+      (mockContractsService.vetoRecoveryBreak as jest.Mock).mockResolvedValue({
+        success: true,
+        message: "Recovery break vetoed by partner",
+      });
+
+      await controller.vetoRecoveryBreak("c-9", testUser);
+
+      expect(mockContractsService.vetoRecoveryBreak).toHaveBeenCalledWith(
+        "c-9",
+        "user-1",
+      );
+    });
+
+    it("POST /contracts/:id/accountability/respond forwards the accept flag", async () => {
+      (mockContractsService.respondToInvite as jest.Mock).mockResolvedValue({
+        success: true,
+        status: "DECLINED",
+      });
+
+      await controller.respondToAccountabilityInvite("c-9", testUser, {
+        accept: false,
+      });
+
+      expect(mockContractsService.respondToInvite).toHaveBeenCalledWith(
+        "c-9",
+        "user-1",
+        false,
       );
     });
   });

--- a/src/api/src/modules/contracts/contracts.controller.ts
+++ b/src/api/src/modules/contracts/contracts.controller.ts
@@ -85,6 +85,26 @@ export class ContractsController {
     return this.contractsService.getCohortSnapshot(cohortId, user.id);
   }
 
+  // Single-segment literal routes MUST stay above @Get(":id"): Nest registers
+  // handlers in declaration order and Express serves the first match, so a
+  // literal declared after the wildcard is dead — "invitations" was being
+  // routed into getContract() as a contract id.
+  @UseGuards(AuthGuard, GeofenceGuard)
+  @Get("invitations")
+  @ApiOperation({ summary: "List pending accountability partner invitations" })
+  async getInvitations(@CurrentUser() user: { id: string }) {
+    return this.contractsService.getPendingInvitations(user.id);
+  }
+
+  @UseGuards(AuthGuard, GeofenceGuard)
+  @Get("partnerships")
+  @ApiOperation({
+    summary: "List contracts the authenticated user is an active partner on",
+  })
+  async getPartnerships(@CurrentUser() user: { id: string }) {
+    return this.contractsService.getPartnerships(user.id);
+  }
+
   @UseGuards(AuthGuard, GeofenceGuard)
   @Get(":id")
   @ApiOperation({ summary: "Get a single contract by ID" })
@@ -238,13 +258,6 @@ export class ContractsController {
       ...dto,
       userId: user.id,
     });
-  }
-
-  @UseGuards(AuthGuard, GeofenceGuard)
-  @Get("invitations")
-  @ApiOperation({ summary: "List pending accountability partner invitations" })
-  async getInvitations(@CurrentUser() user: { id: string }) {
-    return this.contractsService.getPendingInvitations(user.id);
   }
 
   @UseGuards(AuthGuard, GeofenceGuard, BannedUserGuard)

--- a/src/api/src/modules/contracts/contracts.service.spec.ts
+++ b/src/api/src/modules/contracts/contracts.service.spec.ts
@@ -2410,6 +2410,156 @@ describe("ContractsService", () => {
     });
   });
 
+  // ── getPartnerships ──────────────────────────────────────────
+
+  describe("getPartnerships", () => {
+    it("should read the partner side of the relationship, not the owner side", async () => {
+      const rows = [
+        {
+          id: "ap-2",
+          contract_id: "c-2",
+          status: "ACTIVE",
+          owner_email: "owner@styx.app",
+        },
+      ];
+      mockPool.query.mockResolvedValueOnce({ rows });
+
+      const result = await service.getPartnerships("partner-1");
+
+      expect(result).toEqual(rows);
+      const [sql, params] = mockPool.query.mock.calls[0];
+      expect(sql).toContain("ap.partner_user_id = $1");
+      expect(sql).toContain("ap.status = 'ACTIVE'");
+      expect(params).toEqual(["partner-1"]);
+    });
+  });
+
+  // ── partner lifecycle notifications ──────────────────────────
+
+  describe("partner lifecycle notifications", () => {
+    // The service takes notifications as an @Optional() dependency and every
+    // other case in this file passes `undefined`, so this block builds its own
+    // instance with the collaborator wired in.
+    let notifyPool: { query: jest.Mock };
+    let notifyService: ContractsService;
+    const mockNotifications = { create: jest.fn().mockResolvedValue({}) };
+
+    beforeEach(() => {
+      notifyPool = { query: jest.fn().mockResolvedValue({ rows: [] }) };
+      mockNotifications.create.mockClear();
+      notifyService = new ContractsService(
+        notifyPool as unknown as Pool,
+        mockLedger,
+        mockTruthLog,
+        mockStripe,
+        mockRealStripe as any,
+        mockDispute,
+        mockFuryRouter,
+        mockAegis,
+        mockRecovery,
+        mockDynamicPenalty as any,
+        mockAnomaly,
+        mockNotifications as any,
+        undefined, // compliancePolicy
+        mockSettlement,
+      );
+    });
+
+    it("notifies the invitee when a partner is invited", async () => {
+      notifyPool.query
+        .mockResolvedValueOnce({ rows: [{ id: "c-1", user_id: "owner-1" }] }) // contract
+        .mockResolvedValueOnce({ rows: [{ id: "partner-9" }] }) // partner lookup
+        .mockResolvedValueOnce({ rows: [] }) // INSERT accountability_partners
+        .mockResolvedValueOnce({ rows: [] }); // INSERT event
+
+      await notifyService.invitePartner("c-1", "owner-1", "friend@styx.app");
+
+      expect(mockNotifications.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "partner-9",
+          type: "PARTNER_INVITATION",
+          metadata: { contractId: "c-1" },
+        }),
+      );
+    });
+
+    it("notifies the owner when the invitation is declined", async () => {
+      notifyPool.query
+        .mockResolvedValueOnce({ rows: [{ id: "ap-1" }] }) // UPDATE RETURNING
+        .mockResolvedValueOnce({ rows: [] }) // INSERT event
+        .mockResolvedValueOnce({ rows: [{ user_id: "owner-1" }] }); // owner lookup
+
+      await notifyService.respondToInvite("c-1", "partner-9", false);
+
+      expect(mockNotifications.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "owner-1",
+          type: "PARTNER_INVITATION_DECLINED",
+        }),
+      );
+    });
+
+    it("notifies the owner when the invitation is accepted", async () => {
+      notifyPool.query
+        .mockResolvedValueOnce({ rows: [{ id: "ap-1" }] }) // UPDATE RETURNING
+        .mockResolvedValueOnce({ rows: [{ user_id: "owner-1" }] }); // owner lookup
+
+      await notifyService.acceptPartnerInvitation("c-1", "partner-9");
+
+      expect(mockNotifications.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "owner-1",
+          type: "PARTNER_INVITATION_ACCEPTED",
+        }),
+      );
+    });
+
+    it("notifies the owner when an attestation is co-signed", async () => {
+      notifyPool.query
+        .mockResolvedValueOnce({ rows: [{ "?column?": 1 }] }) // partner check
+        .mockResolvedValueOnce({ rows: [{ id: "attest-1" }] }) // latest attestation
+        .mockResolvedValueOnce({ rows: [] }) // UPDATE attestation
+        .mockResolvedValueOnce({ rows: [{ user_id: "owner-1" }] }); // owner lookup
+
+      await notifyService.cosignAttestation("c-1", "partner-9");
+
+      expect(mockNotifications.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "owner-1",
+          type: "ATTESTATION_COSIGNED",
+        }),
+      );
+    });
+
+    it("notifies the owner when a recovery break is vetoed", async () => {
+      notifyPool.query
+        .mockResolvedValueOnce({ rows: [{ id: "ap-1" }] }) // active partner check
+        .mockResolvedValueOnce({ rows: [] }) // UPDATE recovery_break_requests
+        .mockResolvedValueOnce({ rows: [] }) // INSERT event
+        .mockResolvedValueOnce({ rows: [{ user_id: "owner-1" }] }); // owner lookup
+
+      await notifyService.vetoRecoveryBreak("c-1", "partner-9");
+
+      expect(mockNotifications.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "owner-1",
+          type: "RECOVERY_BREAK_VETOED",
+        }),
+      );
+    });
+
+    it("returns successfully when the notification collaborator throws", async () => {
+      mockNotifications.create.mockRejectedValueOnce(new Error("queue down"));
+      notifyPool.query
+        .mockResolvedValueOnce({ rows: [{ id: "ap-1" }] })
+        .mockResolvedValueOnce({ rows: [{ user_id: "owner-1" }] });
+
+      await expect(
+        notifyService.acceptPartnerInvitation("c-1", "partner-9"),
+      ).resolves.toEqual({ status: "active" });
+    });
+  });
+
   // ── processHealthKitSample ───────────────────────────────────
 
   describe("processHealthKitSample", () => {

--- a/src/api/src/modules/contracts/contracts.service.ts
+++ b/src/api/src/modules/contracts/contracts.service.ts
@@ -3177,6 +3177,42 @@ export class ContractsService {
     return result.rows;
   }
 
+  /**
+   * Contracts the user is an ACTIVE accountability partner on.
+   *
+   * The mirror of getPendingInvitations, and the only read that answers
+   * "what am I partnered on" — getActivePartnerships (retention) runs the
+   * opposite direction (an owner's partners), so a partner had no way to
+   * find their own contracts again after accepting an invitation.
+   */
+  async getPartnerships(userId: string) {
+    const result = await this.pool.query(
+      `SELECT ap.id, ap.contract_id, ap.status, ap.accepted_at,
+              c.oath_category, c.stake_amount, c.ends_at,
+              c.status AS contract_status,
+              u.email AS owner_email
+       FROM accountability_partners ap
+       JOIN contracts c ON ap.contract_id = c.id
+       JOIN users u ON c.user_id = u.id
+       WHERE ap.partner_user_id = $1 AND ap.status = 'ACTIVE'
+       ORDER BY ap.accepted_at DESC NULLS LAST`,
+      [userId],
+    );
+    return result.rows;
+  }
+
+  /**
+   * Owner of a contract, or null when the row is gone. Partner lifecycle
+   * notifications address the owner, who is never the actor performing them.
+   */
+  private async getContractOwnerId(contractId: string): Promise<string | null> {
+    const { rows } = await this.pool.query(
+      `SELECT user_id FROM contracts WHERE id = $1`,
+      [contractId],
+    );
+    return rows[0]?.user_id ?? null;
+  }
+
   async acceptPartnerInvitation(contractId: string, partnerUserId: string) {
     const result = await this.pool.query(
       `UPDATE accountability_partners
@@ -3194,6 +3230,22 @@ export class ContractsService {
       contractId,
       partnerUserId,
     });
+
+    // Notify the contract owner (non-critical)
+    try {
+      const ownerId = await this.getContractOwnerId(contractId);
+      if (ownerId) {
+        await this.notifications?.create({
+          userId: ownerId,
+          type: "PARTNER_INVITATION_ACCEPTED",
+          title: "Partner Accepted",
+          body: "Your accountability partner accepted the invitation and can now co-sign your attestations.",
+          metadata: { contractId, partnerUserId },
+        });
+      }
+    } catch {
+      // Notification failure must never abort an accepted invitation
+    }
 
     return { status: "active" };
   }
@@ -3236,6 +3288,22 @@ export class ContractsService {
       contractId,
       partnerUserId,
     });
+
+    // Notify the contract owner (non-critical)
+    try {
+      const ownerId = await this.getContractOwnerId(contractId);
+      if (ownerId) {
+        await this.notifications?.create({
+          userId: ownerId,
+          type: "ATTESTATION_COSIGNED",
+          title: "Attestation Co-Signed",
+          body: "Your accountability partner co-signed today's attestation.",
+          metadata: { contractId, attestationId, partnerUserId },
+        });
+      }
+    } catch {
+      // Notification failure must never abort a recorded co-signature
+    }
 
     return { status: "cosigned" };
   }
@@ -3669,6 +3737,20 @@ export class ContractsService {
       [contractId, userId, JSON.stringify({ partnerId })],
     );
 
+    // Notify the invitee (non-critical). Without this the invitation is a
+    // PENDING row and an event log line — nothing the invited user can see.
+    try {
+      await this.notifications?.create({
+        userId: partnerId,
+        type: "PARTNER_INVITATION",
+        title: "Partner Invitation",
+        body: "You have been invited to be an accountability partner on a Styx contract.",
+        metadata: { contractId },
+      });
+    } catch {
+      // Notification failure must never abort a recorded invitation
+    }
+
     return { success: true, partnerId };
   }
 
@@ -3690,6 +3772,28 @@ export class ContractsService {
       "INSERT INTO accountability_partner_events (contract_id, actor_id, event_type) VALUES (\$1, \$2, \$3)",
       [contractId, partnerId, accept ? "INVITE_ACCEPTED" : "INVITE_DECLINED"],
     );
+
+    // Notify the contract owner (non-critical). A decline is the case that
+    // most needs a signal: the owner is otherwise left waiting on a partner
+    // who will never arrive.
+    try {
+      const ownerId = await this.getContractOwnerId(contractId);
+      if (ownerId) {
+        await this.notifications?.create({
+          userId: ownerId,
+          type: accept
+            ? "PARTNER_INVITATION_ACCEPTED"
+            : "PARTNER_INVITATION_DECLINED",
+          title: accept ? "Partner Accepted" : "Partner Declined",
+          body: accept
+            ? "Your accountability partner accepted the invitation and can now co-sign your attestations."
+            : "Your accountability partner declined the invitation. Invite someone else to keep the contract covered.",
+          metadata: { contractId, partnerId },
+        });
+      }
+    } catch {
+      // Notification failure must never abort a recorded response
+    }
 
     return { success: true, status };
   }
@@ -3713,6 +3817,24 @@ export class ContractsService {
       "INSERT INTO accountability_partner_events (contract_id, actor_id, event_type) VALUES (\$1, \$2, 'VETO_TRIGGERED')",
       [contractId, partnerId],
     );
+
+    // Notify the contract owner (non-critical). A veto cancels a break the
+    // owner queued and is waiting on — silence here reads as the timelock
+    // simply never releasing.
+    try {
+      const ownerId = await this.getContractOwnerId(contractId);
+      if (ownerId) {
+        await this.notifications?.create({
+          userId: ownerId,
+          type: "RECOVERY_BREAK_VETOED",
+          title: "Break Vetoed",
+          body: "Your accountability partner vetoed the intentional break you queued. The contract stays active.",
+          metadata: { contractId, partnerId },
+        });
+      }
+    } catch {
+      // Notification failure must never abort a recorded veto
+    }
 
     return { success: true, message: "Recovery break vetoed by partner" };
   }

--- a/src/web/app/contracts/[id]/page.test.tsx
+++ b/src/web/app/contracts/[id]/page.test.tsx
@@ -38,6 +38,8 @@ jest.mock('../../../services/api-client', () => ({
     submitProof: jest.fn(),
     useGraceDay: jest.fn(),
     disputeContract: jest.fn(),
+    getAccountabilityStatus: jest.fn().mockResolvedValue({ partners: [], history: [] }),
+    invitePartner: jest.fn(),
   },
 }));
 

--- a/src/web/app/contracts/[id]/page.tsx
+++ b/src/web/app/contracts/[id]/page.tsx
@@ -5,9 +5,10 @@ import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import {
   ArrowLeft, Clock, CheckCircle, XCircle, Loader2, AlertTriangle,
-  Send, Calendar, Shield, FileText,
+  Send, Calendar, Shield, FileText, UserPlus,
 } from 'lucide-react';
 import { api } from '../../../services/api-client';
+import type { AccountabilityStatus } from '../../../services/api-client';
 import { useAuth } from '../../../contexts/AuthContext';
 import RecoveryLockCountdown from '../../../components/RecoveryLockCountdown';
 import DangerZoneBanner from '../../../components/DangerZoneBanner';
@@ -72,6 +73,12 @@ export default function ContractDetailPage() {
   const [disputeLoading, setDisputeLoading] = useState(false);
   const [disputeResult, setDisputeResult] = useState<string | null>(null);
 
+  // Accountability partner (owner side)
+  const [partnerStatus, setPartnerStatus] = useState<AccountabilityStatus | null>(null);
+  const [partnerEmail, setPartnerEmail] = useState('');
+  const [inviteLoading, setInviteLoading] = useState(false);
+  const [inviteResult, setInviteResult] = useState<string | null>(null);
+
   useEffect(() => {
     if (authLoading || !authUser) return;
     async function load() {
@@ -79,6 +86,9 @@ export default function ContractDetailPage() {
         const contractData = await api.getContract(contractId);
         setContract(contractData as any);
         setProofs(contractData.proofs as any || []);
+        // A contract with no partners is the normal case, not an error — the
+        // roster stays null and the panel renders its invite form.
+        setPartnerStatus(await api.getAccountabilityStatus(contractId).catch(() => null));
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load contract');
       } finally {
@@ -136,6 +146,22 @@ export default function ContractDetailPage() {
       setDisputeResult(err instanceof Error ? err.message : 'Failed to file dispute');
     } finally {
       setDisputeLoading(false);
+    }
+  };
+
+  const handleInvitePartner = async () => {
+    if (!partnerEmail.trim()) return;
+    setInviteLoading(true);
+    setInviteResult(null);
+    try {
+      await api.invitePartner(contractId, partnerEmail.trim());
+      setPartnerEmail('');
+      setInviteResult('Invitation sent. They accept it from their partner page.');
+      setPartnerStatus(await api.getAccountabilityStatus(contractId).catch(() => partnerStatus));
+    } catch (err) {
+      setInviteResult(err instanceof Error ? err.message : 'Failed to invite partner');
+    } finally {
+      setInviteLoading(false);
     }
   };
 
@@ -375,6 +401,73 @@ export default function ContractDetailPage() {
           </div>
         </div>
       )}
+
+      {/* Accountability Partner — owner side of the partner protocol */}
+      <div className="mt-8 p-6 bg-neutral-900 border border-neutral-800 rounded-2xl space-y-4">
+        <h2 className="font-bold text-sm uppercase tracking-widest text-neutral-500">
+          Accountability Partner
+        </h2>
+
+        {partnerStatus && partnerStatus.partners.length > 0 ? (
+          <div className="space-y-2">
+            {partnerStatus.partners.map((partner) => (
+              <div
+                key={`${partner.partner_user_id}-${partner.email}`}
+                className="flex items-center justify-between p-3 bg-black rounded-xl border border-neutral-800"
+              >
+                <p className="font-bold text-sm break-all">{partner.email}</p>
+                <span className={`text-xs font-bold px-3 py-1 rounded-full ${
+                  partner.status === 'ACTIVE' ? 'bg-green-900/30 text-green-400' :
+                  partner.status === 'PENDING' ? 'bg-blue-900/30 text-blue-400' :
+                  'bg-red-900/30 text-red-400'
+                }`}>
+                  {partner.status}
+                </span>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-neutral-500">
+            No partner on this contract. A partner co-signs your daily attestations.
+          </p>
+        )}
+
+        <div className="space-y-3">
+          <input
+            type="email"
+            value={partnerEmail}
+            onChange={(e) => setPartnerEmail(e.target.value)}
+            placeholder="partner@example.com"
+            className="w-full px-4 py-3 bg-black border border-neutral-700 rounded-xl text-white placeholder-neutral-600 focus:outline-none focus:border-red-600"
+          />
+          <button
+            onClick={handleInvitePartner}
+            disabled={inviteLoading || !partnerEmail.trim()}
+            className="w-full py-3 bg-neutral-800 hover:bg-neutral-700 disabled:opacity-50 text-white font-bold rounded-xl transition-colors flex items-center justify-center gap-2"
+          >
+            {inviteLoading ? <Loader2 className="animate-spin" size={16} /> : <UserPlus size={16} />}
+            Invite Partner
+          </button>
+          {inviteResult && <p className="text-sm text-neutral-400">{inviteResult}</p>}
+        </div>
+
+        {partnerStatus && partnerStatus.history.length > 0 && (
+          <div className="space-y-2">
+            <h3 className="text-xs uppercase tracking-widest text-neutral-500">Partner Ledger</h3>
+            {partnerStatus.history.map((event) => (
+              <div
+                key={event.id}
+                className="flex items-center justify-between p-3 bg-black rounded-xl border border-neutral-800"
+              >
+                <span className="text-sm font-bold">{event.event_type.replace(/_/g, ' ')}</span>
+                <span className="text-xs text-neutral-500">
+                  {event.created_at ? new Date(event.created_at).toLocaleString() : ''}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/web/app/dashboard/page.tsx
+++ b/src/web/app/dashboard/page.tsx
@@ -125,6 +125,9 @@ export default function IdentityDashboard() {
           <Link href="/wallet" className="px-3 md:px-4 py-2 bg-neutral-900 rounded-full border border-neutral-800 text-xs md:text-sm font-bold text-neutral-400 hover:text-white transition-colors">
             WALLET
           </Link>
+          <Link href="/partner" className="px-3 md:px-4 py-2 bg-neutral-900 rounded-full border border-neutral-800 text-xs md:text-sm font-bold text-neutral-400 hover:text-white transition-colors">
+            PARTNER
+          </Link>
           <Link href="/settings" className="px-3 md:px-4 py-2 bg-neutral-900 rounded-full border border-neutral-800 text-xs md:text-sm font-bold text-neutral-400 hover:text-white transition-colors flex items-center gap-1">
             <Settings size={14} />
           </Link>

--- a/src/web/app/partner/page.test.tsx
+++ b/src/web/app/partner/page.test.tsx
@@ -1,0 +1,221 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+jest.mock('next/link', () => {
+  return function MockLink({ children, href }: { children: React.ReactNode; href: string }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+jest.mock('../../services/api-client', () => ({
+  api: {
+    getPartnerInvitations: jest.fn().mockResolvedValue([]),
+    getPartnerships: jest.fn().mockResolvedValue([]),
+    acceptPartnerInvitation: jest.fn(),
+    respondToPartnerInvite: jest.fn(),
+    cosignAttestation: jest.fn(),
+    vetoRecoveryBreak: jest.fn(),
+    getAccountabilityStatus: jest.fn(),
+    getPartnerCheckIns: jest.fn(),
+    completePartnerCheckIn: jest.fn(),
+  },
+}));
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'partner-1', email: 'partner@styx.io', integrity_score: 80, role: 'USER' },
+    token: 'mock-token', // allow-secret
+    login: jest.fn(),
+    register: jest.fn(),
+    logout: jest.fn(),
+    isLoading: false,
+  }),
+}));
+
+import PartnerPage, {
+  CheckInThread,
+  InvitationCard,
+  PartnershipCard,
+  supportsVeto,
+} from './page';
+
+const invitation = {
+  id: 'ap-1',
+  contract_id: 'contract-1',
+  partner_user_id: 'partner-1',
+  partner_email: 'partner@styx.io',
+  status: 'PENDING',
+  invited_at: '2026-08-01T00:00:00Z',
+  accepted_at: null,
+  oath_category: 'RECOVERY_NOCONTACT',
+  stake_amount: '150.00',
+  owner_email: 'owner@styx.io',
+};
+
+const partnership = {
+  id: 'ap-2',
+  contract_id: 'contract-2',
+  status: 'ACTIVE',
+  accepted_at: '2026-08-02T00:00:00Z',
+  oath_category: 'RECOVERY_NOCONTACT',
+  stake_amount: '150.00',
+  ends_at: '2026-09-01T00:00:00Z',
+  contract_status: 'ACTIVE',
+  owner_email: 'owner@styx.io',
+};
+
+const noop = () => undefined;
+
+describe('Partner page', () => {
+  it('renders its own loading state while the two lists are in flight', () => {
+    const html = renderToStaticMarkup(<PartnerPage />);
+
+    expect(html).toContain('Loading partner activity');
+    expect(html).toContain('animate-spin');
+  });
+});
+
+describe('InvitationCard', () => {
+  const render = (busy = false) =>
+    renderToStaticMarkup(
+      <InvitationCard invitation={invitation} busy={busy} onAccept={noop} onDecline={noop} />,
+    );
+
+  it('names the inviting owner, the oath, and the stake at risk', () => {
+    const html = render();
+
+    expect(html).toContain('owner@styx.io');
+    expect(html).toContain('RECOVERY NOCONTACT');
+    expect(html).toContain('$150.00');
+  });
+
+  it('offers both a decision and its opposite', () => {
+    const html = render();
+
+    expect(html).toContain('ACCEPT');
+    expect(html).toContain('DECLINE');
+  });
+
+  it('disables both decisions while one is in flight', () => {
+    const html = render(true);
+
+    expect(html.match(/disabled=""/g)?.length).toBe(2);
+  });
+});
+
+describe('PartnershipCard', () => {
+  const render = (overrides: Partial<React.ComponentProps<typeof PartnershipCard>> = {}) =>
+    renderToStaticMarkup(
+      <PartnershipCard
+        partnership={partnership}
+        busy={false}
+        expanded={false}
+        status={null}
+        checkIns={[]}
+        draft=""
+        onToggle={noop}
+        onCosign={noop}
+        onVeto={noop}
+        onDraftChange={noop}
+        onCompleteCheckIn={noop}
+        {...overrides}
+      />,
+    );
+
+  it('surfaces the co-sign action on the contract the partner can reach', () => {
+    expect(render()).toContain('CO-SIGN ATTESTATION');
+  });
+
+  it('surfaces the veto only on recovery contracts', () => {
+    expect(render()).toContain('VETO PENDING BREAK');
+    expect(
+      render({ partnership: { ...partnership, oath_category: 'BIOLOGICAL_WEIGHT' } }),
+    ).not.toContain('VETO PENDING BREAK');
+  });
+
+  it('keeps the partner ledger and check-in thread behind the history toggle', () => {
+    const collapsed = render();
+    expect(collapsed).toContain('SHOW HISTORY');
+    expect(collapsed).not.toContain('Partner Ledger');
+
+    const open = render({
+      expanded: true,
+      status: {
+        partners: [{ email: 'partner@styx.io', status: 'ACTIVE', partner_user_id: 'partner-1' }],
+        history: [
+          {
+            id: 'evt-1',
+            contract_id: 'contract-2',
+            actor_id: 'partner-1',
+            event_type: 'INVITE_ACCEPTED',
+            payload: null,
+            created_at: '2026-08-02T00:00:00Z',
+          },
+        ],
+      },
+    });
+    expect(open).toContain('HIDE HISTORY');
+    expect(open).toContain('Partner Ledger');
+    expect(open).toContain('INVITE ACCEPTED');
+    expect(open).toContain('Check-In History');
+  });
+});
+
+describe('CheckInThread', () => {
+  const scheduled = {
+    id: 'chk-1',
+    contractId: 'contract-2',
+    partnerId: 'partner-1',
+    type: 'SCHEDULED' as const,
+    status: 'PENDING' as const,
+    scheduledAt: '2026-08-03T00:00:00Z',
+  };
+
+  it('offers the compose box only when a check-in is still PENDING', () => {
+    const pending = renderToStaticMarkup(
+      <CheckInThread
+        checkIns={[scheduled]}
+        draft="holding steady"
+        busy={false}
+        onDraftChange={noop}
+        onComplete={noop}
+      />,
+    );
+    expect(pending).toContain('COMPLETE CHECK-IN');
+
+    const done = renderToStaticMarkup(
+      <CheckInThread
+        checkIns={[{ ...scheduled, status: 'COMPLETED', message: 'held the line' }]}
+        draft=""
+        busy={false}
+        onDraftChange={noop}
+        onComplete={noop}
+      />,
+    );
+    expect(done).not.toContain('COMPLETE CHECK-IN');
+    expect(done).toContain('held the line');
+  });
+
+  it('reports an empty thread instead of rendering nothing', () => {
+    const html = renderToStaticMarkup(
+      <CheckInThread
+        checkIns={[]}
+        draft=""
+        busy={false}
+        onDraftChange={noop}
+        onComplete={noop}
+      />,
+    );
+
+    expect(html).toContain('No check-ins scheduled yet.');
+  });
+});
+
+describe('supportsVeto', () => {
+  it('is true only for the recovery stream, which is the only one with a break timelock', () => {
+    expect(supportsVeto('RECOVERY_NOCONTACT')).toBe(true);
+    expect(supportsVeto('RECOVERY_SOBRIETY')).toBe(true);
+    expect(supportsVeto('BIOLOGICAL_WEIGHT')).toBe(false);
+    expect(supportsVeto('DEEP_WORK_FOCUS')).toBe(false);
+  });
+});

--- a/src/web/app/partner/page.tsx
+++ b/src/web/app/partner/page.tsx
@@ -1,0 +1,464 @@
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import {
+  ArrowLeft, Ban, Check, Clock, Inbox, Loader2, MessageSquare, PenLine, Users, X,
+} from 'lucide-react';
+import { api } from '../../services/api-client';
+import { useAuth } from '../../contexts/AuthContext';
+import type {
+  AccountabilityStatus,
+  PartnerCheckIn,
+  PartnerInvitation,
+  Partnership,
+} from '../../services/api-client';
+
+function categoryLabel(oathCategory: string): string {
+  return oathCategory.replace(/_/g, ' ');
+}
+
+function stakeLabel(stakeAmount: string): string {
+  const value = Number(stakeAmount);
+  return Number.isFinite(value) ? `$${value.toFixed(2)}` : '$0.00';
+}
+
+/**
+ * Only RECOVERY_* contracts have a break-request timelock, so the veto is the
+ * one partner action that is category-conditional.
+ */
+export function supportsVeto(oathCategory: string): boolean {
+  return oathCategory.startsWith('RECOVERY_');
+}
+
+export function InvitationCard({
+  invitation,
+  busy,
+  onAccept,
+  onDecline,
+}: {
+  invitation: PartnerInvitation;
+  busy: boolean;
+  onAccept: () => void;
+  onDecline: () => void;
+}) {
+  return (
+    <div className="bg-neutral-900 border border-neutral-800 rounded-2xl p-6 space-y-4">
+      <div>
+        <p className="text-xs uppercase tracking-widest text-neutral-500">Invited by</p>
+        <p className="font-bold text-white break-all">{invitation.owner_email}</p>
+      </div>
+      <div className="flex flex-wrap gap-6">
+        <div>
+          <p className="text-xs uppercase tracking-widest text-neutral-500">Oath</p>
+          <p className="font-bold text-white">{categoryLabel(invitation.oath_category)}</p>
+        </div>
+        <div>
+          <p className="text-xs uppercase tracking-widest text-neutral-500">Stake</p>
+          <p className="font-bold text-red-500">{stakeLabel(invitation.stake_amount)}</p>
+        </div>
+      </div>
+      <p className="text-sm text-neutral-400">
+        As their partner you co-sign daily attestations and can veto an intentional break
+        while it is still in its 24-hour cooldown.
+      </p>
+      <div className="flex gap-3">
+        <button
+          onClick={onAccept}
+          disabled={busy}
+          className="flex-1 py-3 bg-green-600 hover:bg-green-700 disabled:opacity-50 text-black font-black rounded-xl transition-colors flex items-center justify-center gap-2"
+        >
+          {busy ? <Loader2 className="animate-spin" size={16} /> : <Check size={16} />}
+          ACCEPT
+        </button>
+        <button
+          onClick={onDecline}
+          disabled={busy}
+          className="flex-1 py-3 bg-neutral-800 hover:bg-neutral-700 disabled:opacity-50 text-white font-bold rounded-xl transition-colors flex items-center justify-center gap-2"
+        >
+          <X size={16} />
+          DECLINE
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function CheckInThread({
+  checkIns,
+  draft,
+  busy,
+  onDraftChange,
+  onComplete,
+}: {
+  checkIns: PartnerCheckIn[];
+  draft: string;
+  busy: boolean;
+  onDraftChange: (value: string) => void;
+  onComplete: (checkInId: string) => void;
+}) {
+  const pending = checkIns.find((c) => c.status === 'PENDING');
+
+  return (
+    <div className="space-y-3">
+      <h4 className="text-xs uppercase tracking-widest text-neutral-500">Check-In History</h4>
+      {checkIns.length === 0 ? (
+        <p className="text-sm text-neutral-500">No check-ins scheduled yet.</p>
+      ) : (
+        <ul className="space-y-2">
+          {checkIns.map((checkIn) => (
+            <li
+              key={checkIn.id}
+              className="p-3 bg-black border border-neutral-800 rounded-xl flex items-start justify-between gap-3"
+            >
+              <div className="min-w-0">
+                <p className="text-sm font-bold text-white">{checkIn.type.replace(/_/g, ' ')}</p>
+                <p className="text-xs text-neutral-500">
+                  {checkIn.scheduledAt ? new Date(checkIn.scheduledAt).toLocaleString() : 'Unscheduled'}
+                </p>
+                {checkIn.message && (
+                  <p className="text-sm text-neutral-300 mt-1 break-words">{checkIn.message}</p>
+                )}
+              </div>
+              <span
+                className={`text-xs font-bold px-3 py-1 rounded-full shrink-0 ${
+                  checkIn.status === 'COMPLETED'
+                    ? 'bg-green-900/30 text-green-400'
+                    : checkIn.status === 'PENDING'
+                      ? 'bg-blue-900/30 text-blue-400'
+                      : 'bg-red-900/30 text-red-400'
+                }`}
+              >
+                {checkIn.status}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {pending && (
+        <div className="space-y-2">
+          <textarea
+            value={draft}
+            onChange={(e) => onDraftChange(e.target.value)}
+            placeholder="How are they holding up?"
+            rows={2}
+            className="w-full px-4 py-3 bg-black border border-neutral-700 rounded-xl text-white placeholder-neutral-600 focus:outline-none focus:border-red-600"
+          />
+          <button
+            onClick={() => onComplete(pending.id)}
+            disabled={busy || draft.trim().length === 0}
+            className="w-full py-3 bg-neutral-800 hover:bg-neutral-700 disabled:opacity-50 text-white font-bold rounded-xl transition-colors flex items-center justify-center gap-2"
+          >
+            {busy ? <Loader2 className="animate-spin" size={16} /> : <MessageSquare size={16} />}
+            COMPLETE CHECK-IN
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function PartnershipCard({
+  partnership,
+  busy,
+  expanded,
+  status,
+  checkIns,
+  draft,
+  onToggle,
+  onCosign,
+  onVeto,
+  onDraftChange,
+  onCompleteCheckIn,
+}: {
+  partnership: Partnership;
+  busy: boolean;
+  expanded: boolean;
+  status: AccountabilityStatus | null;
+  checkIns: PartnerCheckIn[];
+  draft: string;
+  onToggle: () => void;
+  onCosign: () => void;
+  onVeto: () => void;
+  onDraftChange: (value: string) => void;
+  onCompleteCheckIn: (checkInId: string) => void;
+}) {
+  return (
+    <div className="bg-neutral-900 border border-neutral-800 rounded-2xl p-6 space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-widest text-neutral-500">Partnered with</p>
+          <p className="font-bold text-white break-all">{partnership.owner_email}</p>
+          <p className="text-sm text-neutral-400 mt-1">
+            {categoryLabel(partnership.oath_category)} &bull; {stakeLabel(partnership.stake_amount)} at stake
+          </p>
+        </div>
+        <span className="text-xs font-bold px-3 py-1 rounded-full bg-blue-900/30 text-blue-400">
+          {partnership.contract_status}
+        </span>
+      </div>
+
+      <div className="flex flex-wrap gap-3">
+        <button
+          onClick={onCosign}
+          disabled={busy}
+          className="flex-1 min-w-[12rem] py-3 bg-amber-600 hover:bg-amber-700 disabled:opacity-50 text-black font-black rounded-xl transition-colors flex items-center justify-center gap-2"
+        >
+          {busy ? <Loader2 className="animate-spin" size={16} /> : <PenLine size={16} />}
+          CO-SIGN ATTESTATION
+        </button>
+        {supportsVeto(partnership.oath_category) && (
+          <button
+            onClick={onVeto}
+            disabled={busy}
+            className="flex-1 min-w-[12rem] py-3 bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white font-bold rounded-xl transition-colors flex items-center justify-center gap-2"
+          >
+            <Ban size={16} />
+            VETO PENDING BREAK
+          </button>
+        )}
+        <button
+          onClick={onToggle}
+          className="py-3 px-4 bg-neutral-800 hover:bg-neutral-700 text-white font-bold rounded-xl transition-colors flex items-center gap-2"
+        >
+          <Clock size={16} />
+          {expanded ? 'HIDE HISTORY' : 'SHOW HISTORY'}
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="space-y-6 pt-2 border-t border-neutral-800">
+          <div className="space-y-3 pt-4">
+            <h4 className="text-xs uppercase tracking-widest text-neutral-500">Partner Ledger</h4>
+            {status && status.history.length > 0 ? (
+              <ul className="space-y-2">
+                {status.history.map((event) => (
+                  <li
+                    key={event.id}
+                    className="p-3 bg-black border border-neutral-800 rounded-xl flex items-center justify-between gap-3"
+                  >
+                    <span className="text-sm font-bold text-white">
+                      {event.event_type.replace(/_/g, ' ')}
+                    </span>
+                    <span className="text-xs text-neutral-500">
+                      {event.created_at ? new Date(event.created_at).toLocaleString() : ''}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-neutral-500">No partner events recorded yet.</p>
+            )}
+          </div>
+
+          <CheckInThread
+            checkIns={checkIns}
+            draft={draft}
+            busy={busy}
+            onDraftChange={onDraftChange}
+            onComplete={onCompleteCheckIn}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function PartnerPage() {
+  const { user, isLoading: authLoading } = useAuth();
+  const [invitations, setInvitations] = useState<PartnerInvitation[]>([]);
+  const [partnerships, setPartnerships] = useState<Partnership[]>([]);
+  const [statuses, setStatuses] = useState<Record<string, AccountabilityStatus>>({});
+  const [checkIns, setCheckIns] = useState<Record<string, PartnerCheckIn[]>>({});
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    const [invites, active] = await Promise.all([
+      api.getPartnerInvitations(),
+      api.getPartnerships(),
+    ]);
+    setInvitations(invites);
+    setPartnerships(active);
+  }, []);
+
+  useEffect(() => {
+    if (authLoading || !user) return;
+    reload()
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : 'Failed to load partner activity');
+      })
+      .finally(() => setLoading(false));
+  }, [user, authLoading, reload]);
+
+  // Every action re-reads both lists: accepting moves a row from one section
+  // to the other, and a decline removes it, so local mutation would drift.
+  const run = async (contractId: string, action: () => Promise<string>) => {
+    setBusyId(contractId);
+    setError(null);
+    setNotice(null);
+    try {
+      setNotice(await action());
+      await reload();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Action failed');
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleAccept = (contractId: string) =>
+    run(contractId, async () => {
+      await api.acceptPartnerInvitation(contractId);
+      return 'Invitation accepted. You are now an active accountability partner.';
+    });
+
+  const handleDecline = (contractId: string) =>
+    run(contractId, async () => {
+      await api.respondToPartnerInvite(contractId, false);
+      return 'Invitation declined.';
+    });
+
+  const handleCosign = (contractId: string) =>
+    run(contractId, async () => {
+      await api.cosignAttestation(contractId);
+      return "Today's attestation co-signed.";
+    });
+
+  const handleVeto = (contractId: string) =>
+    run(contractId, async () => {
+      const result = await api.vetoRecoveryBreak(contractId);
+      return result.message;
+    });
+
+  const handleCompleteCheckIn = (contractId: string, checkInId: string) =>
+    run(contractId, async () => {
+      await api.completePartnerCheckIn(checkInId, drafts[contractId] ?? '');
+      setDrafts((prev) => ({ ...prev, [contractId]: '' }));
+      const refreshed = await api.getPartnerCheckIns(contractId);
+      setCheckIns((prev) => ({ ...prev, [contractId]: refreshed }));
+      return 'Check-in recorded.';
+    });
+
+  const handleToggle = async (contractId: string) => {
+    if (expanded === contractId) {
+      setExpanded(null);
+      return;
+    }
+    setExpanded(contractId);
+    try {
+      const [status, history] = await Promise.all([
+        api.getAccountabilityStatus(contractId),
+        api.getPartnerCheckIns(contractId),
+      ]);
+      setStatuses((prev) => ({ ...prev, [contractId]: status }));
+      setCheckIns((prev) => ({ ...prev, [contractId]: history }));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load partner history');
+    }
+  };
+
+  if (authLoading || loading) {
+    return (
+      <div className="min-h-screen bg-black text-white flex items-center justify-center">
+        <Loader2 className="animate-spin mr-3" size={24} />
+        <span className="text-neutral-400 font-bold">Loading partner activity...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-black text-white font-sans p-6 md:p-12">
+      <header className="flex items-center gap-4 mb-10 border-b border-neutral-800 pb-6">
+        <Link
+          href="/dashboard"
+          className="p-2 bg-neutral-900 rounded-lg border border-neutral-800 hover:bg-neutral-800 transition-colors"
+        >
+          <ArrowLeft size={20} />
+        </Link>
+        <div className="flex items-center gap-4">
+          <div className="w-12 h-12 bg-red-600 rounded-full flex items-center justify-center">
+            <Users className="text-black" size={24} />
+          </div>
+          <div>
+            <h1 className="text-2xl font-black tracking-tight uppercase">Accountability Partner</h1>
+            <p className="text-xs text-neutral-500 uppercase tracking-widest">
+              Invitations, co-signatures, and vetoes
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <div className="max-w-3xl mx-auto space-y-10">
+        {notice && (
+          <div className="p-4 bg-green-900/20 border border-green-600/30 rounded-xl text-green-400 text-sm font-bold">
+            {notice}
+          </div>
+        )}
+        {error && (
+          <div className="p-4 bg-red-600/10 border border-red-600/30 rounded-xl text-red-400 text-sm font-bold">
+            {error}
+          </div>
+        )}
+
+        <section className="space-y-4">
+          <h2 className="text-sm uppercase tracking-widest text-neutral-500 flex items-center gap-2">
+            <Inbox size={14} /> Pending Invitations
+          </h2>
+          {invitations.length === 0 ? (
+            <p className="text-neutral-500 text-sm">
+              No one has invited you to be their accountability partner yet.
+            </p>
+          ) : (
+            invitations.map((invitation) => (
+              <InvitationCard
+                key={invitation.id}
+                invitation={invitation}
+                busy={busyId === invitation.contract_id}
+                onAccept={() => handleAccept(invitation.contract_id)}
+                onDecline={() => handleDecline(invitation.contract_id)}
+              />
+            ))
+          )}
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-sm uppercase tracking-widest text-neutral-500 flex items-center gap-2">
+            <Users size={14} /> Your Partnerships
+          </h2>
+          {partnerships.length === 0 ? (
+            <p className="text-neutral-500 text-sm">
+              You are not an active partner on any contract yet.
+            </p>
+          ) : (
+            partnerships.map((partnership) => (
+              <PartnershipCard
+                key={partnership.id}
+                partnership={partnership}
+                busy={busyId === partnership.contract_id}
+                expanded={expanded === partnership.contract_id}
+                status={statuses[partnership.contract_id] ?? null}
+                checkIns={checkIns[partnership.contract_id] ?? []}
+                draft={drafts[partnership.contract_id] ?? ''}
+                onToggle={() => handleToggle(partnership.contract_id)}
+                onCosign={() => handleCosign(partnership.contract_id)}
+                onVeto={() => handleVeto(partnership.contract_id)}
+                onDraftChange={(value) =>
+                  setDrafts((prev) => ({ ...prev, [partnership.contract_id]: value }))
+                }
+                onCompleteCheckIn={(checkInId) =>
+                  handleCompleteCheckIn(partnership.contract_id, checkInId)
+                }
+              />
+            ))
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/web/lib/guided-tour/registry.ts
+++ b/src/web/lib/guided-tour/registry.ts
@@ -611,6 +611,17 @@ export const TOUR_ROUTES: TourRoute[] = [
     detail:
       "The release gate hashes this artifact set on every run, so what is published here and what CI enforces cannot drift apart silently.",
   },
+  {
+    path: "/partner",
+    title: "The accountability partner",
+    chapter: "Hold the line",
+    persona: "river",
+    label: "working",
+    summary:
+      "Someone a person names to hold them to their promise: they accept the role, co-sign the daily check-ins, and can veto a break request.",
+    detail:
+      "The partner protocol ran server-side for months with no surface — every endpoint guarded, tested, and reachable by nobody. This is that protocol made usable: pending invitations, accept or decline, co-sign an attestation, and the veto that makes a partner more than a spectator.",
+  },
 ];
 
 export const TOUR_BY_PATH = new Map(TOUR_ROUTES.map((route) => [route.path, route]));

--- a/src/web/proxy.ts
+++ b/src/web/proxy.ts
@@ -23,6 +23,7 @@ const PROTECTED_PATHS = [
   '/hr',
   '/tavern',
   '/referrals',
+  '/partner',
 ];
 
 // Browser auth uses HttpOnly cookie sessions. This proxy enforces auth-gating

--- a/src/web/services/api-client.test.ts
+++ b/src/web/services/api-client.test.ts
@@ -273,6 +273,103 @@ describe('Web API client', () => {
     });
   });
 
+  describe('accountability partner endpoints', () => {
+    it('getPartnerInvitations() hits the literal /contracts/invitations route', async () => {
+      mockFetch.mockResolvedValueOnce(jsonOk([]));
+
+      await api.getPartnerInvitations();
+
+      expect(mockFetch.mock.calls[0][0]).toContain('/contracts/invitations');
+    });
+
+    it('getPartnerships() hits /contracts/partnerships', async () => {
+      mockFetch.mockResolvedValueOnce(jsonOk([]));
+
+      await api.getPartnerships();
+
+      expect(mockFetch.mock.calls[0][0]).toContain('/contracts/partnerships');
+    });
+
+    it('acceptPartnerInvitation() posts to the partner-accept path', async () => {
+      mockFetch.mockResolvedValueOnce(jsonOk({ status: 'active' }));
+
+      await api.acceptPartnerInvitation('c-7');
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toContain('/contracts/c-7/partner/accept');
+      expect(opts.method).toBe('POST');
+    });
+
+    it('respondToPartnerInvite() carries the accept flag', async () => {
+      mockFetch.mockResolvedValueOnce(jsonOk({ success: true, status: 'DECLINED' }));
+
+      await api.respondToPartnerInvite('c-7', false);
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toContain('/contracts/c-7/accountability/respond');
+      expect(JSON.parse(opts.body)).toEqual({ accept: false });
+    });
+
+    it('cosignAttestation() posts to the cosign path', async () => {
+      mockFetch.mockResolvedValueOnce(jsonOk({ status: 'cosigned' }));
+
+      await api.cosignAttestation('c-7');
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toContain('/contracts/c-7/attestation/cosign');
+      expect(opts.method).toBe('POST');
+    });
+
+    it('vetoRecoveryBreak() posts to the veto path', async () => {
+      mockFetch.mockResolvedValueOnce(jsonOk({ success: true, message: 'vetoed' }));
+
+      await api.vetoRecoveryBreak('c-7');
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toContain('/contracts/c-7/recovery/veto-break');
+      expect(opts.method).toBe('POST');
+    });
+
+    it('invitePartner() sends the invitee email', async () => {
+      mockFetch.mockResolvedValueOnce(jsonOk({ success: true, partnerId: 'p-1' }));
+
+      await api.invitePartner('c-7', 'friend@styx.io');
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toContain('/contracts/c-7/accountability/invite');
+      expect(JSON.parse(opts.body)).toEqual({ email: 'friend@styx.io' });
+    });
+
+    it('getAccountabilityStatus() hits the status path', async () => {
+      mockFetch.mockResolvedValueOnce(jsonOk({ partners: [], history: [] }));
+
+      await api.getAccountabilityStatus('c-7');
+
+      expect(mockFetch.mock.calls[0][0]).toContain('/contracts/c-7/accountability/status');
+    });
+
+    it('getPartnerCheckIns() appends the limit only when given', async () => {
+      mockFetch.mockResolvedValueOnce(jsonOk([]));
+      await api.getPartnerCheckIns('c-7');
+      expect(mockFetch.mock.calls[0][0]).toContain('/behavioral/retention/partners/check-ins/c-7');
+      expect(mockFetch.mock.calls[0][0]).not.toContain('limit=');
+
+      mockFetch.mockResolvedValueOnce(jsonOk([]));
+      await api.getPartnerCheckIns('c-7', 5);
+      expect(mockFetch.mock.calls[1][0]).toContain('limit=5');
+    });
+
+    it('completePartnerCheckIn() sends the check-in id and message', async () => {
+      mockFetch.mockResolvedValueOnce(jsonOk({ id: 'chk-1' }));
+
+      await api.completePartnerCheckIn('chk-1', 'still holding');
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toContain('/behavioral/retention/partners/check-in');
+      expect(JSON.parse(opts.body)).toEqual({ checkInId: 'chk-1', message: 'still holding' });
+    });
+  });
+
   describe('grillMe()', () => {
     it('sends POST to /ai/grill-me', async () => {
       mockFetch.mockResolvedValueOnce(jsonOk({ questions: ['What is your TAM?'] }));

--- a/src/web/services/api-client.ts
+++ b/src/web/services/api-client.ts
@@ -256,6 +256,61 @@ export interface VerdictDto {
   flagged?: boolean;
 }
 
+/** A PENDING accountability_partners row joined to the contract it covers. */
+export interface PartnerInvitation {
+  id: string;
+  contract_id: string;
+  partner_user_id: string | null;
+  partner_email: string | null;
+  status: string;
+  invited_at: string | null;
+  accepted_at: string | null;
+  oath_category: string;
+  stake_amount: string;
+  owner_email: string;
+}
+
+/** An ACTIVE partnership from the partner's side of the relationship. */
+export interface Partnership {
+  id: string;
+  contract_id: string;
+  status: string;
+  accepted_at: string | null;
+  oath_category: string;
+  stake_amount: string;
+  ends_at: string | null;
+  contract_status: string;
+  owner_email: string;
+}
+
+/** A partner_checkins row, serialized by AccountabilityPartnerService. */
+export interface PartnerCheckIn {
+  id: string;
+  contractId: string;
+  partnerId: string;
+  type: "SCHEDULED" | "EMERGENCY" | "STREAK_MILESTONE";
+  status: "PENDING" | "COMPLETED" | "MISSED" | "ESCALATED";
+  scheduledAt: string;
+  completedAt?: string;
+  message?: string;
+}
+
+export interface AccountabilityStatus {
+  partners: Array<{
+    email: string;
+    status: string;
+    partner_user_id: string;
+  }>;
+  history: Array<{
+    id: string;
+    contract_id: string;
+    actor_id: string;
+    event_type: string;
+    payload: Record<string, unknown> | null;
+    created_at: string;
+  }>;
+}
+
 export interface LeaderboardEntry {
   id: string;
   email: string;
@@ -811,6 +866,72 @@ export const api = {
   submitAttestation: (contractId: string) =>
     request<{ status: string }>(`/contracts/${contractId}/attestation`, {
       method: "POST",
+    }),
+
+  // Accountability partners (TKT-P1-017). The endpoints were guarded and
+  // tested server-side with no web caller at all; these are their first
+  // browser surface. Routes mirror the mobile ApiClient where both exist.
+  getPartnerInvitations: () =>
+    request<PartnerInvitation[]>("/contracts/invitations"),
+
+  getPartnerships: () => request<Partnership[]>("/contracts/partnerships"),
+
+  // Accepting goes through /partner/accept rather than
+  // /accountability/respond: it also claims an email-only invitation by
+  // stamping partner_user_id, which the respond path requires to already
+  // be set. Declining has no equivalent, so it uses respond.
+  acceptPartnerInvitation: (contractId: string) =>
+    request<{ status: string }>(`/contracts/${contractId}/partner/accept`, {
+      method: "POST",
+    }),
+
+  respondToPartnerInvite: (contractId: string, accept: boolean) =>
+    request<{ success: boolean; status: string }>(
+      `/contracts/${contractId}/accountability/respond`,
+      {
+        method: "POST",
+        body: JSON.stringify({ accept }),
+      },
+    ),
+
+  cosignAttestation: (contractId: string) =>
+    request<{ status: string }>(`/contracts/${contractId}/attestation/cosign`, {
+      method: "POST",
+    }),
+
+  vetoRecoveryBreak: (contractId: string) =>
+    request<{ success: boolean; message: string }>(
+      `/contracts/${contractId}/recovery/veto-break`,
+      {
+        method: "POST",
+      },
+    ),
+
+  invitePartner: (contractId: string, email: string) =>
+    request<{ success: boolean; partnerId: string }>(
+      `/contracts/${contractId}/accountability/invite`,
+      {
+        method: "POST",
+        body: JSON.stringify({ email }),
+      },
+    ),
+
+  getAccountabilityStatus: (contractId: string) =>
+    request<AccountabilityStatus>(
+      `/contracts/${contractId}/accountability/status`,
+    ),
+
+  // Behavioral-retention check-ins. Both endpoints authorize either
+  // participant, so the partner and the owner reach the same thread.
+  getPartnerCheckIns: (contractId: string, limit?: number) =>
+    request<PartnerCheckIn[]>(
+      `/behavioral/retention/partners/check-ins/${contractId}${limit ? `?limit=${limit}` : ""}`,
+    ),
+
+  completePartnerCheckIn: (checkInId: string, message: string) =>
+    request<PartnerCheckIn>("/behavioral/retention/partners/check-in", {
+      method: "POST",
+      body: JSON.stringify({ checkInId, message }),
     }),
 
   // Referrals


### PR DESCRIPTION
TKT-P1-017. The accountability partner protocol was a fully-built server feature with no client on either side — and one of its endpoints could not be called at all.

## Every partner endpoint, enumerated

**`contracts.controller.ts` — contract-scoped (7)**

| Route | Body | Service | Now called by |
|---|---|---|---|
| `GET /contracts/invitations` | — | `getPendingInvitations(userId)` | `/partner` |
| `POST /contracts/:id/partner/accept` | — | `acceptPartnerInvitation(id, userId)` | `/partner` accept |
| `POST /contracts/:id/attestation/cosign` | — | `cosignAttestation(id, userId)` | `/partner` co-sign |
| `POST /contracts/:id/accountability/invite` | `{ email }` | `invitePartner(id, userId, email)` | `/contracts/[id]` invite panel |
| `POST /contracts/:id/accountability/respond` | `{ accept: boolean }` | `respondToInvite(id, userId, accept)` | `/partner` decline |
| `POST /contracts/:id/recovery/veto-break` | — | `vetoRecoveryBreak(id, userId)` | `/partner` veto |
| `GET /contracts/:id/accountability/status` | — | `getAccountabilityStatus(id, userId)` | both surfaces (partner ledger) |

**`retention.controller.ts` — behavioral retention (5)**

| Route | Body | Service | Now called by |
|---|---|---|---|
| `POST /behavioral/retention/partners/invite` | `{ categories: string[] }` | `requestPartnerMatch` | not wired — owner-side category matching, a different flow from the email invite |
| `POST /behavioral/retention/partners/accept` | `{ contractId }` | `scheduleCheckIn` | not wired — duplicates `/contracts/:id/partner/accept` for the accept step |
| `GET /behavioral/retention/partners` | — | `getActivePartnerships(userId)` | not wired — reads the **owner's** partners, not the partner's contracts |
| `GET /behavioral/retention/partners/check-ins/:contractId` | `?limit` | `getCheckInHistory` | `/partner` check-in thread |
| `POST /behavioral/retention/partners/check-in` | `{ checkInId, message }` | `completeCheckIn` | `/partner` complete check-in |

The three unwired rows are deliberate, not oversight: they are owner-direction reads/writes that belong on an owner surface, and adding client methods with no caller would recreate exactly the dead layer this ticket is about. Called out here so the next pass does not have to rediscover them.

## `GET /contracts/invitations` was unreachable

`@Get("invitations")` was declared at line 244, well after `@Get(":id")` at line 89. Nest registers handlers in class-declaration order and Express serves the first match, so every request to `/contracts/invitations` was resolving to `findOne()` with `"invitations"` as the contract id. The mobile `ApiClient.getPendingInvitations` — the "already defined, never called" method the ticket names — would have failed had a screen ever called it.

Fixed by moving the literal above the wildcard. A spec now reads `PATH_METADATA` off `ContractsController.prototype` in `Object.getOwnPropertyNames` (declaration) order and asserts every single-segment literal GET precedes `findOne`, so the next one cannot regress silently. Multi-segment literals (`cohorts/:cohortId/waitlist`) never collided and are unaffected.

## New endpoint: `GET /contracts/partnerships`

No endpoint answered "which contracts am I an active partner on". `getPendingInvitations` returns only `PENDING`, and retention's `listPartners` runs the other direction (an owner's partners). After accepting an invitation a partner had no way back to the contract, so the required view was not buildable from the existing surface. `getPartnerships(userId)` is its mirror: `accountability_partners` joined to the contract and owner, filtered to `partner_user_id = $1 AND status = 'ACTIVE'`. It exposes `owner_email`, which `getPendingInvitations` already exposes — no new PII surface.

## Web surface

- **`src/web/app/partner/page.tsx`** — pending invitations (accept / decline), active partnerships (co-sign, veto, expandable partner ledger + retention check-in thread). Accept goes through `/partner/accept` rather than `/accountability/respond` because it also claims an email-only invitation by stamping `partner_user_id`, which the respond path requires to already be set; decline has no equivalent there, so it uses respond. Veto renders only for `RECOVERY_*` contracts — that is the only stream with a break timelock to veto.
- **`src/web/app/contracts/[id]/page.tsx`** — the owner half: invite by email, partner roster, partner ledger. Closes the loop so the invitation an owner sends has a place to be sent from.
- **`src/web/services/api-client.ts`** — nine new methods plus `PartnerInvitation` / `Partnership` / `PartnerCheckIn` / `AccountabilityStatus` types.

**Wiring, grep-proved:** `/partner` is linked from the dashboard header (`href="/partner"`) and added to `proxy.ts` `PROTECTED_PATHS` (it was otherwise reachable while signed out and would have failed at the API instead of redirecting to `/login`). Every new api-client method has at least one caller in `app/partner/page.tsx` or `app/contracts/[id]/page.tsx`.

## Defect fixed: no notification fired on any partner lifecycle event

`contracts.service.ts` reached `this.notifications` at two sites, both inside contract creation. None of `invitePartner`, `respondToInvite`, `acceptPartnerInvitation`, `cosignAttestation`, `vetoRecoveryBreak` notified anyone. An invited user got a `PENDING` row and an event-log line and no signal at all; an owner whose partner declined, or who had a queued recovery break vetoed inside its 24-hour cooldown, saw only silence — the veto case reads as the timelock simply never releasing.

Each site now creates a notification addressed to the counterparty (`PARTNER_INVITATION` to the invitee; `PARTNER_INVITATION_ACCEPTED` / `PARTNER_INVITATION_DECLINED` / `ATTESTATION_COSIGNED` / `RECOVERY_BREAK_VETOED` to the owner), following the existing shape: optional `this.notifications?.create(...)`, wrapped so a notification failure can never abort the recorded transition. A spec asserts the failure path still resolves.

`PUSH_ELIGIBLE_TYPES` in `notifications.service.ts` is deliberately untouched — the new types create rows and SSE events but do not enqueue push. Enabling push is a queue-behaviour change with no local verification path; it is worth a follow-up, particularly for the veto.

## Verification

Scoped, each predicate's own exit code read:

```
src/api  npx jest contracts.service.spec contracts.controller.spec contracts.full-breath.spec
         → 3 suites, 162 tests passed
src/api  npx tsc --noEmit → exit 0
src/web  npx jest app/partner app/contracts app/dashboard services/api-client.test.ts
         → 6 suites, 61 tests passed
src/web  npx tsc --noEmit → exit 0
```

**SQL is not verified.** Every spec in this repo mocks the pg Pool, so the new `getPartnerships` query and the `getContractOwnerId` lookup are asserted as SQL text and bind parameters only — neither has been executed against Postgres. Columns were read from `database/schema.sql` (`accountability_partners`, `accountability_partner_events`, migration 023).

No mobile screens in this pass, per the ticket. The route-ordering fix does make the mobile `ApiClient` partner methods functional for whoever wires them.

## Summary by Sourcery

Expose a full accountability partner surface across API and web, including reachable routes, partner listings, and lifecycle signaling.

New Features:
- Add GET /contracts/partnerships and corresponding getPartnerships service to list contracts where the user is an active accountability partner.
- Introduce web partner page showing pending invitations, active partnerships, partner ledger, and behavioral check-in threads for partners.
- Add owner-side partner panel on contract detail page to invite partners by email, view partner roster, and inspect partner ledger.
- Extend web API client with types and methods for partner invitations, partnerships, accountability status, and partner check-ins.

Bug Fixes:
- Fix routing so GET /contracts/invitations hits the invitations handler instead of the :id wildcard.
- Ensure partner lifecycle operations (invite, respond, accept, co-sign, veto) emit non-failing notifications to the appropriate counterparty.

Enhancements:
- Add controller and service tests around accountability partner flows, including notification behavior and route declaration order.
- Gate the new /partner page behind auth and link it from the dashboard header.
- Provide partner-side UI affordances for co-signing attestations, vetoing recovery breaks, and completing scheduled check-ins.

Tests:
- Add unit tests for getPartnerships and partner lifecycle notification behavior in ContractsService.
- Add controller tests verifying accountability partner routes, delegation, and literal path ordering relative to the :id wildcard.
- Add web API client tests for all new accountability partner and check-in endpoints.
- Add component and page tests for the partner page, including invitation, partnership, check-in UI, and veto support logic.