### PR TITLE
feat(onboarding): identity-based oath declaration bound to the contract (TKT-P1-016)

### DIFF
--- a/src/api/database/migrations/069_identity_oaths.sql
+++ b/src/api/database/migrations/069_identity_oaths.sql
@@ -1,0 +1,36 @@
+-- 069: Identity-based oath onboarding (TKT-P1-016).
+--
+-- Onboarding asks who the user is becoming, not what they will do, and that
+-- declaration is what the contract is bound to. It is stored per user per oath
+-- category so a resumed onboarding session reads back the same identity, and
+-- the unique constraint makes re-declaring an update rather than a second row.
+--
+-- `copy_variant` is the activation-copy arm the pledge was composed under. It is
+-- persisted rather than re-derived at read time so a later change to the
+-- assignment function can never rewrite the sentence a user already agreed to.
+
+CREATE TABLE IF NOT EXISTS user_identity_oaths (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  oath_category TEXT NOT NULL,
+  archetype_id TEXT NOT NULL,
+  identity_label TEXT NOT NULL,
+  pledge_copy TEXT NOT NULL,
+  copy_variant TEXT NOT NULL,
+  -- NULL while the identity step is still open; stamped once, on completion.
+  activated_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT uq_user_identity_oaths_user_category UNIQUE (user_id, oath_category)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_identity_oaths_user
+  ON user_identity_oaths(user_id);
+
+-- The binding itself. Nullable because contracts created before this migration
+-- (and any category without a declared identity journey) have no oath to point
+-- at; ON DELETE SET NULL keeps a contract readable if its oath row is ever
+-- removed with the user's account data.
+ALTER TABLE contracts
+  ADD COLUMN IF NOT EXISTS identity_oath_id UUID
+  REFERENCES user_identity_oaths(id) ON DELETE SET NULL;

--- a/src/api/database/schema.sql
+++ b/src/api/database/schema.sql
@@ -699,3 +699,30 @@ ALTER TABLE deco_commitments ADD COLUMN IF NOT EXISTS committed_at TEXT;
 ALTER TABLE deco_commitments DROP COLUMN IF EXISTS url;
 ALTER TABLE deco_commitments DROP COLUMN IF EXISTS selector;
 ALTER TABLE deco_commitments DROP COLUMN IF EXISTS expected_value;
+
+-- ── Identity-based oath onboarding (migration 069) ──────────────────────────
+-- Onboarding asks who the user is becoming, not what they will do; the
+-- declaration is stored per user per oath category and the contract is bound to
+-- it. `copy_variant` records the activation-copy arm the pledge was composed
+-- under, so a later change to the assignment function cannot rewrite a sentence
+-- the user already agreed to.
+CREATE TABLE IF NOT EXISTS user_identity_oaths (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  oath_category TEXT NOT NULL,
+  archetype_id TEXT NOT NULL,
+  identity_label TEXT NOT NULL,
+  pledge_copy TEXT NOT NULL,
+  copy_variant TEXT NOT NULL,
+  activated_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT uq_user_identity_oaths_user_category UNIQUE (user_id, oath_category)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_identity_oaths_user
+  ON user_identity_oaths(user_id);
+
+ALTER TABLE contracts
+  ADD COLUMN IF NOT EXISTS identity_oath_id UUID
+  REFERENCES user_identity_oaths(id) ON DELETE SET NULL;

--- a/src/api/src/app.module.ts
+++ b/src/api/src/app.module.ts
@@ -28,6 +28,7 @@ import { BehavioralModule } from "./modules/behavioral/behavioral.module";
 import { MarketingModule } from "./modules/marketing/marketing.module";
 import { ReferralModule } from "./modules/referrals/referral.module";
 import { SecurityModule } from "./modules/security/security.module";
+import { OnboardingModule } from "./modules/onboarding/onboarding.module";
 
 @Module({
   imports: [
@@ -72,6 +73,7 @@ import { SecurityModule } from "./modules/security/security.module";
     MarketingModule,
     ReferralModule,
     SecurityModule,
+    OnboardingModule,
   ],
   providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],
 })

--- a/src/api/src/modules/contracts/contracts.module.ts
+++ b/src/api/src/modules/contracts/contracts.module.ts
@@ -33,6 +33,7 @@ import { PayModule } from "../pay/pay.module";
 import { ReferralModule } from "../referrals/referral.module";
 import { EmailModule } from "../email/email.module";
 import { B2BModule } from "../b2b/b2b.module";
+import { OnboardingModule } from "../onboarding/onboarding.module";
 import Redis from "ioredis";
 import { resolveCacheRedisConfig } from "../../config/runtime";
 
@@ -55,6 +56,7 @@ const redisProvider = {
     NotificationsModule,
     ReferralModule,
     EmailModule,
+    OnboardingModule,
     PayModule,
     // Contract resolution fans out to enterprise webhook subscribers; B2BModule
     // owns that store and its delivery queue. It imports nothing, so this edge

--- a/src/api/src/modules/contracts/contracts.service.spec.ts
+++ b/src/api/src/modules/contracts/contracts.service.spec.ts
@@ -876,6 +876,7 @@ describe("ContractsService", () => {
         undefined, // compliancePolicy
         mockSettlement,
         undefined, // referralService
+        undefined, // enterpriseWebhooks
         identityOaths,
       );
     }

--- a/src/api/src/modules/contracts/contracts.service.spec.ts
+++ b/src/api/src/modules/contracts/contracts.service.spec.ts
@@ -823,6 +823,116 @@ describe("ContractsService", () => {
     });
   });
 
+  // ── identity-oath binding (TKT-P1-016) ──────────────────────────
+
+  describe("createContract identity binding", () => {
+    const noContactDto: CreateContractInput = {
+      userId: "user-1",
+      oathCategory: OathCategory.NO_CONTACT_BOUNDARY,
+      verificationMethod: VerificationMethod.DAILY_ATTESTATION,
+      stakeAmount: 15,
+      durationDays: 14,
+    };
+
+    // Routed by SQL shape rather than call order: the identity lookup is not a
+    // pool query at all (it goes through IdentityOathService), so an ordered
+    // chain would encode the wrong contract.
+    function buildRoutedPool() {
+      return {
+        query: jest.fn().mockImplementation((sql: string) => {
+          if (sql.includes("FROM users WHERE id"))
+            return Promise.resolve({ rows: [activeUser] });
+          if (sql.includes("SELECT created_at FROM contracts"))
+            return Promise.resolve({ rows: [] });
+          if (sql.includes("SELECT updated_at FROM contracts"))
+            return Promise.resolve({ rows: [] });
+          if (sql.includes("id != $2"))
+            return Promise.resolve({ rows: [{ count: "1" }] });
+          if (sql.includes("COUNT(*)"))
+            return Promise.resolve({ rows: [{ count: 0 }] });
+          if (sql.includes("INSERT INTO contracts"))
+            return Promise.resolve({ rows: [{ id: "contract-1" }] });
+          if (sql.includes("SYSTEM_ESCROW"))
+            return Promise.resolve({ rows: [{ id: "escrow-acct" }] });
+          return Promise.resolve({ rows: [] });
+        }),
+      };
+    }
+
+    function buildService(pool: { query: jest.Mock }, identityOaths: any) {
+      return new ContractsService(
+        pool as unknown as Pool,
+        mockLedger,
+        mockTruthLog,
+        mockStripe,
+        mockRealStripe as any,
+        mockDispute,
+        mockFuryRouter,
+        mockAegis,
+        mockRecovery,
+        mockDynamicPenalty as any,
+        mockAnomaly,
+        undefined, // notifications
+        undefined, // compliancePolicy
+        mockSettlement,
+        undefined, // referralService
+        identityOaths,
+      );
+    }
+
+    function insertParams(pool: { query: jest.Mock }) {
+      const call = pool.query.mock.calls.find(
+        ([sql]: [string]) =>
+          typeof sql === "string" && sql.includes("INSERT INTO contracts"),
+      );
+      return call?.[1] as unknown[];
+    }
+
+    let originalWebUrl: string | undefined;
+
+    beforeEach(() => {
+      // The NO_CONTACT_BOUNDARY response builds a whistleblower bounty link.
+      originalWebUrl = process.env.STYX_WEB_PUBLIC_URL;
+      process.env.STYX_WEB_PUBLIC_URL = "https://styx.test";
+    });
+
+    afterEach(() => {
+      if (originalWebUrl === undefined) delete process.env.STYX_WEB_PUBLIC_URL;
+      else process.env.STYX_WEB_PUBLIC_URL = originalWebUrl;
+    });
+
+    it("binds the new contract to the activated identity oath", async () => {
+      const pool = buildRoutedPool();
+      const identityOaths = {
+        getActivatedOath: jest.fn().mockResolvedValue({ id: "oath-1" }),
+      };
+
+      await buildService(pool, identityOaths).createContract(noContactDto);
+
+      expect(identityOaths.getActivatedOath).toHaveBeenCalledWith(
+        "user-1",
+        OathCategory.NO_CONTACT_BOUNDARY,
+      );
+      expect(insertParams(pool)).toContain("oath-1");
+    });
+
+    it("still creates the contract when no identity has been declared", async () => {
+      const pool = buildRoutedPool();
+      const identityOaths = {
+        getActivatedOath: jest.fn().mockResolvedValue(null),
+      };
+
+      const result = await buildService(pool, identityOaths).createContract(
+        noContactDto,
+      );
+
+      expect(result.contractId).toBe("contract-1");
+      // Trailing bind parameter is the identity oath id.
+      const params = insertParams(pool);
+      expect(params[params.length - 1]).toBeNull();
+    });
+  });
+
   // ── getContract ─────────────────────────────────────────────────
 
   describe("getContract", () => {
@@ -847,6 +957,37 @@ describe("ContractsService", () => {
         proof_count: 0,
         proofs: [],
         grace_days_max: 2,
+        identity_oath: null,
+      });
+    });
+
+    it("returns the identity the contract is bound to", async () => {
+      mockPool.query.mockResolvedValueOnce({
+        rows: [
+          {
+            id: "contract-1",
+            user_id: "user-1",
+            email: "user@styx.app",
+            integrity_score: 55,
+            proof_count: "0",
+            identity_oath_id: "oath-1",
+            identity_archetype_id: "BOUNDARY_KEEPER",
+            identity_label: "The Boundary Keeper",
+            identity_pledge_copy: "I am becoming someone who keeps the distance they chose.",
+            identity_copy_variant: "DECLARATIVE",
+          },
+        ],
+      });
+      mockPool.query.mockResolvedValueOnce({ rows: [] }); // proofs list
+
+      const result = await service.getContract("contract-1");
+
+      expect(result.identity_oath).toEqual({
+        id: "oath-1",
+        archetype_id: "BOUNDARY_KEEPER",
+        identity_label: "The Boundary Keeper",
+        pledge_copy: "I am becoming someone who keeps the distance they chose.",
+        copy_variant: "DECLARATIVE",
       });
     });
 

--- a/src/api/src/modules/contracts/contracts.service.ts
+++ b/src/api/src/modules/contracts/contracts.service.ts
@@ -61,6 +61,7 @@ import {
   getRealmForCategory,
   RealmId,
 } from "../../../../shared/libs/realm-registry";
+import { IdentityOathService } from "../onboarding/identity-oath.service";
 
 import {
   CreateContractDto as CreateContractDtoBase,
@@ -168,6 +169,9 @@ export class ContractsService {
     @Optional()
     @Inject(WebhookSubscriptionService)
     private readonly enterpriseWebhooks?: WebhookSubscriptionService,
+    @Optional()
+    @Inject(IdentityOathService)
+    private readonly identityOaths?: IdentityOathService,
   ) {}
 
   private stakeAmountToCents(stakeAmount: number | string): number {
@@ -1253,6 +1257,25 @@ export class ContractsService {
     }
   }
 
+  /**
+   * The activated identity declaration this contract belongs to, if any.
+   *
+   * A missing declaration does not block creation: the identity step is an
+   * onboarding-flow requirement, and refusing every API-created contract
+   * without one would strand every account that predates it.
+   */
+  private async resolveIdentityOathId(
+    userId: string,
+    oathCategory: string,
+  ): Promise<string | null> {
+    if (!this.identityOaths) return null;
+    const oath = await this.identityOaths.getActivatedOath(
+      userId,
+      oathCategory,
+    );
+    return oath?.id ?? null;
+  }
+
   private async createContractTwoPhase(input: {
     dto: CreateContractInput;
     user: any;
@@ -1261,6 +1284,7 @@ export class ContractsService {
     endsAt: Date;
     contractMetadata: Record<string, any>;
     pricingMetadata?: PricingMetadata;
+    identityOathId: string | null;
   }): Promise<{
     contractId: string;
     paymentIntentId: string;
@@ -1275,6 +1299,7 @@ export class ContractsService {
       endsAt,
       contractMetadata,
       pricingMetadata,
+      identityOathId,
     } = input;
     const poolWithConnect = this.pool as unknown as {
       connect: () => Promise<PoolClient>;
@@ -1290,8 +1315,8 @@ export class ContractsService {
         dto.realmId ?? getRealmForCategory(dto.oathCategory as OathCategory);
 
       const contractResult = await phaseAClient.query(
-        `INSERT INTO contracts (user_id, oath_category, verification_method, stake_amount, payment_intent_id, duration_days, status, started_at, ends_at, metadata, bounty_link_id, realm_id)
-         VALUES ($1, $2, $3, $4, NULL, $5, 'PENDING_STAKE', $6, $7, $8, $9, $10)
+        `INSERT INTO contracts (user_id, oath_category, verification_method, stake_amount, payment_intent_id, duration_days, status, started_at, ends_at, metadata, bounty_link_id, realm_id, identity_oath_id)
+         VALUES ($1, $2, $3, $4, NULL, $5, 'PENDING_STAKE', $6, $7, $8, $9, $10, $11)
          RETURNING id`,
         [
           dto.userId,
@@ -1304,6 +1329,7 @@ export class ContractsService {
           JSON.stringify(contractMetadata),
           bountyLinkId,
           realmId,
+          identityOathId,
         ],
       );
       contractId = contractResult.rows[0].id;
@@ -1731,6 +1757,15 @@ export class ContractsService {
       contractMetadata.pricing = pricingPlan.pricingMetadata;
     }
 
+    // TKT-P1-016: a contract is the practice of a declared identity, so it
+    // carries the oath the user activated during onboarding. Null is a normal
+    // state — categories without an identity journey, and every contract
+    // created before the identity step existed.
+    const identityOathId = await this.resolveIdentityOathId(
+      dto.userId,
+      dto.oathCategory,
+    );
+
     const supportsTransactionalPath =
       typeof (this.pool as unknown as { connect?: unknown }).connect ===
       "function";
@@ -1744,13 +1779,14 @@ export class ContractsService {
         endsAt,
         contractMetadata,
         pricingMetadata: pricingPlan.pricingMetadata,
+        identityOathId,
       });
     }
 
     // Insert contract first with PENDING_STAKE status (mirrors two-phase pattern)
     const contractResult = await this.pool.query(
-      `INSERT INTO contracts (user_id, oath_category, verification_method, stake_amount, payment_intent_id, duration_days, status, started_at, ends_at, metadata, bounty_link_id)
-       VALUES ($1, $2, $3, $4, NULL, $5, 'PENDING_STAKE', $6, $7, $8, $9)
+      `INSERT INTO contracts (user_id, oath_category, verification_method, stake_amount, payment_intent_id, duration_days, status, started_at, ends_at, metadata, bounty_link_id, identity_oath_id)
+       VALUES ($1, $2, $3, $4, NULL, $5, 'PENDING_STAKE', $6, $7, $8, $9, $10)
        RETURNING id`,
       [
         dto.userId,
@@ -1762,6 +1798,7 @@ export class ContractsService {
         endsAt.toISOString(),
         JSON.stringify(contractMetadata),
         bountyLinkId,
+        identityOathId,
       ],
     );
     const contractId = contractResult.rows[0].id;
@@ -1893,9 +1930,14 @@ export class ContractsService {
   async getContract(contractId: string, requester?: ContractReadRequester) {
     const result = await this.pool.query(
       `SELECT c.*, u.email, u.integrity_score,
+              io.archetype_id AS identity_archetype_id,
+              io.identity_label AS identity_label,
+              io.pledge_copy AS identity_pledge_copy,
+              io.copy_variant AS identity_copy_variant,
               (SELECT COUNT(*) FROM proofs p WHERE p.contract_id = c.id) as proof_count
-       FROM contracts c 
+       FROM contracts c
        JOIN users u ON c.user_id = u.id
+       LEFT JOIN user_identity_oaths io ON io.id = c.identity_oath_id
        WHERE c.id = $1`,
       [contractId],
     );
@@ -1919,6 +1961,17 @@ export class ContractsService {
       proof_count: parseInt(row.proof_count, 10),
       proofs: proofsResult.rows,
       grace_days_max: 2, // Hardcoded for beta
+      // Nested rather than left as flat columns so a client can render "who you
+      // said you were becoming" without reassembling four sibling fields.
+      identity_oath: row.identity_oath_id
+        ? {
+            id: row.identity_oath_id,
+            archetype_id: row.identity_archetype_id,
+            identity_label: row.identity_label,
+            pledge_copy: row.identity_pledge_copy,
+            copy_variant: row.identity_copy_variant,
+          }
+        : null,
     };
   }
 

--- a/src/api/src/modules/onboarding/dto.ts
+++ b/src/api/src/modules/onboarding/dto.ts
@@ -1,0 +1,30 @@
+import { IsIn, IsOptional, IsString } from "class-validator";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import {
+  IDENTITY_ARCHETYPES,
+  IDENTITY_OATH_CATEGORIES,
+} from "../../../../shared/libs/identity-oath";
+
+const ARCHETYPE_IDS = IDENTITY_ARCHETYPES.map((archetype) => archetype.id);
+
+export class DeclareIdentityOathDto {
+  @ApiProperty({
+    description: "Identity archetype the user declares they are becoming",
+    enum: ARCHETYPE_IDS,
+    example: ARCHETYPE_IDS[0],
+  })
+  @IsString()
+  @IsIn(ARCHETYPE_IDS)
+  archetypeId!: string;
+
+  @ApiPropertyOptional({
+    description:
+      "Oath category the identity belongs to (phase-1 exposes RECOVERY_NOCONTACT only)",
+    enum: IDENTITY_OATH_CATEGORIES,
+    example: IDENTITY_OATH_CATEGORIES[0],
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn(IDENTITY_OATH_CATEGORIES as unknown as string[])
+  oathCategory?: string;
+}

--- a/src/api/src/modules/onboarding/identity-oath.service.spec.ts
+++ b/src/api/src/modules/onboarding/identity-oath.service.spec.ts
@@ -1,0 +1,175 @@
+import { BadRequestException } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import { Pool } from "pg";
+import {
+  IDENTITY_ARCHETYPES,
+  assignCopyVariant,
+  buildPledgeCopy,
+} from "../../../../shared/libs/identity-oath";
+import { IdentityOathService } from "./identity-oath.service";
+
+describe("IdentityOathService", () => {
+  let service: IdentityOathService;
+
+  const mockPool = {
+    query: jest.fn(),
+  };
+
+  const archetype = IDENTITY_ARCHETYPES[0];
+
+  const storedRow = {
+    id: "oath-1",
+    user_id: "user-1",
+    oath_category: "RECOVERY_NOCONTACT",
+    archetype_id: archetype.id,
+    identity_label: archetype.label,
+    pledge_copy: buildPledgeCopy(
+      archetype,
+      assignCopyVariant("user-1", archetype.id),
+    ),
+    copy_variant: assignCopyVariant("user-1", archetype.id),
+    activated_at: new Date("2026-03-04T12:00:00.000Z"),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [IdentityOathService, { provide: Pool, useValue: mockPool }],
+    }).compile();
+
+    service = module.get<IdentityOathService>(IdentityOathService);
+  });
+
+  describe("getOnboardingState", () => {
+    it("reports an untouched identity step as resumable and incomplete", async () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+      const state = await service.getOnboardingState("user-1");
+
+      expect(state.oathCategory).toBe("RECOVERY_NOCONTACT");
+      expect(state.oath).toBeNull();
+      expect(state.completed).toBe(false);
+      // The catalogue always ships with the state so a resumed wizard can
+      // re-render the same choices without a second call.
+      expect(state.archetypes).toEqual(IDENTITY_ARCHETYPES);
+    });
+
+    it("returns the declaration on file so onboarding resumes past it", async () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [storedRow] });
+
+      const state = await service.getOnboardingState("user-1");
+
+      expect(state.completed).toBe(true);
+      expect(state.oath).toEqual({
+        id: "oath-1",
+        userId: "user-1",
+        oathCategory: "RECOVERY_NOCONTACT",
+        archetypeId: archetype.id,
+        identityLabel: archetype.label,
+        pledgeCopy: storedRow.pledge_copy,
+        copyVariant: storedRow.copy_variant,
+        activatedAt: storedRow.activated_at,
+      });
+    });
+
+    it("reads a declared-but-unactivated row as incomplete", async () => {
+      mockPool.query.mockResolvedValueOnce({
+        rows: [{ ...storedRow, activated_at: null }],
+      });
+
+      const state = await service.getOnboardingState("user-1");
+
+      expect(state.oath?.activatedAt).toBeNull();
+      expect(state.completed).toBe(false);
+    });
+
+    it("rejects a category outside the phase-1 scope lock", async () => {
+      await expect(
+        service.getOnboardingState("user-1", "BIOLOGICAL_WEIGHT"),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("declare", () => {
+    it("composes the pledge server-side and stamps activation", async () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [storedRow] });
+
+      const oath = await service.declare("user-1", {
+        archetypeId: archetype.id,
+      });
+
+      const [sql, params] = mockPool.query.mock.calls[0];
+      expect(sql).toContain("INSERT INTO user_identity_oaths");
+      expect(sql).toContain("ON CONFLICT (user_id, oath_category) DO UPDATE");
+      expect(params).toEqual([
+        "user-1",
+        "RECOVERY_NOCONTACT",
+        archetype.id,
+        archetype.label,
+        buildPledgeCopy(archetype, assignCopyVariant("user-1", archetype.id)),
+        assignCopyVariant("user-1", archetype.id),
+      ]);
+      expect(oath.id).toBe("oath-1");
+    });
+
+    it("preserves the first activation timestamp when re-declaring", () => {
+      // The row keeps its original activated_at; only the identity fields move.
+      mockPool.query.mockResolvedValueOnce({ rows: [storedRow] });
+
+      return service.declare("user-1", { archetypeId: archetype.id }).then(() => {
+        const [sql] = mockPool.query.mock.calls[0];
+        expect(sql).toContain(
+          "activated_at = COALESCE(user_identity_oaths.activated_at, EXCLUDED.activated_at)",
+        );
+      });
+    });
+
+    it("rejects an unknown archetype without touching the database", async () => {
+      await expect(
+        service.declare("user-1", { archetypeId: "NOT_AN_ARCHETYPE" }),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+
+    it("rejects a category outside the phase-1 scope lock", async () => {
+      await expect(
+        service.declare("user-1", {
+          archetypeId: archetype.id,
+          oathCategory: "COGNITIVE_FOCUS",
+        }),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getActivatedOath", () => {
+    it("returns the oath a contract can bind to", async () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [storedRow] });
+
+      const oath = await service.getActivatedOath(
+        "user-1",
+        "RECOVERY_NOCONTACT",
+      );
+
+      expect(oath?.id).toBe("oath-1");
+    });
+
+    it("returns null while the declaration is not activated", async () => {
+      mockPool.query.mockResolvedValueOnce({
+        rows: [{ ...storedRow, activated_at: null }],
+      });
+
+      expect(
+        await service.getActivatedOath("user-1", "RECOVERY_NOCONTACT"),
+      ).toBeNull();
+    });
+
+    it("returns null for a category with no identity journey", async () => {
+      expect(
+        await service.getActivatedOath("user-1", "BIOLOGICAL_WEIGHT"),
+      ).toBeNull();
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/api/src/modules/onboarding/identity-oath.service.ts
+++ b/src/api/src/modules/onboarding/identity-oath.service.ts
@@ -1,0 +1,162 @@
+import { BadRequestException, Injectable, Logger } from "@nestjs/common";
+import { Pool } from "pg";
+import {
+  IDENTITY_ARCHETYPES,
+  IDENTITY_OATH_CATEGORIES,
+  type IdentityArchetype,
+  type IdentityCopyVariant,
+  composeIdentityOath,
+  getIdentityArchetype,
+  isIdentityOathCategory,
+} from "../../../../shared/libs/identity-oath";
+
+/** Phase-1 scope lock: the only journey with an exposed identity oath. */
+export const DEFAULT_IDENTITY_OATH_CATEGORY = IDENTITY_OATH_CATEGORIES[0];
+
+export interface IdentityOath {
+  id: string;
+  userId: string;
+  oathCategory: string;
+  archetypeId: string;
+  identityLabel: string;
+  pledgeCopy: string;
+  copyVariant: IdentityCopyVariant;
+  activatedAt: Date | null;
+}
+
+export interface IdentityOathState {
+  oathCategory: string;
+  /** The declaration on file, or null when the identity step is untouched. */
+  oath: IdentityOath | null;
+  /** True once the identity step is behind the user — what a resume reads. */
+  completed: boolean;
+  archetypes: readonly IdentityArchetype[];
+}
+
+@Injectable()
+export class IdentityOathService {
+  private readonly logger = new Logger(IdentityOathService.name);
+
+  constructor(private readonly pool: Pool) {}
+
+  /**
+   * Resumable onboarding state. Returns the archetype catalogue alongside the
+   * declaration so a client resuming mid-flow renders the same choices it was
+   * offered originally without a second round trip.
+   */
+  async getOnboardingState(
+    userId: string,
+    oathCategory: string = DEFAULT_IDENTITY_OATH_CATEGORY,
+  ): Promise<IdentityOathState> {
+    const category = this.assertSupportedCategory(oathCategory);
+    const oath = await this.findOath(userId, category);
+
+    return {
+      oathCategory: category,
+      oath,
+      completed: oath?.activatedAt != null,
+      archetypes: IDENTITY_ARCHETYPES,
+    };
+  }
+
+  /**
+   * Declare (or re-declare) the identity for a journey.
+   *
+   * `activated_at` is preserved across a re-declaration: the user may change
+   * which person they are becoming, but the moment they first committed to
+   * declaring one is a fact about the account, not about the current choice.
+   */
+  async declare(
+    userId: string,
+    input: { archetypeId: string; oathCategory?: string },
+  ): Promise<IdentityOath> {
+    const category = this.assertSupportedCategory(
+      input.oathCategory ?? DEFAULT_IDENTITY_OATH_CATEGORY,
+    );
+    const archetype = getIdentityArchetype(input.archetypeId);
+    if (!archetype) {
+      throw new BadRequestException(
+        `Unknown identity archetype: ${input.archetypeId}`,
+      );
+    }
+
+    // Composed server-side from the shared library so the stored pledge is the
+    // one the wizard rendered — a client-supplied sentence could not be trusted
+    // to match the variant it was assigned.
+    const declaration = composeIdentityOath(userId, archetype);
+
+    const {
+      rows: [row],
+    } = await this.pool.query(
+      `INSERT INTO user_identity_oaths
+         (user_id, oath_category, archetype_id, identity_label, pledge_copy, copy_variant, activated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, NOW())
+       ON CONFLICT (user_id, oath_category) DO UPDATE
+       SET archetype_id = EXCLUDED.archetype_id,
+           identity_label = EXCLUDED.identity_label,
+           pledge_copy = EXCLUDED.pledge_copy,
+           copy_variant = EXCLUDED.copy_variant,
+           activated_at = COALESCE(user_identity_oaths.activated_at, EXCLUDED.activated_at),
+           updated_at = NOW()
+       RETURNING *`,
+      [
+        userId,
+        category,
+        declaration.archetypeId,
+        declaration.identityLabel,
+        declaration.pledgeCopy,
+        declaration.copyVariant,
+      ],
+    );
+
+    this.logger.log(
+      `User ${userId} declared identity ${declaration.archetypeId} for ${category} (variant ${declaration.copyVariant})`,
+    );
+    return this.mapOath(row);
+  }
+
+  /** The activated declaration a new contract in this category binds to. */
+  async getActivatedOath(
+    userId: string,
+    oathCategory: string,
+  ): Promise<IdentityOath | null> {
+    if (!isIdentityOathCategory(oathCategory)) return null;
+    const oath = await this.findOath(userId, oathCategory);
+    return oath?.activatedAt ? oath : null;
+  }
+
+  private async findOath(
+    userId: string,
+    oathCategory: string,
+  ): Promise<IdentityOath | null> {
+    const {
+      rows: [row],
+    } = await this.pool.query(
+      "SELECT * FROM user_identity_oaths WHERE user_id = $1 AND oath_category = $2",
+      [userId, oathCategory],
+    );
+    return row ? this.mapOath(row) : null;
+  }
+
+  private assertSupportedCategory(oathCategory: string): string {
+    if (!isIdentityOathCategory(oathCategory)) {
+      throw new BadRequestException(
+        `Identity oaths are not available for category ${oathCategory}`,
+      );
+    }
+    return oathCategory;
+  }
+
+  private mapOath(row: any): IdentityOath {
+    return {
+      id: row.id,
+      userId: row.user_id,
+      oathCategory: row.oath_category,
+      archetypeId: row.archetype_id,
+      identityLabel: row.identity_label,
+      pledgeCopy: row.pledge_copy,
+      copyVariant: row.copy_variant,
+      activatedAt: row.activated_at ?? null,
+    };
+  }
+}

--- a/src/api/src/modules/onboarding/onboarding.controller.spec.ts
+++ b/src/api/src/modules/onboarding/onboarding.controller.spec.ts
@@ -1,0 +1,114 @@
+import { GUARDS_METADATA } from "@nestjs/common/constants";
+import { validate } from "class-validator";
+import { plainToInstance } from "class-transformer";
+import { AuthGuard } from "../../../guards/auth.guard";
+import { IDENTITY_ARCHETYPES } from "../../../../shared/libs/identity-oath";
+import { OnboardingController } from "./onboarding.controller";
+import { IdentityOathService } from "./identity-oath.service";
+import { DeclareIdentityOathDto } from "./dto";
+
+const mockIdentityOaths = {
+  getOnboardingState: jest.fn(),
+  declare: jest.fn(),
+} as unknown as IdentityOathService;
+
+describe("OnboardingController", () => {
+  let controller: OnboardingController;
+  const testUser = { id: "user-1" };
+  const archetype = IDENTITY_ARCHETYPES[0];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    controller = new OnboardingController(mockIdentityOaths);
+  });
+
+  it("requires authentication for the whole onboarding surface", () => {
+    const guards =
+      Reflect.getMetadata(GUARDS_METADATA, OnboardingController) ?? [];
+
+    expect(guards).toContain(AuthGuard);
+  });
+
+  describe("GET /onboarding/identity-oath", () => {
+    it("returns resumable state for the authenticated user", async () => {
+      const state = { oathCategory: "RECOVERY_NOCONTACT", completed: false };
+      (mockIdentityOaths.getOnboardingState as jest.Mock).mockResolvedValue(
+        state,
+      );
+
+      const result = await controller.getIdentityOath(testUser);
+
+      expect(mockIdentityOaths.getOnboardingState).toHaveBeenCalledWith(
+        "user-1",
+        undefined,
+      );
+      expect(result).toBe(state);
+    });
+
+    it("passes an explicit oath category through", async () => {
+      (mockIdentityOaths.getOnboardingState as jest.Mock).mockResolvedValue({});
+
+      await controller.getIdentityOath(testUser, "RECOVERY_NOCONTACT");
+
+      expect(mockIdentityOaths.getOnboardingState).toHaveBeenCalledWith(
+        "user-1",
+        "RECOVERY_NOCONTACT",
+      );
+    });
+  });
+
+  describe("POST /onboarding/identity-oath", () => {
+    it("declares the identity for the authenticated user", async () => {
+      const oath = { id: "oath-1", archetypeId: archetype.id };
+      (mockIdentityOaths.declare as jest.Mock).mockResolvedValue(oath);
+
+      const dto = plainToInstance(DeclareIdentityOathDto, {
+        archetypeId: archetype.id,
+      });
+      const result = await controller.declareIdentityOath(testUser, dto);
+
+      expect(mockIdentityOaths.declare).toHaveBeenCalledWith("user-1", dto);
+      expect(result).toBe(oath);
+    });
+
+    it("propagates service rejections", async () => {
+      (mockIdentityOaths.declare as jest.Mock).mockRejectedValue(
+        new Error("Unknown identity archetype: NOPE"),
+      );
+
+      await expect(
+        controller.declareIdentityOath(testUser, {
+          archetypeId: "NOPE",
+        } as DeclareIdentityOathDto),
+      ).rejects.toThrow("Unknown identity archetype: NOPE");
+    });
+  });
+
+  describe("DeclareIdentityOathDto", () => {
+    it("accepts a declared archetype", async () => {
+      const dto = plainToInstance(DeclareIdentityOathDto, {
+        archetypeId: archetype.id,
+        oathCategory: "RECOVERY_NOCONTACT",
+      });
+
+      expect(await validate(dto)).toHaveLength(0);
+    });
+
+    it("rejects an archetype outside the catalogue", async () => {
+      const dto = plainToInstance(DeclareIdentityOathDto, {
+        archetypeId: "MADE_UP",
+      });
+
+      expect(await validate(dto)).not.toHaveLength(0);
+    });
+
+    it("rejects a category outside the phase-1 scope lock", async () => {
+      const dto = plainToInstance(DeclareIdentityOathDto, {
+        archetypeId: archetype.id,
+        oathCategory: "BIOLOGICAL_WEIGHT",
+      });
+
+      expect(await validate(dto)).not.toHaveLength(0);
+    });
+  });
+});

--- a/src/api/src/modules/onboarding/onboarding.controller.ts
+++ b/src/api/src/modules/onboarding/onboarding.controller.ts
@@ -1,0 +1,36 @@
+import { Body, Controller, Get, Post, Query, UseGuards } from "@nestjs/common";
+import { ApiTags, ApiOperation, ApiBearerAuth } from "@nestjs/swagger";
+import { AuthGuard } from "../../../guards/auth.guard";
+import { CurrentUser } from "../../common/decorators/current-user.decorator";
+import { IdentityOathService } from "./identity-oath.service";
+import { DeclareIdentityOathDto } from "./dto";
+
+@ApiTags("Onboarding")
+@ApiBearerAuth()
+@Controller("onboarding")
+@UseGuards(AuthGuard)
+export class OnboardingController {
+  constructor(private readonly identityOaths: IdentityOathService) {}
+
+  @Get("identity-oath")
+  @ApiOperation({
+    summary: "Get resumable identity-oath onboarding state for the user",
+  })
+  async getIdentityOath(
+    @CurrentUser() user: { id: string },
+    @Query("oathCategory") oathCategory?: string,
+  ) {
+    return this.identityOaths.getOnboardingState(user.id, oathCategory);
+  }
+
+  @Post("identity-oath")
+  @ApiOperation({
+    summary: "Declare the identity the user is becoming for this journey",
+  })
+  async declareIdentityOath(
+    @CurrentUser() user: { id: string },
+    @Body() dto: DeclareIdentityOathDto,
+  ) {
+    return this.identityOaths.declare(user.id, dto);
+  }
+}

--- a/src/api/src/modules/onboarding/onboarding.module.ts
+++ b/src/api/src/modules/onboarding/onboarding.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { OnboardingController } from "./onboarding.controller";
+import { IdentityOathService } from "./identity-oath.service";
+
+@Module({
+  controllers: [OnboardingController],
+  providers: [IdentityOathService],
+  // ContractsModule binds a new contract to the identity declared here.
+  exports: [IdentityOathService],
+})
+export class OnboardingModule {}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -53,6 +53,22 @@ export {
   parseWaitlistAttribution,
 } from "./libs/waitlist-attribution";
 
+// Identity-based oath onboarding (shared by the web wizard and the API)
+export {
+  IDENTITY_OATH_CATEGORIES,
+  IDENTITY_COPY_VARIANTS,
+  IDENTITY_ARCHETYPES,
+  type IdentityOathCategory,
+  type IdentityCopyVariant,
+  type IdentityArchetype,
+  type IdentityOathDeclaration,
+  getIdentityArchetype,
+  isIdentityOathCategory,
+  assignCopyVariant,
+  buildPledgeCopy,
+  composeIdentityOath,
+} from "./libs/identity-oath";
+
 export interface StyxClientBuildMetadata {
   platform: StyxClientPlatform;
   appVersion: string;

--- a/src/shared/libs/identity-oath.spec.ts
+++ b/src/shared/libs/identity-oath.spec.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  IDENTITY_ARCHETYPES,
+  IDENTITY_COPY_VARIANTS,
+  IDENTITY_OATH_CATEGORIES,
+  assignCopyVariant,
+  buildPledgeCopy,
+  composeIdentityOath,
+  getIdentityArchetype,
+  isIdentityOathCategory,
+} from "./identity-oath";
+
+describe("identity archetypes", () => {
+  it("exposes only the phase-1 no-contact journey", () => {
+    expect(IDENTITY_OATH_CATEGORIES).toEqual(["RECOVERY_NOCONTACT"]);
+    expect(isIdentityOathCategory("RECOVERY_NOCONTACT")).toBe(true);
+    expect(isIdentityOathCategory("BIOLOGICAL_WEIGHT")).toBe(false);
+  });
+
+  it("keeps archetype ids unique and resolvable", () => {
+    const ids = IDENTITY_ARCHETYPES.map((archetype) => archetype.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) {
+      expect(getIdentityArchetype(id)?.id).toBe(id);
+    }
+  });
+
+  it("returns null for an unknown archetype", () => {
+    expect(getIdentityArchetype("NOT_AN_ARCHETYPE")).toBeNull();
+  });
+
+  it("phrases every archetype as an identity, not a task", () => {
+    for (const archetype of IDENTITY_ARCHETYPES) {
+      expect(archetype.becoming.startsWith("someone who")).toBe(true);
+      expect(archetype.becoming.endsWith(".")).toBe(false);
+    }
+  });
+});
+
+describe("assignCopyVariant", () => {
+  it("is deterministic for the same user and archetype", () => {
+    const first = assignCopyVariant("user-1", "BOUNDARY_KEEPER");
+    for (let i = 0; i < 25; i += 1) {
+      expect(assignCopyVariant("user-1", "BOUNDARY_KEEPER")).toBe(first);
+    }
+  });
+
+  it("only ever returns a declared variant", () => {
+    for (const archetype of IDENTITY_ARCHETYPES) {
+      for (let i = 0; i < 50; i += 1) {
+        expect(IDENTITY_COPY_VARIANTS).toContain(
+          assignCopyVariant(`user-${i}`, archetype.id),
+        );
+      }
+    }
+  });
+
+  it("splits a population across both arms", () => {
+    const seen = new Set(
+      Array.from({ length: 200 }, (_, i) =>
+        assignCopyVariant(`user-${i}`, "BOUNDARY_KEEPER"),
+      ),
+    );
+    expect(seen.size).toBe(IDENTITY_COPY_VARIANTS.length);
+  });
+
+  it("assigns independently per archetype", () => {
+    // The bucket is keyed on the pair, so re-declaring under a different
+    // archetype must be able to land on the other arm for the same user.
+    const variants = IDENTITY_ARCHETYPES.map((archetype) =>
+      assignCopyVariant("user-42", archetype.id),
+    );
+    expect(variants).toHaveLength(IDENTITY_ARCHETYPES.length);
+  });
+});
+
+describe("buildPledgeCopy", () => {
+  const archetype = IDENTITY_ARCHETYPES[0];
+
+  it("declares the identity in the declarative arm", () => {
+    expect(buildPledgeCopy(archetype, "DECLARATIVE")).toBe(
+      "I am becoming someone who keeps the distance they chose. Every day of no contact I log is the evidence.",
+    );
+  });
+
+  it("asks the identity back in the reflective arm", () => {
+    expect(buildPledgeCopy(archetype, "REFLECTIVE")).toBe(
+      "Who am I becoming? Someone who keeps the distance they chose. Every day of no contact I log is the evidence.",
+    );
+  });
+
+  it("never uses coercive or financial wording", () => {
+    // TKT-P1-016 legal gate: the pledge is a skill-contract declaration, so it
+    // may not threaten, reference money, or describe another person's conduct.
+    // Word-bounded: "themselves" is a legitimate identity word, "them" is not.
+    const forbidden = [
+      /\blose\b/,
+      /\blost\b/,
+      /\bpunish/,
+      /\bforfeit/,
+      /\$/,
+      /\bthem\b/,
+      /\byour ex\b/,
+    ];
+    for (const archetypeUnderTest of IDENTITY_ARCHETYPES) {
+      for (const variant of IDENTITY_COPY_VARIANTS) {
+        const copy = buildPledgeCopy(archetypeUnderTest, variant).toLowerCase();
+        for (const pattern of forbidden) {
+          expect(copy).not.toMatch(pattern);
+        }
+      }
+    }
+  });
+});
+
+describe("composeIdentityOath", () => {
+  it("returns the label, variant, and pledge that belong together", () => {
+    const archetype = IDENTITY_ARCHETYPES[1];
+    const declaration = composeIdentityOath("user-7", archetype);
+
+    expect(declaration.archetypeId).toBe(archetype.id);
+    expect(declaration.identityLabel).toBe(archetype.label);
+    expect(declaration.copyVariant).toBe(
+      assignCopyVariant("user-7", archetype.id),
+    );
+    expect(declaration.pledgeCopy).toBe(
+      buildPledgeCopy(archetype, declaration.copyVariant),
+    );
+  });
+
+  it("recomposes identically on a resumed session", () => {
+    const archetype = IDENTITY_ARCHETYPES[2];
+    expect(composeIdentityOath("user-8", archetype)).toEqual(
+      composeIdentityOath("user-8", archetype),
+    );
+  });
+});

--- a/src/shared/libs/identity-oath.ts
+++ b/src/shared/libs/identity-oath.ts
@@ -1,0 +1,151 @@
+/**
+ * Identity-based oath onboarding — the single source of truth shared by the
+ * web onboarding wizard and the API that persists the declaration.
+ *
+ * A task list ("do not text them for 30 days") describes behavior. An identity
+ * statement ("I am becoming someone who keeps the distance they chose")
+ * describes the person the behavior belongs to, and it is the identity that the
+ * contract is bound to. The archetypes, the pledge wording, and the copy-variant
+ * assignment all live here so the sentence the user reads while declaring is
+ * byte-identical to the sentence stored against their contract — a client that
+ * composed its own wording would leave the persisted pledge silently divergent.
+ *
+ * Wording constraints (TKT-P1-016 legal gate): the pledge is a skill-contract
+ * declaration, never a threat or an inducement. No copy here may reference
+ * losing money, punishment, or another person's behavior.
+ */
+
+/**
+ * Phase-1 scope lock: RECOVERY_NOCONTACT is the only exposed oath category, so
+ * it is the only journey with declared archetypes. Adding a category means
+ * adding its own archetype set, not reusing this one.
+ */
+export const IDENTITY_OATH_CATEGORIES = ["RECOVERY_NOCONTACT"] as const;
+
+export type IdentityOathCategory = (typeof IDENTITY_OATH_CATEGORIES)[number];
+
+/**
+ * Activation copy variants. The two framings say the same thing — one declares
+ * it, one asks it back — so the assignment can be split for copy testing
+ * without either arm making a different promise.
+ */
+export const IDENTITY_COPY_VARIANTS = ["DECLARATIVE", "REFLECTIVE"] as const;
+
+export type IdentityCopyVariant = (typeof IDENTITY_COPY_VARIANTS)[number];
+
+export interface IdentityArchetype {
+  /** Stable key persisted against the oath; never re-used for different copy. */
+  id: string;
+  /** Human label stored as `identity_label` and shown on contract surfaces. */
+  label: string;
+  /** Completes "I am becoming ..." — always lowercase, no trailing period. */
+  becoming: string;
+  /** One-line explanation shown next to the label during selection. */
+  description: string;
+}
+
+export const IDENTITY_ARCHETYPES: readonly IdentityArchetype[] = [
+  {
+    id: "BOUNDARY_KEEPER",
+    label: "The Boundary Keeper",
+    becoming: "someone who keeps the distance they chose",
+    description:
+      "You decided where the line is. Holding it stops being a nightly decision and starts being a fact about you.",
+  },
+  {
+    id: "STEADY_ONE",
+    label: "The Steady One",
+    becoming: "someone who feels the urge and stays steady",
+    description:
+      "The urge still arrives. What changes is that it passes through you instead of moving your hands.",
+  },
+  {
+    id: "REBUILDER",
+    label: "The Rebuilder",
+    becoming: "someone who is building the next chapter instead of re-reading the last one",
+    description:
+      "Your attention goes into the life in front of you, and the days accumulate into something of your own.",
+  },
+  {
+    id: "OWN_WITNESS",
+    label: "Their Own Witness",
+    becoming: "someone who answers to themselves first",
+    description:
+      "You log the day because you were there for it — the record is yours before it is anyone else's.",
+  },
+];
+
+export function getIdentityArchetype(
+  archetypeId: string,
+): IdentityArchetype | null {
+  return (
+    IDENTITY_ARCHETYPES.find((archetype) => archetype.id === archetypeId) ?? null
+  );
+}
+
+export function isIdentityOathCategory(
+  category: string,
+): category is IdentityOathCategory {
+  return (IDENTITY_OATH_CATEGORIES as readonly string[]).includes(category);
+}
+
+/**
+ * FNV-1a over the user/archetype pair. The assignment must be reproducible from
+ * the identifiers alone: the wizard renders the pledge before the row exists,
+ * the API re-derives it when persisting, and a resumed session must land on the
+ * same arm — a stored random draw would make the first two disagree.
+ */
+function fnv1a32(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash >>> 0;
+}
+
+export function assignCopyVariant(
+  userId: string,
+  archetypeId: string,
+): IdentityCopyVariant {
+  const bucket = fnv1a32(`${userId}:${archetypeId}`) % IDENTITY_COPY_VARIANTS.length;
+  return IDENTITY_COPY_VARIANTS[bucket];
+}
+
+export function buildPledgeCopy(
+  archetype: IdentityArchetype,
+  variant: IdentityCopyVariant,
+): string {
+  if (variant === "REFLECTIVE") {
+    return `Who am I becoming? ${capitalize(archetype.becoming)}. Every day of no contact I log is the evidence.`;
+  }
+  return `I am becoming ${archetype.becoming}. Every day of no contact I log is the evidence.`;
+}
+
+function capitalize(value: string): string {
+  return value.length === 0 ? value : value[0].toUpperCase() + value.slice(1);
+}
+
+/**
+ * The full declaration for a user/archetype pair: the archetype, the variant it
+ * deterministically maps to, and the exact pledge sentence to store and show.
+ */
+export interface IdentityOathDeclaration {
+  archetypeId: string;
+  identityLabel: string;
+  copyVariant: IdentityCopyVariant;
+  pledgeCopy: string;
+}
+
+export function composeIdentityOath(
+  userId: string,
+  archetype: IdentityArchetype,
+): IdentityOathDeclaration {
+  const copyVariant = assignCopyVariant(userId, archetype.id);
+  return {
+    archetypeId: archetype.id,
+    identityLabel: archetype.label,
+    copyVariant,
+    pledgeCopy: buildPledgeCopy(archetype, copyVariant),
+  };
+}

--- a/src/web/app/contracts/[id]/page.tsx
+++ b/src/web/app/contracts/[id]/page.tsx
@@ -8,7 +8,7 @@ import {
   Send, Calendar, Shield, FileText, UserPlus,
 } from 'lucide-react';
 import { api } from '../../../services/api-client';
-import type { AccountabilityStatus } from '../../../services/api-client';
+import type { AccountabilityStatus, IdentityOathSummary } from '../../../services/api-client';
 import { useAuth } from '../../../contexts/AuthContext';
 import RecoveryLockCountdown from '../../../components/RecoveryLockCountdown';
 import DangerZoneBanner from '../../../components/DangerZoneBanner';
@@ -38,6 +38,7 @@ interface ContractData {
   email: string;
   integrity_score: number;
   proofs?: Proof[];
+  identity_oath?: IdentityOathSummary | null;
 }
 
 interface Proof {
@@ -219,12 +220,26 @@ export default function ContractDetailPage() {
         </div>
       </div>
 
+      {/* Identity the contract is bound to (TKT-P1-016) — first, because it is
+          who the person said they were becoming; everything below is mechanics. */}
+      {contract.identity_oath && (
+        <div className="mb-6 p-5 bg-red-900/10 border border-red-900/30 rounded-2xl">
+          <p className="text-xs font-bold uppercase tracking-widest text-neutral-500">
+            {contract.identity_oath.identity_label}
+          </p>
+          <p className="mt-2 text-lg font-bold text-white">
+            {contract.identity_oath.pledge_copy}
+          </p>
+        </div>
+      )}
+
       {/* Danger windows — the API only evaluates them for ACTIVE contracts. */}
       {contract.status === 'ACTIVE' && (
         <div className="mb-6">
           <DangerZoneBanner contractId={contract.id} />
         </div>
       )}
+
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {/* Stake & Timeline */}

--- a/src/web/app/contracts/new/page.tsx
+++ b/src/web/app/contracts/new/page.tsx
@@ -122,6 +122,7 @@ function NewContractPageContent() {
   const [error, setError] = useState<string | null>(null);
   const [failureCount, setFailureCount] = useState<number | null>(null);
   const [downscaling, setDownscaling] = useState<DownscalingSignal | null>(null);
+  const [identityPledge, setIdentityPledge] = useState<string | null>(null);
 
   // Recovery stream fields
   const [apEmail, setApEmail] = useState('');
@@ -201,6 +202,23 @@ function NewContractPageContent() {
           setFailureCount(profileFailureCount);
         }
       });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  // The identity declared at onboarding is what this contract binds to, so it
+  // is shown at the moment of committing rather than only in the wizard.
+  useEffect(() => {
+    if (!user) return undefined;
+    let cancelled = false;
+
+    api.getIdentityOath()
+      .then((state) => {
+        if (!cancelled) setIdentityPledge(state.oath?.pledgeCopy ?? null);
+      })
+      .catch(() => undefined);
 
     return () => {
       cancelled = true;
@@ -308,6 +326,16 @@ function NewContractPageContent() {
       </header>
 
       <form onSubmit={handleSubmit} className="max-w-2xl mx-auto space-y-8">
+        {/* Declared identity (TKT-P1-016) */}
+        {identityPledge && (
+          <div className="p-5 bg-red-900/10 border border-red-900/30 rounded-xl">
+            <p className="text-xs font-bold uppercase tracking-widest text-neutral-500">
+              Your Declaration
+            </p>
+            <p className="mt-2 text-lg font-bold text-white">{identityPledge}</p>
+          </div>
+        )}
+
         {/* Oath Category */}
         <div>
           <label className="block text-sm font-bold text-neutral-400 uppercase tracking-widest mb-3">

--- a/src/web/components/OnboardingWizard.test.tsx
+++ b/src/web/components/OnboardingWizard.test.tsx
@@ -1,6 +1,10 @@
+/** @jest-environment jsdom */
+
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { OnboardingWizard } from './OnboardingWizard';
+import { IDENTITY_ARCHETYPES } from '../../shared/libs/identity-oath';
 
 // Mock next/navigation
 jest.mock('next/navigation', () => ({
@@ -9,18 +13,65 @@ jest.mock('next/navigation', () => ({
   }),
 }));
 
+jest.mock('next/link', () => {
+  return function MockLink({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) {
+    return (
+      <a href={href} className={className}>
+        {children}
+      </a>
+    );
+  };
+});
+
+const getIdentityOath = jest.fn();
+const declareIdentityOath = jest.fn();
+
+jest.mock('../services/api-client', () => ({
+  api: {
+    getIdentityOath: (...args: unknown[]) => getIdentityOath(...args),
+    declareIdentityOath: (...args: unknown[]) => declareIdentityOath(...args),
+  },
+}));
+
+const archetype = IDENTITY_ARCHETYPES[0];
+
 describe('OnboardingWizard', () => {
   const defaultProps = {
     onComplete: jest.fn(),
     onSkip: jest.fn(),
   };
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getIdentityOath.mockResolvedValue({
+      oathCategory: 'RECOVERY_NOCONTACT',
+      oath: null,
+      completed: false,
+      archetypes: IDENTITY_ARCHETYPES,
+    });
+    declareIdentityOath.mockResolvedValue({
+      id: 'oath-1',
+      archetypeId: archetype.id,
+      identityLabel: archetype.label,
+      pledgeCopy: 'I am becoming someone who keeps the distance they chose.',
+      copyVariant: 'DECLARATIVE',
+    });
+  });
+
   it('renders the welcome step (step 0) initially', () => {
     const html = renderToStaticMarkup(<OnboardingWizard {...defaultProps} />);
 
     expect(html).toContain('Welcome to Styx');
     expect(html).toContain('Relationship Recovery Beta');
-    expect(html).toContain('Step 1 of 5');
+    expect(html).toContain('Step 1 of 6');
   });
 
   it('renders the key features in welcome step', () => {
@@ -36,5 +87,121 @@ describe('OnboardingWizard', () => {
 
     expect(html).toContain('financial commitments');
     expect(html).toContain('No Contact rule');
+  });
+
+  it('asks who the user is becoming before it asks what they will do', async () => {
+    render(<OnboardingWizard {...defaultProps} />);
+
+    fireEvent.click(screen.getByText('Continue'));
+
+    expect(await screen.findByText('Who Are You Becoming?')).toBeDefined();
+    for (const option of IDENTITY_ARCHETYPES) {
+      expect(screen.getByText(option.label)).toBeDefined();
+    }
+    // The oath-stream step is still ahead of us, not behind.
+    expect(screen.queryByText('Choose Your First Oath')).toBeNull();
+  });
+
+  it('will not advance past the identity step until one is declared', async () => {
+    render(<OnboardingWizard {...defaultProps} />);
+    fireEvent.click(screen.getByText('Continue'));
+    await screen.findByText('Who Are You Becoming?');
+
+    fireEvent.click(screen.getByText('Continue'));
+
+    expect(declareIdentityOath).not.toHaveBeenCalled();
+    expect(screen.getByText('Who Are You Becoming?')).toBeDefined();
+  });
+
+  it('persists the declaration and carries the pledge to the summary', async () => {
+    render(<OnboardingWizard {...defaultProps} />);
+    fireEvent.click(screen.getByText('Continue'));
+    await screen.findByText('Who Are You Becoming?');
+
+    fireEvent.click(screen.getByText(archetype.label));
+    fireEvent.click(screen.getByText('Continue'));
+
+    await waitFor(() =>
+      expect(declareIdentityOath).toHaveBeenCalledWith(archetype.id),
+    );
+    await screen.findByText('Choose Your First Oath');
+
+    // Walk to the final summary: category, stake, payment.
+    fireEvent.click(screen.getByText('No Contact'));
+    fireEvent.click(screen.getByText('Continue'));
+    await screen.findByText('Set Your Stakes');
+    // The default stake (25) sits above the beta cap, so a preset must be
+    // chosen before the step will advance — unchanged by this work.
+    fireEvent.click(screen.getByText('$15'));
+    fireEvent.click(screen.getByText('Continue'));
+    await screen.findByText('Connect Payment');
+    fireEvent.click(screen.getByText('Continue'));
+
+    expect(await screen.findByText('You Are Ready')).toBeDefined();
+    expect(
+      screen.getByText(
+        'I am becoming someone who keeps the distance they chose.',
+      ),
+    ).toBeDefined();
+    expect(screen.getByText(archetype.label)).toBeDefined();
+  });
+
+  it('keeps the user on the identity step when the declaration fails', async () => {
+    declareIdentityOath.mockRejectedValue(new Error('network down'));
+    render(<OnboardingWizard {...defaultProps} />);
+    fireEvent.click(screen.getByText('Continue'));
+    await screen.findByText('Who Are You Becoming?');
+
+    fireEvent.click(screen.getByText(archetype.label));
+    fireEvent.click(screen.getByText('Continue'));
+
+    expect(
+      await screen.findByText(
+        'Could not save your identity. Check your connection and try again.',
+      ),
+    ).toBeDefined();
+    expect(screen.getByText('Who Are You Becoming?')).toBeDefined();
+  });
+
+  it('resumes a declaration made in an earlier session', async () => {
+    getIdentityOath.mockResolvedValue({
+      oathCategory: 'RECOVERY_NOCONTACT',
+      oath: {
+        id: 'oath-1',
+        userId: 'user-1',
+        oathCategory: 'RECOVERY_NOCONTACT',
+        archetypeId: archetype.id,
+        identityLabel: archetype.label,
+        pledgeCopy: 'I am becoming someone who keeps the distance they chose.',
+        copyVariant: 'DECLARATIVE',
+        activatedAt: '2026-03-04T12:00:00.000Z',
+      },
+      completed: true,
+      archetypes: IDENTITY_ARCHETYPES,
+    });
+
+    render(<OnboardingWizard {...defaultProps} />);
+    await waitFor(() => expect(getIdentityOath).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByText('Continue'));
+    await screen.findByText('Who Are You Becoming?');
+
+    // The prior choice is pre-selected, so Continue moves on immediately.
+    fireEvent.click(screen.getByText('Continue'));
+
+    await waitFor(() =>
+      expect(declareIdentityOath).toHaveBeenCalledWith(archetype.id),
+    );
+    expect(await screen.findByText('Choose Your First Oath')).toBeDefined();
+  });
+
+  it('does not block onboarding when the resume lookup fails', async () => {
+    getIdentityOath.mockRejectedValue(new Error('offline'));
+    render(<OnboardingWizard {...defaultProps} />);
+    await waitFor(() => expect(getIdentityOath).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByText('Continue'));
+
+    expect(await screen.findByText('Who Are You Becoming?')).toBeDefined();
   });
 });

--- a/src/web/components/OnboardingWizard.tsx
+++ b/src/web/components/OnboardingWizard.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import {
-  ChevronRight, ChevronLeft, Flame, Shield, DollarSign, CreditCard, X,
+  ChevronRight, ChevronLeft, Flame, Shield, DollarSign, CreditCard, X, UserCheck,
 } from 'lucide-react';
+import { api } from '../services/api-client';
+import { IDENTITY_ARCHETYPES } from '../../shared/libs/identity-oath';
 
 const OATH_CATEGORIES = [
   { id: 'RECOVERY_NOCONTACT', label: 'No Contact', icon: '\u{1F6AB}', description: 'Absolute severance. No texts, calls, or DMs.', color: 'border-red-700 hover:border-red-500' },
@@ -27,25 +29,68 @@ interface OnboardingWizardProps {
 
 export function OnboardingWizard({ onComplete, onSkip }: OnboardingWizardProps) {
   const [step, setStep] = useState(0);
+  const [selectedArchetype, setSelectedArchetype] = useState('');
+  const [pledgeCopy, setPledgeCopy] = useState('');
+  const [identitySaving, setIdentitySaving] = useState(false);
+  const [identityError, setIdentityError] = useState<string | null>(null);
   const [selectedCategory, setSelectedCategory] = useState('');
   const [stakeAmount, setStakeAmount] = useState(25);
   const [customStake, setCustomStake] = useState('');
   const router = useRouter();
 
-  const totalSteps = 5;
+  const totalSteps = 6;
+
+  // Resume: a returning user reads back the identity they already declared
+  // instead of being asked who they are becoming a second time. An unreachable
+  // API leaves the step empty rather than blocking onboarding.
+  useEffect(() => {
+    let cancelled = false;
+
+    api.getIdentityOath()
+      .then((state) => {
+        if (cancelled || !state.oath) return;
+        setSelectedArchetype(state.oath.archetypeId);
+        setPledgeCopy(state.oath.pledgeCopy);
+      })
+      .catch(() => undefined);
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const canProceed = (): boolean => {
     switch (step) {
       case 0: return true; // Welcome — always
-      case 1: return selectedCategory !== ''; // Must select category
-      case 2: return stakeAmount >= 5 && stakeAmount <= MAX_BETA_STAKE; // Valid stake
-      case 3: return true; // Payment info — always
-      case 4: return true; // Redirect
+      case 1: return selectedArchetype !== '' && !identitySaving; // Must declare an identity
+      case 2: return selectedCategory !== ''; // Must select category
+      case 3: return stakeAmount >= 5 && stakeAmount <= MAX_BETA_STAKE; // Valid stake
+      case 4: return true; // Payment info — always
+      case 5: return true; // Redirect
       default: return true;
     }
   };
 
-  const handleNext = () => {
+  const declareIdentity = async (): Promise<boolean> => {
+    setIdentitySaving(true);
+    setIdentityError(null);
+    try {
+      // The pledge sentence is composed server-side, so what the summary shows
+      // is the wording actually stored against the contract.
+      const oath = await api.declareIdentityOath(selectedArchetype);
+      setPledgeCopy(oath.pledgeCopy);
+      return true;
+    } catch {
+      setIdentityError('Could not save your identity. Check your connection and try again.');
+      return false;
+    } finally {
+      setIdentitySaving(false);
+    }
+  };
+
+  const handleNext = async () => {
+    if (step === 1 && !(await declareIdentity())) return;
+
     if (step < totalSteps - 1) {
       setStep(step + 1);
     } else {
@@ -73,6 +118,9 @@ export function OnboardingWizard({ onComplete, onSkip }: OnboardingWizardProps) 
   };
 
   const perceivedLoss = (stakeAmount * LOSS_AVERSION_LAMBDA).toFixed(2);
+  const identityLabel =
+    IDENTITY_ARCHETYPES.find((archetype) => archetype.id === selectedArchetype)?.label
+    ?? 'Not declared';
 
   return (
     <div className="fixed inset-0 z-50 bg-black/80 backdrop-blur-sm flex items-center justify-center p-4">
@@ -152,8 +200,51 @@ export function OnboardingWizard({ onComplete, onSkip }: OnboardingWizardProps) 
             </div>
           )}
 
-          {/* Step 1: Choose Oath Category */}
+          {/* Step 1: Declare Identity */}
           {step === 1 && (
+            <div className="space-y-6">
+              <div>
+                <h2 className="text-2xl font-black tracking-tight">Who Are You Becoming?</h2>
+                <p className="text-neutral-400 text-sm mt-1">
+                  No Contact is not a chore list. Name the person you are becoming —
+                  your contract is bound to that, not to a task.
+                </p>
+              </div>
+
+              <div className="grid grid-cols-1 gap-3">
+                {IDENTITY_ARCHETYPES.map((archetype) => (
+                  <button
+                    key={archetype.id}
+                    onClick={() => setSelectedArchetype(archetype.id)}
+                    className={`p-4 rounded-xl border-2 text-left transition-all ${
+                      selectedArchetype === archetype.id
+                        ? 'border-red-500 bg-red-900/20'
+                        : 'border-neutral-800 bg-black hover:border-neutral-600'
+                    }`}
+                  >
+                    <div className="flex items-center gap-3 mb-1">
+                      <UserCheck size={18} className="text-red-500 shrink-0" />
+                      <span className="font-bold text-white">{archetype.label}</span>
+                    </div>
+                    <p className="text-sm text-neutral-300">I am becoming {archetype.becoming}.</p>
+                    <p className="text-xs text-neutral-500 mt-1">{archetype.description}</p>
+                  </button>
+                ))}
+              </div>
+
+              {identityError && (
+                <p className="text-sm text-red-400">{identityError}</p>
+              )}
+
+              <p className="text-xs text-neutral-600">
+                You can change who you are becoming later. The declaration is yours — it is
+                never shown to the person you are going No Contact with.
+              </p>
+            </div>
+          )}
+
+          {/* Step 2: Choose Oath Category */}
+          {step === 2 && (
             <div className="space-y-6">
               <div>
                 <h2 className="text-2xl font-black tracking-tight">Choose Your First Oath</h2>
@@ -184,8 +275,8 @@ export function OnboardingWizard({ onComplete, onSkip }: OnboardingWizardProps) 
             </div>
           )}
 
-          {/* Step 2: Set Stakes */}
-          {step === 2 && (
+          {/* Step 3: Set Stakes */}
+          {step === 3 && (
             <div className="space-y-6">
               <div>
                 <h2 className="text-2xl font-black tracking-tight">Set Your Stakes</h2>
@@ -262,8 +353,8 @@ export function OnboardingWizard({ onComplete, onSkip }: OnboardingWizardProps) 
             </div>
           )}
 
-          {/* Step 3: Connect Payment */}
-          {step === 3 && (
+          {/* Step 4: Connect Payment */}
+          {step === 4 && (
             <div className="space-y-6">
               <div>
                 <h2 className="text-2xl font-black tracking-tight">Connect Payment</h2>
@@ -307,8 +398,8 @@ export function OnboardingWizard({ onComplete, onSkip }: OnboardingWizardProps) 
             </div>
           )}
 
-          {/* Step 4: Ready to Go */}
-          {step === 4 && (
+          {/* Step 5: Ready to Go */}
+          {step === 5 && (
             <div className="space-y-6 text-center">
               <div className="w-20 h-20 bg-red-600 rounded-full flex items-center justify-center mx-auto">
                 <Flame className="text-black" size={40} />
@@ -321,7 +412,23 @@ export function OnboardingWizard({ onComplete, onSkip }: OnboardingWizardProps) 
                 </p>
               </div>
 
+              {pledgeCopy && (
+                <div className="p-5 bg-red-900/10 border border-red-900/30 rounded-xl text-left">
+                  <p className="text-xs font-bold uppercase tracking-widest text-neutral-500">
+                    Your Declaration
+                  </p>
+                  <p className="mt-2 text-lg font-bold text-white">{pledgeCopy}</p>
+                  <p className="mt-2 text-xs text-neutral-500">
+                    Bound to every contract you open in this stream.
+                  </p>
+                </div>
+              )}
+
               <div className="p-6 bg-black border border-neutral-800 rounded-xl text-left space-y-3">
+                <div className="flex justify-between items-center">
+                  <span className="text-neutral-500 text-sm">Identity</span>
+                  <span className="font-bold">{identityLabel}</span>
+                </div>
                 <div className="flex justify-between items-center">
                   <span className="text-neutral-500 text-sm">Oath Stream</span>
                   <span className="font-bold capitalize">{selectedCategory || 'Not selected'}</span>
@@ -379,7 +486,11 @@ export function OnboardingWizard({ onComplete, onSkip }: OnboardingWizardProps) 
             disabled={!canProceed()}
             className="px-8 py-3 bg-red-600 hover:bg-red-700 disabled:opacity-40 disabled:cursor-not-allowed text-white font-black rounded-xl transition-colors flex items-center gap-2"
           >
-            {step === totalSteps - 1 ? 'Create Contract' : 'Continue'}
+            {identitySaving
+              ? 'Saving...'
+              : step === totalSteps - 1
+                ? 'Create Contract'
+                : 'Continue'}
             <ChevronRight size={18} />
           </button>
         </div>

--- a/src/web/services/api-client.ts
+++ b/src/web/services/api-client.ts
@@ -311,6 +311,38 @@ export interface AccountabilityStatus {
   }>;
 }
 
+/** The identity declaration a contract is bound to (TKT-P1-016). */
+export interface IdentityOathSummary {
+  id: string;
+  archetype_id: string;
+  identity_label: string;
+  pledge_copy: string;
+  copy_variant: string;
+}
+
+export interface IdentityOathRecord {
+  id: string;
+  userId: string;
+  oathCategory: string;
+  archetypeId: string;
+  identityLabel: string;
+  pledgeCopy: string;
+  copyVariant: string;
+  activatedAt: string | null;
+}
+
+export interface IdentityOathState {
+  oathCategory: string;
+  oath: IdentityOathRecord | null;
+  completed: boolean;
+  archetypes: Array<{
+    id: string;
+    label: string;
+    becoming: string;
+    description: string;
+  }>;
+}
+
 export interface LeaderboardEntry {
   id: string;
   email: string;
@@ -441,6 +473,18 @@ export const api = {
       }>;
     }>(`/wallet/history${limit ? `?limit=${limit}` : ""}`),
 
+  // Onboarding — identity-based oath declaration (TKT-P1-016)
+  getIdentityOath: (oathCategory?: string) =>
+    request<IdentityOathState>(
+      `/onboarding/identity-oath${oathCategory ? `?oathCategory=${encodeURIComponent(oathCategory)}` : ""}`,
+    ),
+
+  declareIdentityOath: (archetypeId: string, oathCategory?: string) =>
+    request<IdentityOathRecord>("/onboarding/identity-oath", {
+      method: "POST",
+      body: JSON.stringify({ archetypeId, oathCategory }),
+    }),
+
   // Contracts — userId comes from JWT
   getUserContracts: () =>
     request<
@@ -482,6 +526,7 @@ export const api = {
         media_url: string | null;
       }>;
       grace_days_max: number;
+      identity_oath: IdentityOathSummary | null;
     }>(`/contracts/${id}`),
 
   // `downscaling.multiplier` is advisory only — it is rendered as stake guidance


### PR DESCRIPTION
## TKT-P1-016 — identity-based oath onboarding

Onboarding asked what the user would **do** (pick a stream, pick a stake) and never asked who they were **becoming**, so a No Contact contract was a task list with money attached. This adds the identity declaration and binds it to the contract itself.

### What landed

**Schema** — migration `069_identity_oaths.sql` (the ticket's `user_identity_oaths` shape):

| column | note |
|---|---|
| `user_id`, `oath_category` | `UNIQUE` together — re-declaring updates, never forks |
| `archetype_id`, `identity_label` | the declared identity |
| `pledge_copy`, `copy_variant` | the exact sentence and the activation-copy arm it came from |
| `activated_at` | `NULL` while the step is open; stamped once, preserved across re-declaration |

plus a nullable `contracts.identity_oath_id` (FK, `ON DELETE SET NULL`) — the binding. `database/schema.sql` carries the same shapes so a fresh init matches a migrated database.

**Shared** — `src/shared/libs/identity-oath.ts`: the archetype catalogue, the pledge wording, and a deterministic FNV-1a copy-variant assignment. It is shared rather than duplicated because the wizard renders the pledge *before* the row exists and the API re-composes it when persisting; a client-composed sentence would silently diverge from the stored one. `copy_variant` is persisted rather than re-derived on read, so a later change to the assignment function cannot rewrite a sentence a user already agreed to.

**API** — new `onboarding` module (registered in `AppModule`, guarded by `AuthGuard`):
- `GET /onboarding/identity-oath` → resumable state (`{ oathCategory, oath, completed, archetypes }`)
- `POST /onboarding/identity-oath` → declare/re-declare; the pledge is composed server-side

`ContractsModule` imports it; `createContract` resolves the activated oath and writes `identity_oath_id` on **both** insert paths (transactional and non-transactional), and `getContract` LEFT JOINs it back as a nested `identity_oath`.

**Web** — the wizard gains an identity step *ahead of* the oath stream (6 steps, not 5), resumes a declaration made in an earlier session, blocks advancing until one is declared, and shows the stored pledge on the summary. The pledge also renders on `/contracts/new` and on contract detail, so the API's new field has real consumers.

### Copy

Written for the `RECOVERY_NOCONTACT` journey only (phase-1 scope lock) and kept clear of financial/coercive framing per the ticket's language gate — a spec asserts no pledge string contains `lose`/`punish`/`forfeit`/`$`/`them`.

### Verification

| where | command | result |
|---|---|---|
| shared | `npx jest libs/identity-oath.spec.ts` | 13 passed |
| api | `npx jest src/main.spec.ts src/modules/contracts src/modules/onboarding` | 265 passed (15 suites) |
| api | `npx tsc --noEmit` | clean |
| web | `npx jest components/OnboardingWizard.test.tsx` | 9 passed |
| web | `npx jest services/api-client.test.ts` | 20 passed |
| web | `npx tsc --noEmit` | clean |

**The SQL is not verified.** Every spec in this repo mocks the pg `Pool`, so the migration, the `ON CONFLICT (user_id, oath_category)` upsert, and the new `LEFT JOIN` have been reviewed by reading — not executed against Postgres. A green test run here says nothing about them.

### Deliberately not in this change

- **No server-side gate blocking contract creation without a declaration.** The ticket's acceptance criterion ("new users cannot skip directly to contract creation") is enforced in the wizard only. A hard `createContract` block would reject every account that predates this step; it needs a backfill or a cohort flag decided separately.
- The wizard's existing "Skip for now" exit is untouched.
- Mobile onboarding is unchanged — the shared library is where its identity step would draw from when it lands.

## Summary by Sourcery

Introduce identity-based oath onboarding flow that binds user contracts to a declared identity and exposes that identity across API and web surfaces.

New Features:
- Add shared identity oath library defining archetypes, copy variants, and deterministic pledge wording used by both API and web.
- Expose authenticated onboarding identity-oath API endpoints to fetch resumable state and declare or re-declare identity per oath category.
- Display an identity declaration step in the web onboarding wizard ahead of oath selection, blocking progress until an identity is declared and resuming prior declarations.
- Show the bound identity pledge on new contract creation and contract detail pages so users see who the contract is tied to.

Enhancements:
- Bind newly created contracts to the user’s activated identity oath when available and return the nested identity metadata from the contracts API.
- Extend contracts service and module wiring to integrate the onboarding identity oath service without breaking existing contract creation paths.

Build:
- Add database migration and schema definitions for user_identity_oaths and the contracts.identity_oath_id foreign key to persist identity declarations per user and category.

Tests:
- Add unit tests for the identity oath shared library, onboarding API controller and service, contract identity binding, and updated onboarding wizard behavior to cover resumability, error handling, and pledge rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a six-step identity declaration experience during onboarding, with resumable progress.
  * Users can select an identity archetype and receive a personalized pledge declaration.
  * Identity declarations can be linked to new contracts and displayed in contract details.
  * Added support for viewing the declaration in the contract creation form.
* **Bug Fixes**
  * Improved validation and error handling for invalid identity selections and save failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->