### PR TITLE
feat(fury): wire the collusion engine — scheduler, auto-open, read API, admin screen (TKT-P1-008)

### DIFF
--- a/src/api/database/migrations/070_fury_enforcement_case_read_indexes.sql
+++ b/src/api/database/migrations/070_fury_enforcement_case_read_indexes.sql
@@ -1,0 +1,19 @@
+-- 070: Index the enforcement-case access paths the collusion wiring introduced.
+--
+-- Until TKT-P1-008 the only reader of fury_enforcement_cases was a per-reviewer
+-- lookup, which idx_fury_enforcement_cases_reviewer already served. Two new hot
+-- paths arrive with the sweep:
+--
+--   1. CollusionDetectionScheduler runs every 6 hours and, for each ring member,
+--      asks "does this reviewer already have an open COLLUSION_RING case?" before
+--      filing. That is a (reviewer_id, case_type, status) probe on every sweep.
+--   2. The admin read API lists cases filtered by status/case_type, newest first.
+--
+-- Both would otherwise degrade into sequential scans as cases accumulate, and
+-- cases only ever accumulate — nothing deletes them.
+
+CREATE INDEX IF NOT EXISTS idx_fury_enforcement_cases_reviewer_type_status
+    ON fury_enforcement_cases(reviewer_id, case_type, status);
+
+CREATE INDEX IF NOT EXISTS idx_fury_enforcement_cases_status_created
+    ON fury_enforcement_cases(status, case_type, created_at DESC);

--- a/src/api/services/security/collusion-detection.service.spec.ts
+++ b/src/api/services/security/collusion-detection.service.spec.ts
@@ -112,6 +112,30 @@ describe('CollusionDetectionService', () => {
         }),
       );
     });
+
+    it('skips a reviewer who already has an open collusion case', async () => {
+      // The scheduler's 24h lookback re-detects an unreviewed ring on every 6h
+      // sweep and mints a fresh ringId each time, so the guard — not the ringId —
+      // is what keeps the queue from filling with duplicates.
+      pool.query
+        // fury-a: guarded INSERT matches nothing (case already open)
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any)
+        // fury-b: newly filed
+        .mockResolvedValueOnce({ rows: [{ id: 'case-2' }], rowCount: 1 } as any);
+
+      const caseIds = await service.sanctionRing({
+        ringId: 'ring-test-2',
+        furyIds: ['fury-a', 'fury-b'],
+        confidence: 0.9,
+        signals: [],
+        recommendedAction: 'SANCTION',
+      });
+
+      expect(caseIds).toEqual(['case-2']);
+      expect(truthLog.appendEvent).toHaveBeenCalledTimes(1);
+      expect(pool.query.mock.calls[0][0]).toMatch(/WHERE NOT EXISTS/);
+      expect(pool.query.mock.calls[0][0]).toMatch(/status = 'PENDING_REVIEW'/);
+    });
   });
 
   describe('signal detection', () => {

--- a/src/api/services/security/collusion-detection.service.ts
+++ b/src/api/services/security/collusion-detection.service.ts
@@ -360,6 +360,16 @@ export class CollusionDetectionService {
   /**
    * Open enforcement cases for confirmed collusion rings.
    * Only sanctions rings above the threshold.
+   *
+   * Idempotent per reviewer. `analyzeWindow` looks back over a rolling window that
+   * is wider than the scheduler's cadence, so the same ring is re-detected on every
+   * sweep until an admin dispositions it — and `ringId` is minted fresh each run
+   * (`ring-N-${Date.now()}`), so it cannot itself be the dedupe key. Without a guard
+   * an unreviewed ring would accrue a new PENDING_REVIEW case per member per sweep
+   * and bury the queue. The INSERT...SELECT...WHERE NOT EXISTS is atomic within the
+   * single statement (same shape as EnforcementService.applyPenalty): a reviewer who
+   * already has an open COLLUSION_RING case matches zero rows and is skipped, so the
+   * returned ids are the cases this call actually created.
    */
   async sanctionRing(ring: CollusionRing): Promise<string[]> {
     const caseIds: string[] = [];
@@ -368,7 +378,13 @@ export class CollusionDetectionService {
       const result = await this.pool.query(
         `INSERT INTO fury_enforcement_cases
          (reviewer_id, case_type, confidence, status, evidence_json)
-         VALUES ($1, 'COLLUSION_RING', $2, 'PENDING_REVIEW', $3)
+         SELECT $1, 'COLLUSION_RING', $2, 'PENDING_REVIEW', $3::jsonb
+         WHERE NOT EXISTS (
+           SELECT 1 FROM fury_enforcement_cases
+           WHERE reviewer_id = $1
+             AND case_type = 'COLLUSION_RING'
+             AND status = 'PENDING_REVIEW'
+         )
          RETURNING id`,
         [
           furyId,
@@ -384,6 +400,11 @@ export class CollusionDetectionService {
           }),
         ],
       );
+
+      if (result.rows.length === 0) {
+        // This reviewer already has an open collusion case awaiting review.
+        continue;
+      }
 
       const caseId = result.rows[0].id;
       caseIds.push(caseId);

--- a/src/api/src/modules/fury/collusion-detection.scheduler.spec.ts
+++ b/src/api/src/modules/fury/collusion-detection.scheduler.spec.ts
@@ -1,0 +1,146 @@
+import { CollusionDetectionScheduler } from './collusion-detection.scheduler';
+import {
+  CollusionDetectionService,
+  CollusionRing,
+} from '../../../services/security/collusion-detection.service';
+
+function ring(overrides: Partial<CollusionRing> = {}): CollusionRing {
+  return {
+    ringId: 'ring-1-1700000000000',
+    furyIds: ['fury-a', 'fury-b'],
+    confidence: 0.9,
+    signals: [
+      {
+        pairKey: 'fury-a::fury-b',
+        furyIds: ['fury-a', 'fury-b'],
+        signalType: 'COORDINATED_VOTE',
+        score: 0.95,
+        evidence: {},
+      },
+      {
+        pairKey: 'fury-a::fury-b',
+        furyIds: ['fury-a', 'fury-b'],
+        signalType: 'VERDICT_SYNC',
+        score: 0.92,
+        evidence: {},
+      },
+    ],
+    recommendedAction: 'SANCTION',
+    ...overrides,
+  };
+}
+
+describe('CollusionDetectionScheduler', () => {
+  let scheduler: CollusionDetectionScheduler;
+  let collusion: { analyzeWindow: jest.Mock; sanctionRing: jest.Mock };
+
+  beforeEach(() => {
+    collusion = {
+      analyzeWindow: jest.fn(),
+      sanctionRing: jest.fn(),
+    };
+    scheduler = new CollusionDetectionScheduler(
+      collusion as unknown as CollusionDetectionService,
+    );
+    jest.clearAllMocks();
+  });
+
+  it('analyzes a 24h window requiring corroboration from two signals', async () => {
+    collusion.analyzeWindow.mockResolvedValue([]);
+
+    await scheduler.sweepForCollusionRings();
+
+    expect(collusion.analyzeWindow).toHaveBeenCalledWith(24, 2);
+  });
+
+  it('files SANCTION rings as enforcement cases', async () => {
+    collusion.analyzeWindow.mockResolvedValue([ring()]);
+    collusion.sanctionRing.mockResolvedValue(['case-1', 'case-2']);
+
+    await scheduler.sweepForCollusionRings();
+
+    expect(collusion.sanctionRing).toHaveBeenCalledTimes(1);
+    expect(collusion.sanctionRing).toHaveBeenCalledWith(
+      expect.objectContaining({ ringId: 'ring-1-1700000000000' }),
+    );
+  });
+
+  it('files INVESTIGATE rings too — a case is a queue entry, not a penalty', async () => {
+    collusion.analyzeWindow.mockResolvedValue([
+      ring({ recommendedAction: 'INVESTIGATE', confidence: 0.75 }),
+    ]);
+    collusion.sanctionRing.mockResolvedValue(['case-1']);
+
+    await scheduler.sweepForCollusionRings();
+
+    expect(collusion.sanctionRing).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not file MONITOR rings', async () => {
+    collusion.analyzeWindow.mockResolvedValue([
+      ring({ recommendedAction: 'MONITOR', confidence: 0.4 }),
+    ]);
+
+    await scheduler.sweepForCollusionRings();
+
+    expect(collusion.sanctionRing).not.toHaveBeenCalled();
+  });
+
+  it('does not call sanctionRing when nothing was detected', async () => {
+    collusion.analyzeWindow.mockResolvedValue([]);
+
+    await scheduler.sweepForCollusionRings();
+
+    expect(collusion.sanctionRing).not.toHaveBeenCalled();
+  });
+
+  it('keeps sweeping when one ring fails to file', async () => {
+    collusion.analyzeWindow.mockResolvedValue([
+      ring({ ringId: 'ring-bad' }),
+      ring({ ringId: 'ring-good', furyIds: ['fury-c', 'fury-d'] }),
+    ]);
+    collusion.sanctionRing
+      .mockRejectedValueOnce(new Error('insert exploded'))
+      .mockResolvedValueOnce(['case-3']);
+    const errorSpy = jest
+      .spyOn((scheduler as any).logger, 'error')
+      .mockImplementation();
+
+    await scheduler.sweepForCollusionRings();
+
+    expect(collusion.sanctionRing).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('ring-bad'),
+    );
+  });
+
+  it('swallows an analysis failure so the cron does not crash the scheduler', async () => {
+    collusion.analyzeWindow.mockRejectedValue(new Error('pg down'));
+    const errorSpy = jest
+      .spyOn((scheduler as any).logger, 'error')
+      .mockImplementation();
+
+    await expect(scheduler.sweepForCollusionRings()).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('pg down'),
+    );
+    expect(collusion.sanctionRing).not.toHaveBeenCalled();
+  });
+
+  it('reports a re-detected ring as filed-zero rather than counting it again', async () => {
+    collusion.analyzeWindow.mockResolvedValue([ring()]);
+    // sanctionRing is idempotent per reviewer: a ring already awaiting review
+    // returns no new case ids.
+    collusion.sanctionRing.mockResolvedValue([]);
+    const warnSpy = jest
+      .spyOn((scheduler as any).logger, 'warn')
+      .mockImplementation();
+
+    await scheduler.sweepForCollusionRings();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('0 filed, 0 enforcement case(s) opened'),
+    );
+  });
+});

--- a/src/api/src/modules/fury/collusion-detection.scheduler.ts
+++ b/src/api/src/modules/fury/collusion-detection.scheduler.ts
@@ -1,0 +1,84 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import {
+  CollusionDetectionService,
+  CollusionRing,
+} from '../../../services/security/collusion-detection.service';
+
+/**
+ * The only thing that runs the collusion engine.
+ *
+ * `CollusionDetectionService` is pairwise-correlation analysis over the whole
+ * recent review history — there is no single request that can naturally trigger
+ * it, because no one reviewer's verdict reveals a ring. Before this sweep the
+ * engine had no caller at all outside its own spec: rings were detectable in
+ * principle and detected never in practice.
+ *
+ * The sweep opens PENDING_REVIEW cases; it never applies a penalty. Confirmation
+ * (and therefore the REP_BURN / stake slash) stays with an admin via
+ * `EnforcementService.confirmCase`, which is the same posture honeypot failures
+ * already have — a correlation score is suggestive, not conclusive.
+ */
+@Injectable()
+export class CollusionDetectionScheduler {
+  private readonly logger = new Logger(CollusionDetectionScheduler.name);
+
+  /**
+   * Lookback deliberately wider than the cadence: a ring that votes once per day
+   * would slip through a 6-hour window. Re-detection of an already-filed ring is
+   * absorbed by `sanctionRing`'s per-reviewer idempotency guard.
+   */
+  private static readonly WINDOW_HOURS = 24;
+
+  /** A ring needs corroboration from more than one signal family to be filed. */
+  private static readonly MIN_SIGNALS = 2;
+
+  constructor(private readonly collusion: CollusionDetectionService) {}
+
+  @Cron('0 20 */6 * * *') // every 6 hours, offset off the hour to miss the other sweeps
+  async sweepForCollusionRings(): Promise<void> {
+    let rings: CollusionRing[];
+    try {
+      rings = await this.collusion.analyzeWindow(
+        CollusionDetectionScheduler.WINDOW_HOURS,
+        CollusionDetectionScheduler.MIN_SIGNALS,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Collusion sweep: analysis failed: ${error instanceof Error ? error.message : error}`,
+      );
+      return;
+    }
+
+    if (rings.length === 0) return;
+
+    // MONITOR rings are below the investigation threshold — recorded in the log,
+    // not filed as cases, so the admin queue stays a queue of real suspicions.
+    const actionable = rings.filter((r) => r.recommendedAction !== 'MONITOR');
+    const monitored = rings.length - actionable.length;
+
+    let casesOpened = 0;
+    let ringsFiled = 0;
+    for (const ring of actionable) {
+      try {
+        const caseIds = await this.collusion.sanctionRing(ring);
+        if (caseIds.length > 0) {
+          ringsFiled++;
+          casesOpened += caseIds.length;
+        }
+      } catch (error) {
+        // One unfilable ring must not strand the rest of the sweep.
+        this.logger.error(
+          `Collusion sweep: failed to file ring ${ring.ringId}: ${
+            error instanceof Error ? error.message : error
+          }`,
+        );
+      }
+    }
+
+    this.logger.warn(
+      `Collusion sweep: ${rings.length} ring(s) detected over ${CollusionDetectionScheduler.WINDOW_HOURS}h ` +
+        `(${monitored} below threshold), ${ringsFiled} filed, ${casesOpened} enforcement case(s) opened`,
+    );
+  }
+}

--- a/src/api/src/modules/fury/enforcement.controller.spec.ts
+++ b/src/api/src/modules/fury/enforcement.controller.spec.ts
@@ -11,6 +11,8 @@ describe('EnforcementController', () => {
     appealCase: jest.Mock;
     confirmCase: jest.Mock;
     resolveAppeal: jest.Mock;
+    listCases: jest.Mock;
+    listCollusionRings: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -19,6 +21,8 @@ describe('EnforcementController', () => {
       appealCase: jest.fn(),
       confirmCase: jest.fn(),
       resolveAppeal: jest.fn(),
+      listCases: jest.fn(),
+      listCollusionRings: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -144,6 +148,47 @@ describe('EnforcementController', () => {
         undefined,
       );
       expect(result.outcome).toBe('REVERSED');
+    });
+  });
+  describe('listCases', () => {
+    it('passes the status/caseType filters straight through', async () => {
+      enforcementService.listCases.mockResolvedValue({ cases: [] });
+
+      const result = await controller.listCases('PENDING_REVIEW', 'COLLUSION_RING', '25');
+
+      expect(enforcementService.listCases).toHaveBeenCalledWith({
+        status: 'PENDING_REVIEW',
+        caseType: 'COLLUSION_RING',
+        limit: 25,
+      });
+      expect(result).toEqual({ cases: [] });
+    });
+
+    it('hands an absent limit to the service as NaN so the service clamps it', async () => {
+      enforcementService.listCases.mockResolvedValue({ cases: [] });
+
+      await controller.listCases();
+
+      expect(enforcementService.listCases).toHaveBeenCalledWith({
+        status: undefined,
+        caseType: undefined,
+        limit: NaN,
+      });
+    });
+  });
+
+  describe('listRings', () => {
+    it('returns the grouped rings for the admin screen', async () => {
+      const rings = [{ ring_id: 'ring-1', member_count: 3 }];
+      enforcementService.listCollusionRings.mockResolvedValue({ rings });
+
+      const result = await controller.listRings('48', '10');
+
+      expect(enforcementService.listCollusionRings).toHaveBeenCalledWith({
+        sinceHours: 48,
+        limit: 10,
+      });
+      expect(result).toEqual({ rings });
     });
   });
 });

--- a/src/api/src/modules/fury/enforcement.controller.ts
+++ b/src/api/src/modules/fury/enforcement.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Param, Body, UseGuards } from '@nestjs/common';
+import { Controller, Post, Get, Param, Query, Body, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { AuthGuard } from '../../../guards/auth.guard';
 import { RoleGuard, Roles } from '../../common/guards/role.guard';
@@ -11,6 +11,27 @@ import { EnforcementService } from './enforcement.service';
 @UseGuards(AuthGuard, RoleGuard)
 export class EnforcementController {
   constructor(private readonly enforcementService: EnforcementService) {}
+
+  @Get('cases')
+  @Roles('ADMIN')
+  @ApiOperation({ summary: 'List enforcement cases with their penalty state (Admin only)' })
+  async listCases(
+    @Query('status') status?: string,
+    @Query('caseType') caseType?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.enforcementService.listCases({ status, caseType, limit: Number(limit) });
+  }
+
+  @Get('rings')
+  @Roles('ADMIN')
+  @ApiOperation({ summary: 'List detected collusion rings, grouped from their member cases (Admin only)' })
+  async listRings(@Query('sinceHours') sinceHours?: string, @Query('limit') limit?: string) {
+    return this.enforcementService.listCollusionRings({
+      sinceHours: Number(sinceHours),
+      limit: Number(limit),
+    });
+  }
 
   @Post('evaluate')
   @Roles('ADMIN')

--- a/src/api/src/modules/fury/enforcement.service.spec.ts
+++ b/src/api/src/modules/fury/enforcement.service.spec.ts
@@ -204,4 +204,140 @@ describe('EnforcementService', () => {
       ).rejects.toThrow('Appealed case not found');
     });
   });
+  describe('evaluateCollusion (auto-open from consensus)', () => {
+    it('opens a PENDING_REVIEW case and logs it for each flagged Fury', async () => {
+      mockPool.query
+        .mockResolvedValueOnce({ rows: [{ id: 'case-hp-1' }] })
+        .mockResolvedValueOnce({ rows: [{ id: 'case-hp-2' }] });
+
+      await service.evaluateCollusion('proof-9', ['fury-1', 'fury-2']);
+
+      expect(mockPool.query).toHaveBeenCalledTimes(2);
+      expect(mockPool.query.mock.calls[0][0]).toMatch(/HONEYPOT_FAILURE/);
+      expect(mockPool.query.mock.calls[0][0]).toMatch(/PENDING_REVIEW/);
+      expect(mockTruthLog.appendEvent).toHaveBeenCalledTimes(2);
+      expect(mockTruthLog.appendEvent).toHaveBeenCalledWith(
+        'FURY_ENFORCEMENT_CASE_OPENED',
+        expect.objectContaining({ caseId: 'case-hp-1', proofId: 'proof-9' }),
+      );
+    });
+
+    it('does not double-file when the consensus block re-runs on the LC5 retry path', async () => {
+      // The guarded INSERT matches zero rows because a case for this
+      // (reviewer, proof) already exists.
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+      await service.evaluateCollusion('proof-9', ['fury-1']);
+
+      const insertSql = mockPool.query.mock.calls[0][0];
+      expect(insertSql).toMatch(/WHERE NOT EXISTS/);
+      expect(insertSql).toMatch(/evidence_json->>'proofId' = \$3/);
+      expect(mockTruthLog.appendEvent).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when nothing was flagged', async () => {
+      await service.evaluateCollusion('proof-9', []);
+
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listCases (admin read API)', () => {
+    it('returns cases joined to their penalty and reviewer standing', async () => {
+      mockPool.query.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'case-1',
+            reviewer_id: 'fury-1',
+            case_type: 'COLLUSION_RING',
+            confidence: 0.9,
+            status: 'PENDING_REVIEW',
+            evidence_json: { ringId: 'ring-1' },
+            created_at: '2026-08-15T00:00:00.000Z',
+            integrity_score: 40,
+            reviewer_status: 'ACTIVE',
+            penalty_type: null,
+            amount_cents: null,
+            applied_at: null,
+          },
+        ],
+      });
+
+      const result = await service.listCases({ status: 'PENDING_REVIEW' });
+
+      expect(result.cases).toHaveLength(1);
+      expect(mockPool.query.mock.calls[0][1]).toEqual([
+        'PENDING_REVIEW',
+        null,
+        50,
+      ]);
+    });
+
+    it('never selects the reviewer email onto this list surface', async () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+      await service.listCases();
+
+      expect(mockPool.query.mock.calls[0][0]).not.toMatch(/email/);
+    });
+
+    it('clamps an absent, junk, or oversized limit', async () => {
+      mockPool.query.mockResolvedValue({ rows: [] });
+
+      await service.listCases();
+      await service.listCases({ limit: NaN });
+      await service.listCases({ limit: 100000 });
+      await service.listCases({ limit: 10 });
+
+      expect(mockPool.query.mock.calls[0][1][2]).toBe(50);
+      expect(mockPool.query.mock.calls[1][1][2]).toBe(50);
+      expect(mockPool.query.mock.calls[2][1][2]).toBe(200);
+      expect(mockPool.query.mock.calls[3][1][2]).toBe(10);
+    });
+  });
+
+  describe('listCollusionRings (admin read API)', () => {
+    it('groups member cases back into rings on evidence_json.ringId', async () => {
+      mockPool.query.mockResolvedValueOnce({
+        rows: [
+          {
+            ring_id: 'ring-1-1700000000000',
+            detected_at: '2026-08-15T00:00:00.000Z',
+            confidence: 0.91,
+            member_count: 3,
+            pending_count: 3,
+            penalized_count: 0,
+            appealed_count: 0,
+            signal_count: 4,
+            signal_types: ['COORDINATED_VOTE', 'VERDICT_SYNC'],
+            members: [
+              { caseId: 'case-1', reviewerId: 'fury-1', status: 'PENDING_REVIEW', integrityScore: 40 },
+            ],
+          },
+        ],
+      });
+
+      const result = await service.listCollusionRings({ sinceHours: 48 });
+
+      expect(result.rings).toHaveLength(1);
+      expect(result.rings[0].ring_id).toBe('ring-1-1700000000000');
+
+      const [sql, params] = mockPool.query.mock.calls[0];
+      expect(sql).toMatch(/GROUP BY c\.evidence_json->>'ringId'/);
+      expect(sql).toMatch(/c\.case_type = 'COLLUSION_RING'/);
+      expect(params).toEqual([48, 50]);
+    });
+
+    it('clamps the lookback window rather than trusting the query string', async () => {
+      mockPool.query.mockResolvedValue({ rows: [] });
+
+      await service.listCollusionRings();
+      await service.listCollusionRings({ sinceHours: NaN });
+      await service.listCollusionRings({ sinceHours: 999999 });
+
+      expect(mockPool.query.mock.calls[0][1][0]).toBe(24 * 30);
+      expect(mockPool.query.mock.calls[1][1][0]).toBe(24 * 30);
+      expect(mockPool.query.mock.calls[2][1][0]).toBe(24 * 365);
+    });
+  });
 });

--- a/src/api/src/modules/fury/enforcement.service.ts
+++ b/src/api/src/modules/fury/enforcement.service.ts
@@ -7,6 +7,63 @@ import { AUDITOR_STAKE_AMOUNT } from '../../../../shared/libs/integrity';
 /** Penalty types that move money, and therefore need a real amount and a reversible ledger leg. */
 const FINANCIAL_PENALTY_TYPES = new Set(['STAKE_SLASH']);
 
+const DEFAULT_READ_LIMIT = 50;
+const MAX_READ_LIMIT = 200;
+const DEFAULT_RING_WINDOW_HOURS = 24 * 30;
+const MAX_RING_WINDOW_HOURS = 24 * 365;
+
+export interface EnforcementCaseRow {
+  id: string;
+  reviewer_id: string;
+  case_type: string;
+  confidence: number;
+  status: string;
+  evidence_json: Record<string, unknown>;
+  created_at: string;
+  integrity_score: number | null;
+  reviewer_status: string | null;
+  penalty_type: string | null;
+  amount_cents: number | null;
+  applied_at: string | null;
+}
+
+export interface CollusionRingMember {
+  caseId: string;
+  reviewerId: string;
+  status: string;
+  integrityScore: number | null;
+}
+
+export interface CollusionRingRow {
+  ring_id: string;
+  detected_at: string;
+  confidence: number;
+  member_count: number;
+  pending_count: number;
+  penalized_count: number;
+  appealed_count: number;
+  signal_count: number | null;
+  signal_types: string[] | null;
+  members: CollusionRingMember[];
+}
+
+/**
+ * Query-string numbers arrive as strings and an unbounded LIMIT is a trivial
+ * memory-pressure lever on an authenticated endpoint, so both read paths clamp
+ * rather than trusting the caller.
+ */
+function clampLimit(raw: number | string | undefined): number {
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_READ_LIMIT;
+  return Math.min(Math.floor(parsed), MAX_READ_LIMIT);
+}
+
+function clampSinceHours(raw: number | string | undefined): number {
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_RING_WINDOW_HOURS;
+  return Math.min(Math.floor(parsed), MAX_RING_WINDOW_HOURS);
+}
+
 @Injectable()
 export class EnforcementService {
   private readonly logger = new Logger(EnforcementService.name);
@@ -27,12 +84,34 @@ export class EnforcementService {
       // Open an enforcement case for failing a honeypot. A single honeypot miss is
       // suggestive, not conclusive — the case stays PENDING_REVIEW and the penalty
       // (REP_BURN) is only applied after a reviewer confirms it via confirmCase().
+      //
+      // Idempotent per (reviewer, proof). Now that FuryWorker.checkConsensus calls
+      // this automatically, the LC5 retry path matters: a post-claim failure reverts
+      // the proof to UNDER_REVIEW and the whole consensus block re-runs, which would
+      // otherwise file a second case for the same honeypot miss. Same
+      // INSERT...SELECT...WHERE NOT EXISTS shape as applyPenalty — atomic within the
+      // statement, so a concurrent re-entry cannot duplicate either.
       const caseResult = await this.pool.query(
         `INSERT INTO fury_enforcement_cases (reviewer_id, case_type, confidence, status, evidence_json)
-         VALUES ($1, 'HONEYPOT_FAILURE', 0.5, 'PENDING_REVIEW', $2)
+         SELECT $1, 'HONEYPOT_FAILURE', 0.5, 'PENDING_REVIEW', $2::jsonb
+         WHERE NOT EXISTS (
+           SELECT 1 FROM fury_enforcement_cases
+           WHERE reviewer_id = $1
+             AND case_type = 'HONEYPOT_FAILURE'
+             AND evidence_json->>'proofId' = $3
+         )
          RETURNING id`,
-        [furyId, JSON.stringify({ proofId, reason: 'Verdict disagreed with honeypot expected result' })]
+        [
+          furyId,
+          JSON.stringify({ proofId, reason: 'Verdict disagreed with honeypot expected result' }),
+          proofId,
+        ]
       );
+
+      if (caseResult.rows.length === 0) {
+        // A case for this reviewer on this proof already exists (idempotent no-op).
+        continue;
+      }
 
       const caseId = caseResult.rows[0].id;
 
@@ -43,6 +122,95 @@ export class EnforcementService {
         caseType: 'HONEYPOT_FAILURE',
       });
     }
+  }
+
+  /**
+   * Read side of the enforcement queue — what an admin triages before calling
+   * confirmCase / resolveAppeal.
+   *
+   * `users.email` is deliberately not selected. This is a list surface over every
+   * flagged reviewer, and reviewer_id is the identifier the rest of the admin
+   * surface already keys on; integrity_score is the signal an admin actually needs
+   * next to a case. The single-user admin lookup remains the place email is read.
+   */
+  async listCases(
+    filters: { status?: string; caseType?: string; limit?: number } = {},
+  ): Promise<{ cases: EnforcementCaseRow[] }> {
+    const limit = clampLimit(filters.limit);
+
+    const result = await this.pool.query(
+      `SELECT
+         c.id,
+         c.reviewer_id,
+         c.case_type,
+         c.confidence,
+         c.status,
+         c.evidence_json,
+         c.created_at,
+         u.integrity_score,
+         u.status AS reviewer_status,
+         p.penalty_type,
+         p.amount_cents,
+         p.applied_at
+       FROM fury_enforcement_cases c
+       LEFT JOIN users u ON u.id = c.reviewer_id
+       LEFT JOIN fury_penalties p ON p.case_id = c.id
+       WHERE ($1::text IS NULL OR c.status = $1)
+         AND ($2::text IS NULL OR c.case_type = $2)
+       ORDER BY c.created_at DESC
+       LIMIT $3`,
+      [filters.status || null, filters.caseType || null, limit],
+    );
+
+    return { cases: result.rows };
+  }
+
+  /**
+   * Collusion detections grouped back into the rings that produced them.
+   *
+   * There is no rings table: `CollusionDetectionService.sanctionRing` writes one
+   * case per ring member and carries the cluster identity in evidence_json.ringId,
+   * so the ring is reconstructed by grouping on that key. signalTypes is taken from
+   * the earliest member's evidence because every member of one ring is written with
+   * the same signal summary in the same call.
+   */
+  async listCollusionRings(
+    options: { sinceHours?: number; limit?: number } = {},
+  ): Promise<{ rings: CollusionRingRow[] }> {
+    const limit = clampLimit(options.limit);
+    const sinceHours = clampSinceHours(options.sinceHours);
+
+    const result = await this.pool.query(
+      `SELECT
+         c.evidence_json->>'ringId' AS ring_id,
+         MIN(c.created_at) AS detected_at,
+         MAX(c.confidence) AS confidence,
+         COUNT(*)::int AS member_count,
+         COUNT(*) FILTER (WHERE c.status = 'PENDING_REVIEW')::int AS pending_count,
+         COUNT(*) FILTER (WHERE c.status = 'PENALTY_APPLIED')::int AS penalized_count,
+         COUNT(*) FILTER (WHERE c.status = 'APPEALED')::int AS appealed_count,
+         MAX((c.evidence_json->>'signalCount')::int) AS signal_count,
+         (jsonb_agg(c.evidence_json->'signalTypes' ORDER BY c.created_at))->0 AS signal_types,
+         jsonb_agg(
+           jsonb_build_object(
+             'caseId', c.id,
+             'reviewerId', c.reviewer_id,
+             'status', c.status,
+             'integrityScore', u.integrity_score
+           ) ORDER BY c.created_at
+         ) AS members
+       FROM fury_enforcement_cases c
+       LEFT JOIN users u ON u.id = c.reviewer_id
+       WHERE c.case_type = 'COLLUSION_RING'
+         AND c.evidence_json->>'ringId' IS NOT NULL
+         AND c.created_at >= NOW() - ($1::int * INTERVAL '1 hour')
+       GROUP BY c.evidence_json->>'ringId'
+       ORDER BY MIN(c.created_at) DESC
+       LIMIT $2`,
+      [sinceHours, limit],
+    );
+
+    return { rings: result.rows };
   }
 
   /**

--- a/src/api/src/modules/fury/fury.module.ts
+++ b/src/api/src/modules/fury/fury.module.ts
@@ -6,6 +6,7 @@ import { FuryRouterWorker } from '../../../services/fury-router/fury-router.work
 import { ConsensusEngine } from './consensus.engine';
 import { EnforcementService } from './enforcement.service';
 import { CollusionDetectionService } from '../../../services/security/collusion-detection.service';
+import { CollusionDetectionScheduler } from './collusion-detection.scheduler';
 import { LedgerService } from '../../../services/ledger/ledger.service';
 import { TruthLogService } from '../../../services/ledger/truth-log.service';
 import { R2StorageService } from '../../../services/storage/r2.service';
@@ -25,6 +26,7 @@ import { RoleGuard } from '../../common/guards/role.guard';
     ConsensusEngine, 
     EnforcementService,
     CollusionDetectionService,
+    CollusionDetectionScheduler,
     LedgerService, 
     TruthLogService, 
     R2StorageService, 

--- a/src/api/src/modules/fury/fury.worker.enforcement.spec.ts
+++ b/src/api/src/modules/fury/fury.worker.enforcement.spec.ts
@@ -1,0 +1,144 @@
+import { FuryWorker } from './fury.worker';
+import { ConsensusEngine } from './consensus.engine';
+import { ContractsService } from '../contracts/contracts.service';
+import { EnforcementService } from './enforcement.service';
+import { Pool } from 'pg';
+
+/**
+ * TKT-P1-008: before this wiring `EnforcementService.evaluateCollusion` was
+ * reachable only from `POST /fury/enforcement/evaluate` (ADMIN), so a honeypot
+ * miss opened a case only if a human noticed and typed the request. Consensus
+ * resolution is the point where the flagged set exists, so it is the point that
+ * files the case.
+ */
+describe('FuryWorker — honeypot enforcement auto-open', () => {
+  let worker: FuryWorker;
+  let mockPool: { query: jest.Mock };
+  let mockEnforcement: { evaluateCollusion: jest.Mock };
+
+  const mockConsensus = {
+    evaluate: jest.fn(),
+  } as unknown as ConsensusEngine;
+
+  const mockContractsService = {
+    resolveContract: jest.fn().mockResolvedValue(undefined),
+  } as unknown as ContractsService;
+
+  beforeEach(() => {
+    mockPool = { query: jest.fn() };
+    mockEnforcement = { evaluateCollusion: jest.fn().mockResolvedValue(undefined) };
+    worker = new FuryWorker(
+      mockPool as unknown as Pool,
+      mockConsensus,
+      mockContractsService,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      mockEnforcement as unknown as EnforcementService,
+    );
+    jest.clearAllMocks();
+  });
+
+  function primeHoneypotConsensus(
+    proofId: string,
+    flaggedFuries: string[],
+    outcome: 'VERIFIED' | 'REJECTED' = 'REJECTED',
+  ) {
+    // fury_assignments
+    mockPool.query.mockResolvedValueOnce({
+      rows: [{ fury_user_id: 'fury-1', verdict: 'PASS' }],
+    });
+    // claim resolution
+    mockPool.query.mockResolvedValueOnce({ rows: [{ id: proofId }] });
+    // proofs SELECT
+    mockPool.query.mockResolvedValueOnce({
+      rows: [{ is_honeypot: true, contract_id: 'c-1' }],
+    });
+    (mockConsensus.evaluate as jest.Mock).mockResolvedValueOnce({
+      outcome,
+      votes: [],
+      flaggedFuries,
+    });
+    // UPDATE proofs
+    mockPool.query.mockResolvedValueOnce({ rows: [] });
+    // Notification: contract user lookup
+    mockPool.query.mockResolvedValueOnce({ rows: [{ user_id: 'u-1' }] });
+  }
+
+  it('opens enforcement cases for the Furies a honeypot flagged', async () => {
+    primeHoneypotConsensus('proof-hp-flagged', ['fury-1', 'fury-2']);
+
+    await worker.checkConsensus('proof-hp-flagged');
+
+    expect(mockEnforcement.evaluateCollusion).toHaveBeenCalledWith(
+      'proof-hp-flagged',
+      ['fury-1', 'fury-2'],
+    );
+  });
+
+  it('does not open a case when the honeypot flagged nobody', async () => {
+    primeHoneypotConsensus('proof-hp-clean', [], 'VERIFIED');
+
+    await worker.checkConsensus('proof-hp-clean');
+
+    expect(mockEnforcement.evaluateCollusion).not.toHaveBeenCalled();
+  });
+
+  it('does not open a case for a real (non-honeypot) proof', async () => {
+    // fury_assignments
+    mockPool.query.mockResolvedValueOnce({
+      rows: [{ fury_user_id: 'fury-1', verdict: 'PASS' }],
+    });
+    // claim resolution
+    mockPool.query.mockResolvedValueOnce({ rows: [{ id: 'proof-real' }] });
+    // proofs SELECT — not a honeypot
+    mockPool.query.mockResolvedValueOnce({
+      rows: [{ is_honeypot: false, contract_id: 'c-1' }],
+    });
+    (mockConsensus.evaluate as jest.Mock).mockResolvedValueOnce({
+      outcome: 'VERIFIED',
+      votes: [{ furyUserId: 'fury-1', verdict: 'PASS' }],
+      flaggedFuries: ['fury-1'],
+    });
+    // UPDATE proofs, accuracy +2, demotion stats, notification lookup
+    mockPool.query.mockResolvedValue({
+      rows: [{ total_audits: '5', successful_audits: '4', false_accusations: '0' }],
+    });
+
+    await worker.checkConsensus('proof-real');
+
+    expect(mockEnforcement.evaluateCollusion).not.toHaveBeenCalled();
+  });
+
+  it('does not strand the proof in RESOLVING when case filing throws', async () => {
+    primeHoneypotConsensus('proof-hp-boom', ['fury-1']);
+    mockEnforcement.evaluateCollusion.mockRejectedValueOnce(new Error('pg down'));
+    const errorSpy = jest
+      .spyOn((worker as any).logger, 'error')
+      .mockImplementation();
+
+    await expect(worker.checkConsensus('proof-hp-boom')).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('proof-hp-boom'),
+    );
+    // The revert path sets status back to UNDER_REVIEW; a swallowed filing error
+    // must not trigger it.
+    const revertCalls = mockPool.query.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes("SET status = 'UNDER_REVIEW'"),
+    );
+    expect(revertCalls).toHaveLength(0);
+  });
+
+  it('resolves consensus normally when no EnforcementService is wired', async () => {
+    const bareWorker = new FuryWorker(
+      mockPool as unknown as Pool,
+      mockConsensus,
+      mockContractsService,
+    );
+    primeHoneypotConsensus('proof-hp-bare', ['fury-1']);
+
+    await expect(bareWorker.checkConsensus('proof-hp-bare')).resolves.toBeUndefined();
+  });
+});

--- a/src/api/src/modules/fury/fury.worker.ts
+++ b/src/api/src/modules/fury/fury.worker.ts
@@ -8,6 +8,7 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { LedgerService } from '../../../services/ledger/ledger.service';
 import { TruthLogService } from '../../../services/ledger/truth-log.service';
 import { HoneypotService } from '../../../services/intelligence/honeypot.service';
+import { EnforcementService } from './enforcement.service';
 import { shouldDemoteFury, AUDITOR_STAKE_AMOUNT } from '../../../../shared/libs/integrity';
 
 interface FuryRouteJob {
@@ -31,6 +32,7 @@ export class FuryWorker implements OnModuleInit {
     @Optional() @Inject(LedgerService) private readonly ledger?: LedgerService,
     @Optional() @Inject(TruthLogService) private readonly truthLog?: TruthLogService,
     @Optional() @Inject(HoneypotService) private readonly honeypotService?: HoneypotService,
+    @Optional() @Inject(EnforcementService) private readonly enforcement?: EnforcementService,
   ) {}
 
   onModuleInit() {
@@ -168,6 +170,22 @@ export class FuryWorker implements OnModuleInit {
           await this.honeypotService.gradeHoneypotPerformance(proofId, result.flaggedFuries);
         } catch (err) {
           this.logger.error(`Honeypot grading failed for proof ${proofId}: ${err instanceof Error ? err.message : err}`);
+        }
+      }
+
+      // Open the enforcement case for a honeypot miss here, where the flagged set is
+      // in hand. Previously evaluateCollusion was reachable only from an ADMIN POST,
+      // so a Fury could fail every honeypot injected at it and no case would ever be
+      // filed unless a human noticed and typed the request. Non-fatal by design: the
+      // integrity penalty above has already landed, and stranding the proof in
+      // RESOLVING over a case-filing failure would cost more than the missed case.
+      if (is_honeypot && this.enforcement && result.flaggedFuries.length > 0) {
+        try {
+          await this.enforcement.evaluateCollusion(proofId, result.flaggedFuries);
+        } catch (err) {
+          this.logger.error(
+            `Enforcement case filing failed for honeypot proof ${proofId}: ${err instanceof Error ? err.message : err}`,
+          );
         }
       }
 

--- a/src/web/app/admin/collusion/page.tsx
+++ b/src/web/app/admin/collusion/page.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import React, { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  Loader2,
+  AlertTriangle,
+  Network,
+  RefreshCw,
+  Gavel,
+} from "lucide-react";
+import { api } from "../../../services/api-client";
+import type {
+  CollusionRing,
+  EnforcementCase,
+} from "../../../services/api-client";
+import { useAuth } from "../../../contexts/AuthContext";
+
+const RING_WINDOW_HOURS = 24 * 30;
+
+const STATUS_COLORS: Record<string, string> = {
+  PENDING_REVIEW: "bg-yellow-900/50 text-yellow-400 border-yellow-800",
+  PENALTY_APPLIED: "bg-red-900/50 text-red-400 border-red-800",
+  APPEALED: "bg-blue-900/50 text-blue-400 border-blue-800",
+  UPHELD: "bg-red-900/50 text-red-400 border-red-800",
+  REVERSED: "bg-green-900/50 text-green-400 border-green-800",
+};
+
+function statusClass(status: string): string {
+  return (
+    STATUS_COLORS[status] || "bg-neutral-800 text-neutral-400 border-neutral-700"
+  );
+}
+
+function shortId(id: string): string {
+  return id.slice(0, 8);
+}
+
+export default function CollusionPage() {
+  const { user: authUser, isLoading: authLoading } = useAuth();
+  const [rings, setRings] = useState<CollusionRing[]>([]);
+  const [cases, setCases] = useState<EnforcementCase[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [confirming, setConfirming] = useState<string | null>(null);
+
+  const loadData = useCallback(async () => {
+    try {
+      setLoading(true);
+      const [ringsData, casesData] = await Promise.all([
+        api.getCollusionRings(RING_WINDOW_HOURS),
+        api.getEnforcementCases({ status: "PENDING_REVIEW" }),
+      ]);
+      setRings(ringsData.rings || []);
+      setCases(casesData.cases || []);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load data");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (authLoading || !authUser) return;
+    if (authUser.role !== "ADMIN") {
+      setError("Forbidden: ADMIN role required");
+      setLoading(false);
+      return;
+    }
+    loadData();
+  }, [authUser, authLoading, loadData]);
+
+  // Confirming is what actually burns reputation — the sweep only ever files a
+  // PENDING_REVIEW case, so this button is the human step the detector defers to.
+  const handleConfirm = async (caseId: string) => {
+    setConfirming(caseId);
+    try {
+      await api.confirmEnforcementCase(caseId, { penaltyType: "REP_BURN" });
+      await loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to confirm case");
+    } finally {
+      setConfirming(null);
+    }
+  };
+
+  if (authLoading || loading) {
+    return (
+      <div className="min-h-screen bg-black text-white flex items-center justify-center">
+        <Loader2 className="animate-spin mr-3" size={24} />
+        <span className="text-neutral-400 font-bold">
+          Loading collusion detections...
+        </span>
+      </div>
+    );
+  }
+
+  if (error && rings.length === 0 && cases.length === 0) {
+    return (
+      <div className="min-h-screen bg-black text-white flex items-center justify-center">
+        <div className="text-center space-y-4">
+          <AlertTriangle className="mx-auto text-red-500" size={48} />
+          <p className="text-red-400 font-bold">{error}</p>
+          <Link
+            href="/admin"
+            className="text-neutral-400 hover:text-white underline"
+          >
+            Back to Admin
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const pendingRings = rings.filter((r) => r.pending_count > 0).length;
+  const flaggedReviewers = rings.reduce((sum, r) => sum + r.member_count, 0);
+
+  return (
+    <div className="min-h-screen bg-black text-white font-sans p-6 md:p-12 max-w-6xl mx-auto">
+      <div className="flex items-center gap-4 mb-8">
+        <Link
+          href="/admin"
+          className="text-neutral-400 hover:text-white transition-colors"
+        >
+          <ArrowLeft size={24} />
+        </Link>
+        <div className="flex items-center gap-3">
+          <Network className="text-red-500" size={28} />
+          <h1 className="text-2xl font-black tracking-tight uppercase">
+            Collusion Detections
+          </h1>
+        </div>
+        <button
+          onClick={loadData}
+          className="ml-auto p-2 text-neutral-400 hover:text-white transition-colors"
+          title="Refresh"
+        >
+          <RefreshCw size={20} />
+        </button>
+      </div>
+
+      {error && (
+        <p className="mb-6 text-red-400 font-bold text-sm">{error}</p>
+      )}
+
+      <div className="grid grid-cols-3 gap-4 mb-8">
+        <div className="p-4 rounded-2xl border bg-neutral-900 border-neutral-800 text-center">
+          <p className="text-2xl font-black">{rings.length}</p>
+          <p className="text-xs uppercase tracking-widest text-neutral-500">
+            Rings (30d)
+          </p>
+        </div>
+        <div className="p-4 rounded-2xl border bg-neutral-900 border-neutral-800 text-center">
+          <p className="text-2xl font-black">{pendingRings}</p>
+          <p className="text-xs uppercase tracking-widest text-neutral-500">
+            Awaiting Review
+          </p>
+        </div>
+        <div className="p-4 rounded-2xl border bg-neutral-900 border-neutral-800 text-center">
+          <p className="text-2xl font-black">{flaggedReviewers}</p>
+          <p className="text-xs uppercase tracking-widest text-neutral-500">
+            Flagged Reviewers
+          </p>
+        </div>
+      </div>
+
+      <h2 className="text-sm font-bold uppercase tracking-widest text-neutral-500 mb-3">
+        Detected Rings
+      </h2>
+      <div className="space-y-4 mb-12">
+        {rings.map((ring) => (
+          <div
+            key={ring.ring_id}
+            className="bg-neutral-900 border border-neutral-800 rounded-2xl p-6"
+          >
+            <div className="flex items-start justify-between gap-4 flex-wrap">
+              <div>
+                <p className="font-mono text-xs text-neutral-500">
+                  {ring.ring_id}
+                </p>
+                <p className="font-bold mt-1">
+                  {ring.member_count} reviewers ·{" "}
+                  {(Number(ring.confidence) * 100).toFixed(1)}% confidence
+                </p>
+                <p className="text-xs text-neutral-500 mt-1">
+                  Detected {new Date(ring.detected_at).toLocaleString()} ·{" "}
+                  {ring.signal_count ?? 0} signals
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {(ring.signal_types || []).map((signal) => (
+                  <span
+                    key={signal}
+                    className="px-2 py-1 rounded-lg text-[10px] font-bold uppercase tracking-widest border bg-neutral-800 border-neutral-700 text-neutral-400"
+                  >
+                    {signal.replace(/_/g, " ")}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            <div className="mt-4 flex flex-wrap gap-2">
+              {(ring.members || []).map((member) => (
+                <span
+                  key={member.caseId}
+                  className={`px-3 py-1.5 rounded-lg text-xs font-bold border ${statusClass(member.status)}`}
+                  title={`Reviewer ${member.reviewerId} — case ${member.caseId}`}
+                >
+                  {shortId(member.reviewerId)} · {member.status}
+                  {member.integrityScore !== null
+                    ? ` · IS ${member.integrityScore}`
+                    : ""}
+                </span>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {rings.length === 0 && (
+        <div className="text-center py-8 text-neutral-500 mb-12">
+          No collusion rings detected in the last 30 days.
+        </div>
+      )}
+
+      <h2 className="text-sm font-bold uppercase tracking-widest text-neutral-500 mb-3">
+        Cases Awaiting Review
+      </h2>
+      <div className="bg-neutral-900 border border-neutral-800 rounded-2xl overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-neutral-800">
+                <th className="px-6 py-4 text-left text-xs font-bold uppercase tracking-widest text-neutral-500">
+                  Reviewer
+                </th>
+                <th className="px-6 py-4 text-left text-xs font-bold uppercase tracking-widest text-neutral-500">
+                  Type
+                </th>
+                <th className="px-6 py-4 text-left text-xs font-bold uppercase tracking-widest text-neutral-500">
+                  Confidence
+                </th>
+                <th className="px-6 py-4 text-left text-xs font-bold uppercase tracking-widest text-neutral-500">
+                  Integrity
+                </th>
+                <th className="px-6 py-4 text-left text-xs font-bold uppercase tracking-widest text-neutral-500">
+                  Opened
+                </th>
+                <th className="px-6 py-4 text-left text-xs font-bold uppercase tracking-widest text-neutral-500">
+                  Action
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {cases.map((enforcementCase) => (
+                <tr
+                  key={enforcementCase.id}
+                  className="border-b border-neutral-800/50 hover:bg-neutral-800/30 transition-colors"
+                >
+                  <td className="px-6 py-4 text-sm font-mono text-neutral-400">
+                    {shortId(enforcementCase.reviewer_id)}
+                  </td>
+                  <td className="px-6 py-4 text-sm font-bold">
+                    {enforcementCase.case_type}
+                  </td>
+                  <td className="px-6 py-4 text-sm text-neutral-400">
+                    {(Number(enforcementCase.confidence) * 100).toFixed(1)}%
+                  </td>
+                  <td className="px-6 py-4 text-sm text-neutral-400">
+                    {enforcementCase.integrity_score ?? "—"}
+                  </td>
+                  <td className="px-6 py-4 text-xs text-neutral-500">
+                    {new Date(enforcementCase.created_at).toLocaleDateString()}
+                  </td>
+                  <td className="px-6 py-4">
+                    <button
+                      onClick={() => handleConfirm(enforcementCase.id)}
+                      disabled={confirming === enforcementCase.id}
+                      className="px-4 py-2 rounded-xl text-xs font-bold bg-red-800 hover:bg-red-700 disabled:opacity-50 transition-colors inline-flex items-center gap-2"
+                    >
+                      {confirming === enforcementCase.id ? (
+                        <Loader2 className="animate-spin" size={14} />
+                      ) : (
+                        <Gavel size={14} />
+                      )}
+                      Confirm REP_BURN
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {cases.length === 0 && (
+        <div className="text-center py-12 text-neutral-500">
+          No enforcement cases awaiting review.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/web/lib/guided-tour/registry.ts
+++ b/src/web/lib/guided-tour/registry.ts
@@ -544,6 +544,16 @@ export const TOUR_ROUTES: TourRoute[] = [
     detail: "Not a customer-facing surface. Shown so the operational cost of running the product is visible rather than assumed.",
   },
   {
+    path: "/admin/collusion",
+    title: "Detected collusion rings",
+    chapter: "The employer",
+    persona: "hr",
+    label: "future",
+    summary: "Where an operator reviews reviewers who appear to be voting together, and acts on it.",
+    detail:
+      "The ring-detection engine analysed nothing for months — it was written, tested, registered, and called by no scheduler. It now runs on a cadence and opens enforcement cases automatically; this screen is where a human confirms or overturns what it found.",
+  },
+  {
     path: "/admin/cac-ltv",
     title: "Acquisition cost and lifetime value",
     chapter: "The employer",

--- a/src/web/services/api-client.test.ts
+++ b/src/web/services/api-client.test.ts
@@ -407,4 +407,47 @@ describe('Web API client', () => {
       expect(JSON.parse(opts.body)).toEqual({ slideContent: 'Slide 1: TAM is $5B' });
     });
   });
+  describe('collusion / enforcement admin reads', () => {
+    it('sends the ring lookback window as a query parameter', async () => {
+      mockFetch.mockResolvedValueOnce(jsonOk({ rings: [] }));
+
+      await api.getCollusionRings(720);
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('/fury/enforcement/rings?sinceHours=720');
+    });
+
+    it('omits the query string entirely when no ring filters are given', async () => {
+      mockFetch.mockResolvedValueOnce(jsonOk({ rings: [] }));
+
+      await api.getCollusionRings();
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('/fury/enforcement/rings');
+      expect(url).not.toContain('?');
+    });
+
+    it('sends the case filters the admin screen uses', async () => {
+      mockFetch.mockResolvedValueOnce(jsonOk({ cases: [] }));
+
+      await api.getEnforcementCases({ status: 'PENDING_REVIEW', caseType: 'COLLUSION_RING' });
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('status=PENDING_REVIEW');
+      expect(url).toContain('caseType=COLLUSION_RING');
+    });
+
+    it('POSTs a confirmation with the penalty type', async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonOk({ success: true, caseId: 'case-1', status: 'PENALTY_APPLIED' }),
+      );
+
+      await api.confirmEnforcementCase('case-1', { penaltyType: 'REP_BURN' });
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toContain('/fury/enforcement/confirm/case-1');
+      expect(opts.method).toBe('POST');
+      expect(JSON.parse(opts.body)).toEqual({ penaltyType: 'REP_BURN' });
+    });
+  });
 });

--- a/src/web/services/api-client.ts
+++ b/src/web/services/api-client.ts
@@ -410,6 +410,46 @@ export interface DashboardProgress {
   };
 }
 
+export interface EnforcementCase {
+  id: string;
+  reviewer_id: string;
+  case_type: string;
+  confidence: number;
+  status: string;
+  evidence_json: Record<string, unknown>;
+  created_at: string;
+  integrity_score: number | null;
+  reviewer_status: string | null;
+  penalty_type: string | null;
+  amount_cents: number | null;
+  applied_at: string | null;
+}
+
+export interface CollusionRingMember {
+  caseId: string;
+  reviewerId: string;
+  status: string;
+  integrityScore: number | null;
+}
+
+/**
+ * A ring is reconstructed server-side by grouping member cases on
+ * evidence_json.ringId — there is no rings table, so `ring_id` is the detection
+ * run's identifier and not a stable primary key across sweeps.
+ */
+export interface CollusionRing {
+  ring_id: string;
+  detected_at: string;
+  confidence: number;
+  member_count: number;
+  pending_count: number;
+  penalized_count: number;
+  appealed_count: number;
+  signal_count: number | null;
+  signal_types: string[] | null;
+  members: CollusionRingMember[];
+}
+
 export const api = {
   health: () => request<{ status: string }>("/health"),
   getMobileBootstrap: () =>
@@ -819,6 +859,43 @@ export const api = {
       method: "PATCH",
       body: JSON.stringify(data),
     }),
+
+  getCollusionRings: (sinceHours?: number, limit?: number) => {
+    const params = new URLSearchParams();
+    if (sinceHours) params.set("sinceHours", String(sinceHours));
+    if (limit) params.set("limit", String(limit));
+    const qs = params.toString();
+    return request<{ rings: CollusionRing[] }>(
+      `/fury/enforcement/rings${qs ? `?${qs}` : ""}`,
+    );
+  },
+
+  getEnforcementCases: (opts?: {
+    status?: string;
+    caseType?: string;
+    limit?: number;
+  }) => {
+    const params = new URLSearchParams();
+    if (opts?.status) params.set("status", opts.status);
+    if (opts?.caseType) params.set("caseType", opts.caseType);
+    if (opts?.limit) params.set("limit", String(opts.limit));
+    const qs = params.toString();
+    return request<{ cases: EnforcementCase[] }>(
+      `/fury/enforcement/cases${qs ? `?${qs}` : ""}`,
+    );
+  },
+
+  confirmEnforcementCase: (
+    caseId: string,
+    data?: { penaltyType?: string; amountCents?: number },
+  ) =>
+    request<{ success: boolean; caseId: string; status: string }>(
+      `/fury/enforcement/confirm/${caseId}`,
+      {
+        method: "POST",
+        body: JSON.stringify(data ?? {}),
+      },
+    ),
 
   getKillSwitch: () =>
     request<{ refundOnlyMode: boolean }>("/admin/kill-switch"),


### PR DESCRIPTION
## The defect

`CollusionDetectionService` is a complete ring-detection engine — four signal families, union-find clustering, confidence scoring, case filing — and it had **zero callers outside its own spec**. `analyzeWindow` and `sanctionRing` were registered in `fury.module.ts` and fully specced, and nothing in the running system ever invoked either. The whole engine was dead.

Separately, `EnforcementService.evaluateCollusion` was reachable **only** from `POST /fury/enforcement/evaluate` (ADMIN). No honeypot failure, no collusion signal, no scheduler ever called it — so a Fury could fail every honeypot injected at it and no enforcement case would open unless a human noticed and typed the request.

## What is wired

All four layers, and each has a caller (`grep` proof at the bottom).

**1. Scheduler.** `CollusionDetectionScheduler` (`@Cron('0 20 */6 * * *')`) runs `analyzeWindow(24, 2)` and files rings whose `recommendedAction` is `SANCTION` or `INVESTIGATE`. `MONITOR` rings are logged, not filed, so the admin queue stays a queue of real suspicions. It only ever opens `PENDING_REVIEW` cases — confirmation, and therefore the REP_BURN, stays with an admin. That is the same posture honeypot failures already had, and it is deliberate: a correlation score is suggestive, not conclusive.

Registered in `fury.module.ts` providers. `ScheduleModule.forRoot()` is already global (loaded by contracts/admin/users), and `FuryModule` is in `app.module.ts` — same shape as `VideoProcessingScheduler` in `ProofsModule`, which also registers a `@Cron` without importing `ScheduleModule`.

**2. Auto-open on honeypot failure.** `FuryWorker.checkConsensus` now calls `evaluateCollusion(proofId, result.flaggedFuries)` right after honeypot grading — the one point in the system where the flagged set exists. That method is reached live from `fury.controller.ts:238` on verdict submission. `EnforcementService` is injected `@Optional()` (trailing param, so no existing spec constructor breaks) and the call is wrapped: the integrity penalty has already landed by then, and stranding a proof in `RESOLVING` over a case-filing failure costs more than the missed case. A spec asserts the revert path is *not* taken when filing throws.

**3. Read API.** `GET /fury/enforcement/cases` and `GET /fury/enforcement/rings`, both ADMIN, on the existing `EnforcementController`.

> **On persistence — the ticket asked me to check.** Detections *are* persisted. `sanctionRing` writes one `fury_enforcement_cases` row per ring member and carries the cluster identity in `evidence_json.ringId`, so no new table was needed. There is no rings table, though: the rings endpoint reconstructs a ring by `GROUP BY evidence_json->>'ringId'`. One consequence worth knowing — `ring_id` identifies a *detection run*, not a stable entity across sweeps; it is minted `ring-N-${Date.now()}` each time. `MONITOR` rings are never persisted at all, since they are never filed.

`users.email` is deliberately not selected onto either list surface (a spec pins this). `reviewer_id` is what the rest of the admin surface keys on, and `integrity_score` is the signal an admin actually needs next to a case. Both endpoints clamp `limit` and `sinceHours` rather than trusting the query string.

**4. Admin screen.** `src/web/app/admin/collusion/page.tsx` — ring cards (members, confidence, signal families, per-member case status) over the pending-case table, with the confirm action that applies the penalty. Follows the `app/admin/jurisdictions` page pattern: same auth gate, same dark table shell, same refresh affordance.

## Two idempotency defects the wiring exposes

Both fixed at the source, both using the `INSERT...SELECT...WHERE NOT EXISTS` shape `applyPenalty` already uses in this file (atomic within the single statement).

- **`sanctionRing`.** The 24h lookback is deliberately wider than the 6h cadence, so an unreviewed ring is re-detected on every sweep — and `ringId` is minted fresh each run, so it cannot itself be the dedupe key. Unguarded, one ring accrues a new case per member per sweep and buries the queue. Now guarded on `(reviewer_id, 'COLLUSION_RING', 'PENDING_REVIEW')`.
- **`evaluateCollusion`.** The LC5 retry path reverts a proof to `UNDER_REVIEW` and re-runs the whole consensus block. Now that consensus calls this automatically, that would file a second case for the same honeypot miss. Now guarded on `(reviewer_id, 'HONEYPOT_FAILURE', evidence_json->>'proofId')`.

Migration `070` indexes both new access paths — the per-sweep reviewer probe and the admin list — because enforcement cases only ever accumulate; nothing deletes them. (`schema.sql` is intentionally untouched: it does not carry `068`'s column either, so it is not kept in lockstep with every migration.)

## Verification

```
src/api  npx jest src/modules/fury services/security/collusion-detection.service.spec.ts
         → 12 suites, 100 tests passed
src/api  npx jest database/migrations/migrate.spec.ts
         → 1 suite, 30 tests passed
src/web  npx jest services/api-client.test.ts app/admin
         → 2 suites, 31 tests passed
src/web  npx tsc --noEmit  → clean (exit 0)
```

`src/api npx tsc --noEmit` reports exactly one error, and it is **not** from this branch:

```
../shared/libs/waitlist-attribution.spec.ts(1,38): error TS2307:
  Cannot find module '@jest/globals'
```

That file is untouched here, landed on `main` in `904bda0`, and the failure is a local module-resolution artifact (`@jest/globals` is installed under `src/api/node_modules`, and `src/shared/**` does not resolve into it). No other type error appears.

### What the tests do NOT prove

**Every spec in this repo mocks the pg Pool, and these are no exception — none of the new SQL is executed against a real Postgres.** The specs assert query *shape* and parameter binding, not that the statements run. Unverified against a live database:

- the two guarded `INSERT...SELECT...WHERE NOT EXISTS` statements;
- the `listCases` `LEFT JOIN users` + `LEFT JOIN fury_penalties` query;
- the `listCollusionRings` grouping — `jsonb_agg(... ORDER BY ...)`, `(jsonb_agg(evidence_json->'signalTypes'))->0`, `COUNT(*) FILTER`, and `NOW() - ($1::int * INTERVAL '1 hour')`;
- migration `070` itself.

The ring-grouping query is the one I would review hardest.

## Wiring proof

```
$ grep -rn "analyzeWindow|sanctionRing|evaluateCollusion|CollusionDetectionScheduler|getCollusionRings" src/ --exclude=*.spec.* --exclude=*.test.*

api/src/modules/fury/collusion-detection.scheduler.ts:42   → analyzeWindow
api/src/modules/fury/collusion-detection.scheduler.ts:64   → sanctionRing
api/src/modules/fury/fury.module.ts:29                     → CollusionDetectionScheduler registered
api/src/modules/fury/fury.worker.ts:184                    → evaluateCollusion  (live from fury.controller.ts:238)
api/src/modules/fury/enforcement.controller.ts:30          → listCollusionRings
web/app/admin/collusion/page.tsx:52                        → api.getCollusionRings
```

Closes TKT-P1-008.

## Summary by Sourcery

Wire the collusion detection and enforcement flow end-to-end, including scheduled detection, automatic honeypot case opening, admin read APIs, and an admin UI for triaging and confirming penalties.

New Features:
- Introduce a scheduled collusion detection sweep that analyzes recent reviews and opens enforcement cases for actionable rings.
- Automatically open honeypot enforcement cases during consensus resolution when furies are flagged.
- Expose admin read APIs to list enforcement cases and reconstructed collusion rings with pagination and clamped filters.
- Add an admin collusion page that surfaces detected rings and pending enforcement cases with a confirm action to apply penalties.

Bug Fixes:
- Make collusion ring case creation idempotent per reviewer to prevent duplicate cases across sweeps.
- Make honeypot failure case creation idempotent per reviewer and proof to avoid duplicate enforcement cases on consensus retries.

Enhancements:
- Add server-side models and queries to join enforcement cases with reviewer integrity state and penalty status.
- Clamp admin case and ring listing limits and lookback windows to guard against unbounded queries and memory pressure.
- Improve logging around collusion sweeps and honeypot enforcement failures to avoid crashing schedulers and to keep proofs from being stranded.
- Extend the Fury worker to inject EnforcementService and tolerate case-filing failures without reverting consensus.
- Add tests covering collusion scheduler behavior, enforcement auto-open wiring, ring idempotency, and admin read APIs.

Tests:
- Add unit tests for the collusion detection scheduler’s filing behavior, error handling, and idempotent reporting of re-detected rings.
- Add Fury worker tests to verify honeypot enforcement auto-open behavior and robustness when EnforcementService is absent or fails.
- Add tests for enforcement admin read APIs and web API client methods for listing cases and rings and confirming enforcement cases.

Chores:
- Add indexes over enforcement-case reviewer/type/status and status/type/created_at access paths to support new scheduler and admin queries.