### PR TITLE
fix(b2b): give CrmService an HTTP surface and wire the enterprise SSO deep link

### DIFF
--- a/docs/api/api--spec.md
+++ b/docs/api/api--spec.md
@@ -461,6 +461,35 @@ curl -sS "$STYX_API_URL/b2b/datalake/ent_123?start=2026-01-01&end=2026-04-01" \
 The response includes `contractMetrics`, `behavioralTrends`, and
 `cohortAnalysis`. Small groups are suppressed to reduce re-identification risk.
 
+### CRM Handoff
+
+```bash
+curl -sS "$STYX_API_URL/b2b/crm/integrity/ent_123" \
+  -H "Authorization: Bearer $TOKEN"
+
+curl -sS -X POST "$STYX_API_URL/b2b/crm/events/ent_123" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "employeeId": "emp_456",
+    "eventType": "contract_completed",
+    "metadata": { "integrityDelta": 5 }
+  }'
+```
+
+`GET /b2b/crm/integrity/:enterpriseId` returns `averageIntegrity`,
+`activeContracts`, and `behavioralVelocity` aggregated over the enterprise's
+active users — never per-employee health data.
+
+`eventType` (and `type` on `/b2b/crm/interactions/:enterpriseId`) must be one of
+`contract_created`, `contract_completed`, `contract_failed`, `integrity_change`;
+anything else is rejected with `400` rather than forwarded to the customer's CRM.
+Event timestamps are stamped server-side. On `/b2b/crm/sync/:enterpriseId` the CRM
+tenant is taken from the verified path parameter, not from the request body.
+
+When no CRM connector is configured (`SALESFORCE_BASE_URL` / `HUBSPOT_API_KEY`
+unset) these routes succeed and log only — they never fail the caller.
+
 ### Register And Test Enterprise Webhooks
 
 ```bash
@@ -666,6 +695,10 @@ Auth requirements use these labels:
 | `POST` | `/b2b/webhook/test` | Enterprise Admin | Send signed test webhook event. |
 | `GET` | `/b2b/export/hr/:enterpriseId` | Enterprise Admin | Pseudonymized HR export with small-cohort suppression. |
 | `GET` | `/b2b/datalake/:enterpriseId` | Enterprise Admin | Time-bounded analytics snapshot. Query: `start`, `end`. |
+| `GET` | `/b2b/crm/integrity/:enterpriseId` | Enterprise Admin | Aggregate corporate integrity score. |
+| `POST` | `/b2b/crm/events/:enterpriseId` | Enterprise Admin | Push an employee behavioral event to the configured CRM connectors. |
+| `POST` | `/b2b/crm/interactions/:enterpriseId` | Enterprise Admin | Log a CRM interaction against an employee email. |
+| `POST` | `/b2b/crm/sync/:enterpriseId` | Enterprise Admin | Sync an enterprise employee into the configured CRM. |
 
 ### Notifications And Public Feed
 

--- a/docs/enterprise/revenue-packaging.md
+++ b/docs/enterprise/revenue-packaging.md
@@ -113,7 +113,10 @@ build-vs-sell gap in the ladder.
    (`GET /b2b/export/hr/:enterpriseId`), data-lake export. Anonymization before export:
    `src/api/src/modules/b2b/anonymize.service.ts`.
 5. **CRM handoff** — `src/api/src/modules/b2b/crm.service.ts` with Salesforce/HubSpot
-   connectors (`src/api/src/modules/b2b/connectors/`).
+   connectors (`src/api/src/modules/b2b/connectors/`), reachable over the same
+   enterprise-scoped surface: `GET /b2b/crm/integrity/:enterpriseId`,
+   `POST /b2b/crm/events/:enterpriseId`, `POST /b2b/crm/interactions/:enterpriseId`,
+   `POST /b2b/crm/sync/:enterpriseId`.
 
 **What enterprise buys, control-wise:** the compliance packaging in
 `docs/enterprise/compliance-packaging.md` (audit log, access controls, geofence,

--- a/src/api/src/modules/b2b/b2b.controller.spec.ts
+++ b/src/api/src/modules/b2b/b2b.controller.spec.ts
@@ -5,6 +5,7 @@ import { WebhookService } from './webhook.service';
 import { MetricsService } from './metrics.service';
 import { AnonymizeService } from './anonymize.service';
 import { DataLakeService } from './datalake.service';
+import { CrmService } from './crm.service';
 
 describe('B2BController', () => {
   let controller: B2BController;
@@ -51,8 +52,27 @@ describe('B2BController', () => {
     }),
   } as unknown as DataLakeService;
 
+  const mockCrm = {
+    calculateCorporateIntegrityScore: jest.fn().mockResolvedValue({
+      averageIntegrity: 70,
+      activeContracts: 2,
+      behavioralVelocity: 2,
+    }),
+    pushEmployeeEvent: jest.fn().mockResolvedValue(undefined),
+    logInteraction: jest.fn().mockResolvedValue(undefined),
+    syncUser: jest.fn().mockResolvedValue(undefined),
+  } as unknown as CrmService;
+
   beforeEach(() => {
-    controller = new B2BController(mockPool, mockBilling, mockWebhook, mockMetrics, mockAnonymize, mockDataLake);
+    controller = new B2BController(
+      mockPool,
+      mockBilling,
+      mockWebhook,
+      mockMetrics,
+      mockAnonymize,
+      mockDataLake,
+      mockCrm,
+    );
     jest.clearAllMocks();
     (mockPool.query as jest.Mock).mockResolvedValue({
       rows: [{ enterprise_id: 'ent-001', role: 'ADMIN' }],
@@ -172,6 +192,151 @@ describe('B2BController', () => {
 
       expect(result.enterpriseId).toBe('ent-001');
       expect(mockDataLake.extractSnapshot).toHaveBeenCalledWith('ent-001', '2026-01-01', '2026-02-01');
+    });
+  });
+
+  describe('getCorporateIntegrityScore', () => {
+    it('should return the aggregate integrity score for the enterprise', async () => {
+      const result = await controller.getCorporateIntegrityScore(adminUser, 'ent-001');
+
+      expect(result).toEqual({ averageIntegrity: 70, activeContracts: 2, behavioralVelocity: 2 });
+      expect(mockCrm.calculateCorporateIntegrityScore).toHaveBeenCalledWith('ent-001');
+    });
+
+    it('should reject when caller is not a member/admin of the enterprise', async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({
+        rows: [{ enterprise_id: 'other-ent', role: 'ADMIN' }],
+      });
+
+      await expect(controller.getCorporateIntegrityScore(adminUser, 'ent-001')).rejects.toThrow();
+      expect(mockCrm.calculateCorporateIntegrityScore).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pushCrmEvent', () => {
+    it('should dispatch the event with a server-stamped timestamp', async () => {
+      const result = await controller.pushCrmEvent(adminUser, 'ent-001', {
+        employeeId: 'emp-1',
+        eventType: 'contract_completed',
+        metadata: { integrityDelta: 5 },
+      });
+
+      expect(result).toEqual({
+        status: 'dispatched',
+        enterpriseId: 'ent-001',
+        employeeId: 'emp-1',
+        eventType: 'contract_completed',
+      });
+      expect(mockCrm.pushEmployeeEvent).toHaveBeenCalledWith('ent-001', {
+        employeeId: 'emp-1',
+        eventType: 'contract_completed',
+        timestamp: expect.any(Date),
+        metadata: { integrityDelta: 5 },
+      });
+    });
+
+    it('should reject an eventType outside the connector union', async () => {
+      await expect(
+        controller.pushCrmEvent(adminUser, 'ent-001', {
+          employeeId: 'emp-1',
+          eventType: 'employee_terminated',
+        }),
+      ).rejects.toThrow(/eventType must be one of/);
+      expect(mockCrm.pushEmployeeEvent).not.toHaveBeenCalled();
+    });
+
+    it('should reject a missing employeeId', async () => {
+      await expect(
+        controller.pushCrmEvent(adminUser, 'ent-001', {
+          employeeId: '',
+          eventType: 'contract_created',
+        }),
+      ).rejects.toThrow(/employeeId is required/);
+      expect(mockCrm.pushEmployeeEvent).not.toHaveBeenCalled();
+    });
+
+    it('should reject before dispatching when the caller fails the tenant check', async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({
+        rows: [{ enterprise_id: 'other-ent', role: 'ADMIN' }],
+      });
+
+      await expect(
+        controller.pushCrmEvent(adminUser, 'ent-001', {
+          employeeId: 'emp-1',
+          eventType: 'contract_created',
+        }),
+      ).rejects.toThrow();
+      expect(mockCrm.pushEmployeeEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('logCrmInteraction', () => {
+    it('should log the interaction against the employee email', async () => {
+      const result = await controller.logCrmInteraction(adminUser, 'ent-001', {
+        email: 'employee@example.com',
+        type: 'integrity_change',
+        metadata: { delta: -3 },
+      });
+
+      expect(result).toEqual({
+        status: 'logged',
+        enterpriseId: 'ent-001',
+        email: 'employee@example.com',
+        type: 'integrity_change',
+      });
+      expect(mockCrm.logInteraction).toHaveBeenCalledWith('employee@example.com', 'integrity_change', {
+        delta: -3,
+      });
+    });
+
+    it('should reject a type outside the connector union', async () => {
+      await expect(
+        controller.logCrmInteraction(adminUser, 'ent-001', {
+          email: 'employee@example.com',
+          type: 'demo_booked',
+        }),
+      ).rejects.toThrow(/type must be one of/);
+      expect(mockCrm.logInteraction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('syncCrmUser', () => {
+    it('should pin the CRM tenant to the verified enterprise, not the body', async () => {
+      const result = await controller.syncCrmUser(adminUser, 'ent-001', {
+        email: 'employee@example.com',
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+      });
+
+      expect(result).toEqual({
+        status: 'synced',
+        enterpriseId: 'ent-001',
+        email: 'employee@example.com',
+      });
+      expect(mockCrm.syncUser).toHaveBeenCalledWith({
+        email: 'employee@example.com',
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+        company: 'ent-001',
+      });
+    });
+
+    it('should reject a missing email', async () => {
+      await expect(
+        controller.syncCrmUser(adminUser, 'ent-001', { email: '' }),
+      ).rejects.toThrow(/email is required/);
+      expect(mockCrm.syncUser).not.toHaveBeenCalled();
+    });
+
+    it('should reject when caller is not a member/admin of the enterprise', async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({
+        rows: [{ enterprise_id: 'other-ent', role: 'ADMIN' }],
+      });
+
+      await expect(
+        controller.syncCrmUser(adminUser, 'ent-001', { email: 'employee@example.com' }),
+      ).rejects.toThrow();
+      expect(mockCrm.syncUser).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/api/src/modules/b2b/b2b.controller.ts
+++ b/src/api/src/modules/b2b/b2b.controller.ts
@@ -1,4 +1,14 @@
-import { Controller, Get, Post, Param, Body, Query, UseGuards, ForbiddenException } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Body,
+  Query,
+  UseGuards,
+  BadRequestException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { Pool } from 'pg';
 import { AuthGuard } from '../../../guards/auth.guard';
@@ -9,6 +19,8 @@ import { WebhookService } from './webhook.service';
 import { MetricsService } from './metrics.service';
 import { AnonymizeService } from './anonymize.service';
 import { DataLakeService } from './datalake.service';
+import { CrmService } from './crm.service';
+import { EMPLOYEE_EVENT_TYPES, EmployeeEventType } from './connectors/crm-connector.interface';
 
 @ApiTags('B2B')
 @ApiBearerAuth()
@@ -23,6 +35,7 @@ export class B2BController {
     private readonly metrics: MetricsService,
     private readonly anonymize: AnonymizeService,
     private readonly dataLake: DataLakeService,
+    private readonly crm: CrmService,
   ) {}
 
   /**
@@ -56,6 +69,20 @@ export class B2BController {
     if (String(role || '').toUpperCase() !== 'ADMIN') {
       throw new ForbiddenException('Enterprise admin role required');
     }
+  }
+
+  /**
+   * eventType arrives as free-text JSON. Anything accepted here is forwarded to a
+   * customer's live Salesforce/HubSpot org, so it is checked against the connector
+   * union at the edge rather than cast into it.
+   */
+  private assertEmployeeEventType(value: string, field: string): EmployeeEventType {
+    if (!(EMPLOYEE_EVENT_TYPES as readonly string[]).includes(value)) {
+      throw new BadRequestException(
+        `${field} must be one of: ${EMPLOYEE_EVENT_TYPES.join(', ')}`,
+      );
+    }
+    return value as EmployeeEventType;
   }
 
   @Get('metrics/:enterpriseId')
@@ -138,5 +165,82 @@ export class B2BController {
   ) {
     await this.assertEnterpriseMembership(user.id, enterpriseId);
     return this.dataLake.extractSnapshot(enterpriseId, start, end);
+  }
+
+  @Get('crm/integrity/:enterpriseId')
+  @ApiOperation({ summary: 'Get the aggregate corporate integrity score for an enterprise' })
+  async getCorporateIntegrityScore(
+    @CurrentUser() user: { id: string },
+    @Param('enterpriseId') enterpriseId: string,
+  ) {
+    await this.assertEnterpriseMembership(user.id, enterpriseId);
+    return this.crm.calculateCorporateIntegrityScore(enterpriseId);
+  }
+
+  @Post('crm/events/:enterpriseId')
+  @ApiOperation({ summary: 'Push an employee behavioral event to the configured CRM connectors' })
+  async pushCrmEvent(
+    @CurrentUser() user: { id: string },
+    @Param('enterpriseId') enterpriseId: string,
+    @Body() body: { employeeId: string; eventType: string; metadata?: Record<string, unknown> },
+  ) {
+    await this.assertEnterpriseMembership(user.id, enterpriseId);
+    const eventType = this.assertEmployeeEventType(body.eventType, 'eventType');
+    if (!body.employeeId) {
+      throw new BadRequestException('employeeId is required');
+    }
+
+    // The timestamp is stamped server-side: a client-supplied one would let an
+    // enterprise admin backdate behavioral events in their own CRM record.
+    await this.crm.pushEmployeeEvent(enterpriseId, {
+      employeeId: body.employeeId,
+      eventType,
+      timestamp: new Date(),
+      metadata: body.metadata ?? {},
+    });
+
+    return { status: 'dispatched', enterpriseId, employeeId: body.employeeId, eventType };
+  }
+
+  @Post('crm/interactions/:enterpriseId')
+  @ApiOperation({ summary: 'Log a CRM interaction against an enterprise employee' })
+  async logCrmInteraction(
+    @CurrentUser() user: { id: string },
+    @Param('enterpriseId') enterpriseId: string,
+    @Body() body: { email: string; type: string; metadata?: Record<string, unknown> },
+  ) {
+    await this.assertEnterpriseMembership(user.id, enterpriseId);
+    const type = this.assertEmployeeEventType(body.type, 'type');
+    if (!body.email) {
+      throw new BadRequestException('email is required');
+    }
+
+    await this.crm.logInteraction(body.email, type, body.metadata ?? {});
+    return { status: 'logged', enterpriseId, email: body.email, type };
+  }
+
+  @Post('crm/sync/:enterpriseId')
+  @ApiOperation({ summary: 'Sync an enterprise employee into the configured CRM' })
+  async syncCrmUser(
+    @CurrentUser() user: { id: string },
+    @Param('enterpriseId') enterpriseId: string,
+    @Body() body: { email: string; firstName?: string; lastName?: string },
+  ) {
+    await this.assertEnterpriseMembership(user.id, enterpriseId);
+    if (!body.email) {
+      throw new BadRequestException('email is required');
+    }
+
+    // CrmService resolves the CRM tenant from `company`, so it is pinned to the
+    // enterprise the caller was just verified against — never taken from the body,
+    // which would let a verified admin of one tenant pull another tenant's roster.
+    await this.crm.syncUser({
+      email: body.email,
+      firstName: body.firstName,
+      lastName: body.lastName,
+      company: enterpriseId,
+    });
+
+    return { status: 'synced', enterpriseId, email: body.email };
   }
 }

--- a/src/api/src/modules/b2b/connectors/crm-connector.interface.ts
+++ b/src/api/src/modules/b2b/connectors/crm-connector.interface.ts
@@ -6,9 +6,24 @@
  * enterprise offering.
  */
 
+/**
+ * The event types an external CRM is willing to receive. Exported as a runtime
+ * array (not just a union) because the values arrive over HTTP, where the type
+ * system cannot help: a controller must be able to reject an unknown eventType
+ * before it is pushed to a customer's Salesforce/HubSpot org.
+ */
+export const EMPLOYEE_EVENT_TYPES = [
+  'contract_created',
+  'contract_completed',
+  'contract_failed',
+  'integrity_change',
+] as const;
+
+export type EmployeeEventType = (typeof EMPLOYEE_EVENT_TYPES)[number];
+
 export interface EmployeeEvent {
   employeeId: string;
-  eventType: 'contract_created' | 'contract_completed' | 'contract_failed' | 'integrity_change';
+  eventType: EmployeeEventType;
   timestamp: Date;
   metadata: Record<string, unknown>;
 }

--- a/src/api/src/modules/b2b/crm.service.ts
+++ b/src/api/src/modules/b2b/crm.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Pool } from 'pg';
 import { SalesforceConnector } from './connectors/salesforce.connector';
 import { HubSpotConnector } from './connectors/hubspot.connector';
-import { CrmConnector, EmployeeEvent } from './connectors/crm-connector.interface';
+import { CrmConnector, EmployeeEvent, EmployeeEventType } from './connectors/crm-connector.interface';
 
 export interface CrmUser {
   email: string;
@@ -68,7 +68,13 @@ export class CrmService {
     this.logger.log(`[CRM_SYNC] Synced ${users.length} users for enterprise ${enterpriseId}`);
   }
 
-  async logInteraction(email: string, type: string, metadata: Record<string, any>): Promise<void> {
+  /**
+   * `type` is the connector event union rather than a free-text string: this used to
+   * cast an arbitrary string through `as`, which meant a caller could put any label
+   * on the wire to a customer's CRM. Narrowing it here pushes the rejection to the
+   * edge (the controller validates the HTTP body against EMPLOYEE_EVENT_TYPES).
+   */
+  async logInteraction(email: string, type: EmployeeEventType, metadata: Record<string, any>): Promise<void> {
     this.logger.log(`[CRM_INTERACTION] ${email} - ${type}: ${JSON.stringify(metadata)}`);
 
     if (!this.connector) {
@@ -77,7 +83,7 @@ export class CrmService {
 
     const event: EmployeeEvent = {
       employeeId: email,
-      eventType: type as EmployeeEvent['eventType'],
+      eventType: type,
       timestamp: new Date(),
       metadata,
     };

--- a/src/mobile/App.enterprise-sso.spec.tsx
+++ b/src/mobile/App.enterprise-sso.spec.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+
+// Lives in its own spec file rather than App.navigation.spec.tsx because proving the
+// SSO handoff requires mocking App's whole async service layer, which would change
+// what the navigator-wiring tests are actually exercising.
+const nativeScreenRegistry: Array<{ name: string }> = [];
+
+jest.mock('@react-navigation/native', () => ({
+  NavigationContainer: ({ children }: any) => React.createElement(React.Fragment, null, children),
+}));
+
+jest.mock('@react-navigation/native-stack', () => ({
+  createNativeStackNavigator: () => ({
+    Navigator: ({ children }: any) => React.createElement(React.Fragment, null, children),
+    Screen: ({ name }: any) => {
+      nativeScreenRegistry.push({ name });
+      return null;
+    },
+  }),
+}));
+
+jest.mock('@react-navigation/bottom-tabs', () => ({
+  createBottomTabNavigator: () => ({
+    Navigator: ({ children }: any) => React.createElement(React.Fragment, null, children),
+    Screen: () => null,
+  }),
+}));
+
+jest.mock('./screens/DigitalExhaustScreen', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('./services/EnterpriseSSO', () => ({
+  EnterpriseSSO: {
+    initializeDeepLinkListener: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('./services/SessionService', () => ({
+  SessionService: {
+    isLoggedIn: jest.fn().mockResolvedValue(false),
+    clearSession: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('./services/NotificationService', () => ({
+  NotificationService: {
+    initialize: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('./services/ApiClient', () => ({
+  ApiClient: {
+    getMobileBootstrap: jest.fn().mockResolvedValue({
+      environment: {
+        label: 'test',
+        apiBaseUrl: null,
+        privateBeta: true,
+        testMoneyMode: true,
+        allowlistUsOnly: true,
+        maintenanceMode: false,
+      },
+      mobile: { minSupportedVersion: '0.0.0', minSupportedBuild: '0', platformPrimary: 'ios' },
+      featureFlags: {
+        phase1MobilePrimary: true,
+        phase1NoContactOnly: true,
+        enableB2bHrUi: false,
+        maintenanceMode: false,
+        privateBeta: true,
+        testMoneyMode: true,
+        allowlistUsOnly: true,
+      },
+      labels: { betaBanner: 'Private beta', complianceNotice: 'Test money only' },
+      release: { apiVersion: '0.0.0', buildSha: null, snapshotHash: 'test' },
+    }),
+  },
+  setAuthToken: jest.fn(),
+}));
+
+const { EnterpriseSSO } = require('./services/EnterpriseSSO');
+const App = require('./App').default;
+
+async function mountApp() {
+  await act(async () => {
+    render(React.createElement(App));
+  });
+}
+
+describe('App enterprise SSO wiring', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    nativeScreenRegistry.length = 0;
+    (EnterpriseSSO.initializeDeepLinkListener as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('registers the enterprise SSO deep link listener on mount', async () => {
+    await mountApp();
+
+    expect(EnterpriseSSO.initializeDeepLinkListener).toHaveBeenCalledTimes(1);
+    expect(EnterpriseSSO.initializeDeepLinkListener).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('leaves the auth stack when the SSO token exchange succeeds', async () => {
+    await mountApp();
+
+    // Logged out, so the auth stack owns the tree.
+    expect(nativeScreenRegistry.map((route) => route.name)).toContain('Login');
+
+    const callback = (EnterpriseSSO.initializeDeepLinkListener as jest.Mock).mock.calls[0][0];
+
+    // A successful exchange has already stored the session token on ApiClient, so the
+    // only thing left for App to do is flip out of the auth stack.
+    nativeScreenRegistry.length = 0;
+    await act(async () => {
+      callback({ success: true, userId: 'ent-user-1' });
+    });
+
+    expect(nativeScreenRegistry.map((route) => route.name)).not.toContain('Login');
+  });
+
+  it('stays in the auth stack when the SSO token exchange fails', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    await mountApp();
+
+    const callback = (EnterpriseSSO.initializeDeepLinkListener as jest.Mock).mock.calls[0][0];
+    await act(async () => {
+      callback({ success: false, error: 'Invalid enterprise token' });
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Enterprise SSO handoff failed: Invalid enterprise token'),
+    );
+    // A failed handoff must not grant a session.
+    expect(nativeScreenRegistry.map((route) => route.name)).toContain('Login');
+    warn.mockRestore();
+  });
+
+  it('reports a listener that cannot be initialized instead of leaving an unhandled rejection', async () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    (EnterpriseSSO.initializeDeepLinkListener as jest.Mock).mockRejectedValueOnce(
+      new Error('Linking unavailable'),
+    );
+
+    await mountApp();
+
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining('Enterprise SSO listener failed to initialize: Linking unavailable'),
+    );
+    error.mockRestore();
+  });
+});

--- a/src/mobile/App.tsx
+++ b/src/mobile/App.tsx
@@ -7,6 +7,7 @@ import { SessionService } from './services/SessionService';
 import { OfflineCache } from './services/OfflineCache';
 import { ApiClient } from './services/ApiClient';
 import { NotificationService } from './services/NotificationService';
+import { EnterpriseSSO } from './services/EnterpriseSSO';
 import { linking, resolveNotificationDeepLink } from './config/linking';
 import {
   getMobileBetaBannerText,
@@ -220,6 +221,24 @@ export default function App() {
     return () => {
       mounted = false;
     };
+  }, []);
+
+  // Corporate SSO: styx://enterprise/?token=... carries a one-time token that // allow-secret
+  // EnterpriseSSO redeems against POST /auth/enterprise. The listener is registered
+  // unconditionally on mount rather than behind the login gate, because the link IS
+  // how these employees authenticate — it has to work from a logged-out cold start,
+  // which is why initializeDeepLinkListener also drains Linking.getInitialURL().
+  useEffect(() => {
+    EnterpriseSSO.initializeDeepLinkListener((result) => {
+      if (result.success) {
+        setIsLoggedIn(true);
+      } else {
+        console.warn(`Enterprise SSO handoff failed: ${result.error}`);
+      }
+    }).catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`Enterprise SSO listener failed to initialize: ${message}`);
+    });
   }, []);
 
   // Handle push notification taps → navigate via deep link

--- a/src/mobile/config/linking.spec.ts
+++ b/src/mobile/config/linking.spec.ts
@@ -1,4 +1,4 @@
-import { linking, resolveNotificationDeepLink } from './linking';
+import { isEnterpriseSSOLink, linking, resolveNotificationDeepLink } from './linking';
 
 describe('deep link configuration', () => {
   it('declares styx:// and com.styxprotocol.app:// prefixes', () => {
@@ -25,6 +25,30 @@ describe('deep link configuration', () => {
     const screens = linking.config?.screens as Record<string, any>;
     expect(screens.Profile.screens.ProfileMain).toBe('profile');
     expect(screens.Profile.screens.Settings).toBe('settings');
+  });
+});
+
+describe('isEnterpriseSSOLink', () => {
+  it('matches the styx:// enterprise SSO entry point', () => {
+    expect(isEnterpriseSSOLink('styx://enterprise/callback?token=abc')).toBe(true); // allow-secret
+  });
+
+  it('matches the bundle-id scheme too', () => {
+    expect(isEnterpriseSSOLink('com.styxprotocol.app://enterprise/callback?token=abc')).toBe(true); // allow-secret
+  });
+
+  it('does not match other styx deep links', () => {
+    expect(isEnterpriseSSOLink('styx://wallet')).toBe(false);
+    expect(isEnterpriseSSOLink('styx://contracts/abc-123/attest')).toBe(false);
+  });
+
+  it('does not match foreign schemes', () => {
+    expect(isEnterpriseSSOLink('https://example.com/enterprise/?token=abc')).toBe(false); // allow-secret
+  });
+
+  it('is deliberately absent from config.screens — it is an auth handoff, not a route', () => {
+    const screens = linking.config?.screens as Record<string, any>;
+    expect(Object.values(screens)).not.toContain('enterprise');
   });
 });
 

--- a/src/mobile/config/linking.ts
+++ b/src/mobile/config/linking.ts
@@ -13,6 +13,7 @@ import type { LinkingOptions } from '@react-navigation/native';
  *   styx://dashboard                   → Dashboard (home)
  *   styx://profile                     → Profile
  *   styx://settings                    → Settings
+ *   styx://enterprise/?token=...       → EnterpriseSSO (auth handoff, not a screen) // allow-secret
  *
  * Push notification payloads use the `data.url` field:
  *   { type: 'attestation_reminder', contractId: '...' }
@@ -48,6 +49,23 @@ export const linking: LinkingOptions<any> = {
     },
   },
 };
+
+const ENTERPRISE_SSO_PATH = 'enterprise/';
+
+/**
+ * Corporate SSO entry point: `styx://enterprise/?token=...` carries a one-time // allow-secret
+ * token that EnterpriseSSO exchanges for a session via POST /auth/enterprise.
+ *
+ * It is deliberately NOT a `config.screens` entry: the token has to be redeemed
+ * before an authenticated screen exists to route to, so React Navigation must
+ * leave the URL alone and let the SSO listener consume it. Declaring the match
+ * here keeps the app's whole deep-link surface — navigational and not — in one
+ * file, and derives from `linking.prefixes` so a link minted with the bundle-id
+ * scheme behaves exactly like a styx:// one.
+ */
+export function isEnterpriseSSOLink(url: string): boolean {
+  return linking.prefixes.some((prefix) => url.startsWith(`${prefix}${ENTERPRISE_SSO_PATH}`));
+}
 
 /**
  * Resolve a push notification payload into a deep link URL.

--- a/src/mobile/services/EnterpriseSSO.ts
+++ b/src/mobile/services/EnterpriseSSO.ts
@@ -1,5 +1,6 @@
 import { Linking } from 'react-native';
 import { ApiClient, setAuthToken } from './ApiClient';
+import { isEnterpriseSSOLink } from '../config/linking';
 
 type SSOCallback = (result: { success: boolean; userId?: string; error?: string }) => void;
 
@@ -28,7 +29,7 @@ export class EnterpriseSSO {
     const { url } = event;
     console.log(`EnterpriseSSO: Intercepted deep link [${url}]`);
 
-    if (!url.startsWith('styx://enterprise/')) {
+    if (!isEnterpriseSSOLink(url)) {
       return;
     }
 


### PR DESCRIPTION
An unwired-service sweep: three complete, registered, tested services that nothing reached. Two are now wired; the third turned out not to be the defect it was filed as.

## 1. `CrmService` had zero HTTP surface

Registered in `src/api/src/modules/b2b/b2b.module.ts` as both a provider (:22) and an export (:34), with a unit spec *and* a testcontainers integration spec — but `B2BController`'s constructor never injected it, and no other symbol referenced it. Grep before the change:

```
$ grep -rn "CrmService" --exclude-dir=node_modules --exclude-dir=.git .
docs/CHANGELOG.md:16
docs/planning/planning--alpha-omega-completion-matrix.md:109
src/api/src/modules/b2b/crm.service.int.spec.ts:{3,14,17,36,49}
src/api/src/modules/b2b/b2b.module.ts:{8,22,34}
src/api/src/modules/b2b/crm.service.{ts,spec.ts}
```

Every hit is the module registration, the service itself, its own two specs, or a doc. So the Corporate Integrity Score (F-B2B-04 — a real aggregate SQL query, exercised against Postgres by `crm.service.int.spec.ts`) and both the Salesforce and HubSpot connectors were unreachable from outside the process.

Injected `CrmService` and added four routes, each behind the same `assertEnterpriseMembership` tenant check the neighbouring B2B routes use:

| Method | Path | Service method |
|---|---|---|
| `GET` | `/b2b/crm/integrity/:enterpriseId` | `calculateCorporateIntegrityScore` |
| `POST` | `/b2b/crm/events/:enterpriseId` | `pushEmployeeEvent` |
| `POST` | `/b2b/crm/interactions/:enterpriseId` | `logInteraction` |
| `POST` | `/b2b/crm/sync/:enterpriseId` | `syncUser` |

That reaches all four of the service's public methods.

Three deliberate choices in the surface:

- **`eventType` is validated, not cast.** It arrives as free-text JSON and is forwarded to a customer's live Salesforce/HubSpot org, so the connector union is now also a runtime array `EMPLOYEE_EVENT_TYPES` that the controller checks against, returning `400` on anything else. This is the shape `BillingService` already uses for `METERED_EVENT_TYPES`, for the same reason. It also let `CrmService.logInteraction` drop its `type as EmployeeEvent['eventType']` cast and take the narrowed type directly.
- **Timestamps are stamped server-side.** A client-supplied `timestamp` would let an enterprise admin backdate behavioral events in their own CRM record.
- **`/crm/sync` pins the CRM tenant to the path param.** `CrmService.syncUser` resolves the tenant from `CrmUser.company`; taking that from the request body would let a verified admin of one enterprise pull another enterprise's roster through `syncUserList`.

Grep after the change (`.spec.` excluded):

```
src/api/src/modules/b2b/b2b.controller.ts:22:import { CrmService } from './crm.service';
src/api/src/modules/b2b/b2b.controller.ts:38:    private readonly crm: CrmService,
src/api/src/modules/b2b/b2b.module.ts:{8,22,34}
```

## 2. `EnterpriseSSO.initializeDeepLinkListener` was never called

Referenced only by its own spec. `src/mobile/App.tsx` never invoked it, so the enterprise deep link was never redeemed — while its backend counterpart `POST /auth/enterprise` is live and `src/api/src/modules/auth/auth.service.ts:289` explicitly names `mobile/services/EnterpriseSSO.ts` as its caller. An asymmetric dead path.

- **`App.tsx`** now registers the listener in a mount effect, *not* behind the login gate — the link is how these employees authenticate, so it has to work from a logged-out cold start, which is exactly why `initializeDeepLinkListener` also drains `Linking.getInitialURL()`. A successful exchange flips `isLoggedIn`; a failure warns and leaves the auth stack in place; a listener that cannot initialize is reported rather than left as an unhandled rejection.
- **`config/linking.ts`** now declares the enterprise entry point — but **not** as a `config.screens` route, and that is a deliberate deviation from the item as filed. React Navigation resolves a path to a *screen*; the credential has to be redeemed before any authenticated screen exists to route to, and there is no Enterprise screen to name. A custom `getStateFromPath` was the other option and is not viable here: `src/mobile/jest.config.js` maps `^react-native$` to a stub and does not transform `@react-navigation/native`'s ESM, so a runtime import of it from `linking.ts` breaks every spec that loads the file (verified with a throwaway probe spec — `SyntaxError: Unexpected token 'export'`). So the path is exported as `isEnterpriseSSOLink()` instead, documented in the same header block as the navigational links, and `EnterpriseSSO` now uses it in place of its hard-coded prefix: one source of truth, and it picks up the `com.styxprotocol.app://` scheme the old literal silently missed. `linking.spec.ts` asserts the absence from `config.screens` so the reasoning is pinned, not just commented.

Note, unchanged and out of scope: `EnterpriseSSO` calls `setAuthToken` but not `SessionService.saveSession`, so an SSO session does not survive an app restart. That is a pre-existing property of the service, not something this wiring introduces.

## 3. The billing "duplicate" is not a duplicate — nothing deleted

The item asked for `src/api/services/b2b/billing.service.ts` to be deleted as a duplicate of the `src/api/src/modules/b2b` implementation, after confirming the duplication. It does not hold up.

| | `services/b2b/billing.service.ts` | `src/modules/b2b/billing.service.ts` |
|---|---|---|
| Class | `ConsumptionBillingService` | `BillingService` |
| Backend | Postgres `consumption_logs` | Stripe Billing Meter Events |
| Deps | `pg.Pool` | `stripe` |
| Methods | `trackEvent`, `getCurrentUsage`, `getUsageHistory` | `recordConsumptionEvent`, `recordUsage`, `getUsageSummary` |

`diff` between the two files shares nothing but the `@nestjs/common` import line. The `consumption_logs` table it queries is real — `src/api/database/schema.sql:223` and `src/api/database/migrations/063_schema_chain_reconciliation.sql:9`, with the composite indexes the queries rely on. And `docs/enterprise/revenue-packaging.md` already describes them as two distinct layers: item 2 is "Stripe metered billing", item 3 is "Internal consumption ledger (pre-invoice reporting / reconciliation)".

Importers of the file proposed for deletion:

```
$ grep -rn "ConsumptionBillingService" --exclude-dir=node_modules --exclude-dir=.git .
docs/CHANGELOG.md:18
docs/enterprise/revenue-packaging.md:108
docs/planning/planning--implementation-status.md:40
src/web/lib/styx-knowledge.ts:1046
src/api/services/b2b/billing.service.spec.ts:{1,3,4,9}
src/api/services/b2b/billing.service.ts:{12,13}
```

It is genuinely unwired to HTTP — but it is a distinct implementation of a documented layer, not dead duplicated code, so deleting it would remove behaviour rather than remove a lie. Both files left in place, per the item's own instruction for this case.

## Docs

`docs/api/api--spec.md` gains the four routes in the Enterprise table plus a CRM Handoff section (allowed event types, server-side timestamps, the sync tenant rule, and the log-only behaviour when no connector is configured). `docs/enterprise/revenue-packaging.md` item 5 now names the routes that reach the CRM handoff.

## Verification

```
src/api $ npx jest src/modules/b2b services/b2b --coverage=false
  Test Suites: 11 passed, 11 total
  Tests:       118 passed, 118 total

src/api $ npx tsc --noEmit
  ../shared/libs/waitlist-attribution.spec.ts(1,38): error TS2307:
    Cannot find module '@jest/globals' or its corresponding type declarations.
  exit 2

src/mobile $ npx jest --coverage
  Test Suites: 33 passed, 33 total
  Tests:       312 passed, 312 total

src/mobile $ npx tsc --noEmit
  exit 0
```

The one `tsc` error is **pre-existing on `origin/main`** and untouched by this branch: confirmed by `git stash`-ing the whole diff and re-running `npx tsc --noEmit`, which produced the identical single error. `git diff --stat origin/main -- src/shared` is empty.

**SQL caveat:** every unit spec here mocks the `pg` Pool, so none of this verifies SQL. `calculateCorporateIntegrityScore`'s query is unchanged by this PR; its real coverage is `crm.service.int.spec.ts` (testcontainers Postgres), which was not run in this session. No query text was added or edited anywhere in the diff.

## Summary by Sourcery

Wire the previously unused CrmService into the B2B HTTP API and connect the mobile enterprise SSO deep link flow so corporate users can authenticate via app links without changing existing billing layers.

New Features:
- Expose CRM handoff endpoints under the B2B controller for integrity scoring, behavioral events, interactions, and user sync, all scoped by enterprise and guarded by membership checks.
- Enable enterprise SSO authentication in the mobile app by registering an unconditional deep link listener that redeems enterprise tokens and transitions users out of the auth stack when successful.

Bug Fixes:
- Validate CRM employee event types and interaction types against an explicit connector union and enforce server-side timestamps to prevent invalid or backdated events from being pushed to customer CRMs.
- Ensure CRM user sync derives the tenant from the verified enterprise path parameter rather than request body data to avoid cross-tenant roster access.
- Route enterprise SSO deep links via a centralized linking helper that recognizes both app schemes and keeps the auth handoff out of the navigation routes.

Enhancements:
- Strengthen CRM connector typing by replacing free-text interaction types with the EmployeeEventType union, eliminating unsafe casts.
- Document the CRM handoff HTTP surface and behavior in the API spec and revenue packaging docs, including allowed event types and connector-less log-only behavior.

Tests:
- Add B2B controller tests for the new CRM endpoints covering tenant checks, validation, and sync behavior.
- Add mobile tests verifying enterprise SSO listener registration, successful and failed token exchanges, and proper handling of listener initialization failures.
- Extend deep link configuration tests to cover enterprise SSO link recognition and confirm it is intentionally omitted from navigation screens.

Chores:
- Leave the internal consumption billing service in place alongside the Stripe-backed billing module, recognizing it as a distinct documented layer rather than a duplicate implementation.