### PR TITLE
feat(security): security.txt, CSP headers, and a wired B2B webhook store

### DIFF
--- a/docs/api/api--spec.md
+++ b/docs/api/api--spec.md
@@ -508,11 +508,38 @@ curl -sS -X POST "$STYX_API_URL/b2b/webhook/test" \
     "enterpriseId": "ent_123",
     "url": "https://customer.example.com/styx/webhook"
   }'
+
+curl -sS "$STYX_API_URL/b2b/webhook/subscriptions/ent_123" \
+  -H "Authorization: Bearer $TOKEN"
 ```
+
+`register` persists the subscription and returns its `subscriptionId`;
+re-registering the same URL reactivates the existing row rather than creating a
+duplicate. Registration runs the URL through the same guard delivery uses, so an
+unreachable-by-policy target is refused with a `400` at registration time.
 
 Webhook targets must use `http` or `https`, must not include credentials, and
 must not resolve to loopback, private, link-local, localhost, or obfuscated IP
 addresses. Delivery uses up to 3 attempts with exponential backoff.
+
+Every active subscription of the enterprise receives a `CONTRACT_RESOLVED` event
+when a contract belonging to one of its members resolves:
+
+```json
+{
+  "type": "CONTRACT_RESOLVED",
+  "enterpriseId": "ent_123",
+  "subject": "9f2c…",
+  "outcome": "COMPLETED",
+  "occurredAt": "2026-08-15T00:00:00.000Z"
+}
+```
+
+`subject` is the salted pseudonym also used by the HR export — stable for the
+same employee within the same enterprise, and not reversible to a user. The
+event carries no goal, category, stake amount, or proof reference: the privacy
+firewall means an employer learns that engagement happened, not what a person is
+working on.
 
 Webhook deliveries include:
 
@@ -691,7 +718,8 @@ Auth requirements use these labels:
 |--------|------|------|---------|
 | `GET` | `/b2b/metrics/:enterpriseId` | Enterprise Admin | Enterprise completion and integrity metrics. |
 | `GET` | `/b2b/billing/:enterpriseId` | Enterprise Admin | Read-only billing summary. |
-| `POST` | `/b2b/webhook/register` | Enterprise Admin | Register webhook URL. |
+| `POST` | `/b2b/webhook/register` | Enterprise Admin | Register (or reactivate) a webhook subscription. |
+| `GET` | `/b2b/webhook/subscriptions/:enterpriseId` | Enterprise Admin | List active webhook subscriptions. |
 | `POST` | `/b2b/webhook/test` | Enterprise Admin | Send signed test webhook event. |
 | `GET` | `/b2b/export/hr/:enterpriseId` | Enterprise Admin | Pseudonymized HR export with small-cohort suppression. |
 | `GET` | `/b2b/datalake/:enterpriseId` | Enterprise Admin | Time-bounded analytics snapshot. Query: `start`, `end`. |

--- a/src/api/config/queue.config.ts
+++ b/src/api/config/queue.config.ts
@@ -16,6 +16,7 @@ export const FURY_ROUTER_QUEUE_NAME = 'FURY_ROUTER_QUEUE';
 export const SETTLEMENT_QUEUE_NAME = 'SETTLEMENT_QUEUE';
 export const VIDEO_PROCESSING_QUEUE_NAME = 'VIDEO_PROCESSING_QUEUE';
 export const PUSH_DISPATCH_QUEUE_NAME = 'PUSH_DISPATCH_QUEUE';
+export const ENTERPRISE_WEBHOOK_QUEUE_NAME = 'ENTERPRISE_WEBHOOK_QUEUE';
 
 export const getDefaultQueueOptions = (): QueueOptions => ({
   connection: getRedisConnectionConfig(),

--- a/src/api/database/migrations/069_webhook_subscriptions.sql
+++ b/src/api/database/migrations/069_webhook_subscriptions.sql
@@ -1,0 +1,29 @@
+-- 069: Persist enterprise webhook registrations.
+--
+-- POST /b2b/webhook/register previously echoed {status:'registered'} and stored
+-- nothing, so no contract-lifecycle code could ever find a URL to notify. This is
+-- the missing store: one row per (enterprise, url), soft-deactivated rather than
+-- deleted so a re-registration after a delivery outage keeps its history.
+--
+-- last_delivery_at / last_delivery_ok are written by the delivery worker. They are
+-- the only support signal an operator has when an enterprise reports "we stopped
+-- receiving events" — the payload itself is never retained (it carries a pseudonym
+-- for a real employee, and the privacy firewall means Styx keeps no copy).
+
+CREATE TABLE IF NOT EXISTS webhook_subscriptions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  enterprise_id UUID NOT NULL REFERENCES enterprises(id) ON DELETE CASCADE,
+  url TEXT NOT NULL,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  registered_by UUID REFERENCES users(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_delivery_at TIMESTAMPTZ,
+  last_delivery_ok BOOLEAN,
+  CONSTRAINT one_subscription_per_enterprise_url UNIQUE (enterprise_id, url)
+);
+
+-- The dispatch path only ever asks for the active rows of one enterprise.
+CREATE INDEX IF NOT EXISTS idx_webhook_subscriptions_active
+  ON webhook_subscriptions(enterprise_id)
+  WHERE active;

--- a/src/api/src/modules/b2b/b2b.controller.spec.ts
+++ b/src/api/src/modules/b2b/b2b.controller.spec.ts
@@ -2,6 +2,7 @@ import { Pool } from 'pg';
 import { B2BController } from './b2b.controller';
 import { BillingService } from './billing.service';
 import { WebhookService } from './webhook.service';
+import { WebhookSubscriptionService } from './webhook-subscription.service';
 import { MetricsService } from './metrics.service';
 import { AnonymizeService } from './anonymize.service';
 import { DataLakeService } from './datalake.service';
@@ -26,6 +27,11 @@ describe('B2BController', () => {
   const mockWebhook = {
     dispatchEnterpriseMetricEvent: jest.fn(),
   } as unknown as WebhookService;
+
+  const mockWebhookSubscriptions = {
+    register: jest.fn(),
+    listActive: jest.fn(),
+  } as unknown as WebhookSubscriptionService;
 
   const mockMetrics = {
     getEnterpriseMetrics: jest.fn(),
@@ -64,10 +70,14 @@ describe('B2BController', () => {
   } as unknown as CrmService;
 
   beforeEach(() => {
+    // Both the webhook-subscription store and the CRM service were injected by
+    // separate changes landing together; the argument order here follows the
+    // controller's own constructor.
     controller = new B2BController(
       mockPool,
       mockBilling,
       mockWebhook,
+      mockWebhookSubscriptions,
       mockMetrics,
       mockAnonymize,
       mockDataLake,
@@ -76,6 +86,14 @@ describe('B2BController', () => {
     jest.clearAllMocks();
     (mockPool.query as jest.Mock).mockResolvedValue({
       rows: [{ enterprise_id: 'ent-001', role: 'ADMIN' }],
+    });
+    (mockWebhookSubscriptions.register as jest.Mock).mockResolvedValue({
+      id: 'sub-1',
+      enterpriseId: 'ent-001',
+      url: 'https://example.com/webhook',
+      active: true,
+      lastDeliveryAt: null,
+      lastDeliveryOk: null,
     });
   });
 
@@ -117,17 +135,58 @@ describe('B2BController', () => {
   });
 
   describe('registerWebhook', () => {
-    it('should register a webhook URL', async () => {
+    it('should persist the registration and return its subscription id', async () => {
       const result = await controller.registerWebhook(adminUser, {
         enterpriseId: 'ent-001',
         url: 'https://example.com/webhook',
       });
 
+      expect(mockWebhookSubscriptions.register).toHaveBeenCalledWith(
+        'ent-001',
+        'https://example.com/webhook',
+        'admin-1',
+      );
       expect(result).toEqual({
         status: 'registered',
+        subscriptionId: 'sub-1',
         enterpriseId: 'ent-001',
         url: 'https://example.com/webhook',
       });
+    });
+
+    it('should reject before persisting when the caller is not an admin of the enterprise', async () => {
+      (mockPool.query as jest.Mock).mockResolvedValueOnce({
+        rows: [{ enterprise_id: 'other-ent', role: 'ADMIN' }],
+      });
+
+      await expect(
+        controller.registerWebhook(adminUser, {
+          enterpriseId: 'ent-001',
+          url: 'https://example.com/webhook',
+        }),
+      ).rejects.toThrow();
+      expect(mockWebhookSubscriptions.register).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listWebhookSubscriptions', () => {
+    it('should return the active subscriptions of the enterprise', async () => {
+      const rows = [
+        {
+          id: 'sub-1',
+          enterpriseId: 'ent-001',
+          url: 'https://example.com/webhook',
+          active: true,
+          lastDeliveryAt: null,
+          lastDeliveryOk: null,
+        },
+      ];
+      (mockWebhookSubscriptions.listActive as jest.Mock).mockResolvedValueOnce(rows);
+
+      await expect(
+        controller.listWebhookSubscriptions(adminUser, 'ent-001'),
+      ).resolves.toEqual(rows);
+      expect(mockWebhookSubscriptions.listActive).toHaveBeenCalledWith('ent-001');
     });
   });
 

--- a/src/api/src/modules/b2b/b2b.controller.ts
+++ b/src/api/src/modules/b2b/b2b.controller.ts
@@ -16,6 +16,7 @@ import { RoleGuard, Roles } from '../../common/guards/role.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { BillingService } from './billing.service';
 import { WebhookService } from './webhook.service';
+import { WebhookSubscriptionService } from './webhook-subscription.service';
 import { MetricsService } from './metrics.service';
 import { AnonymizeService } from './anonymize.service';
 import { DataLakeService } from './datalake.service';
@@ -32,6 +33,7 @@ export class B2BController {
     private readonly pool: Pool,
     private readonly billing: BillingService,
     private readonly webhook: WebhookService,
+    private readonly webhookSubscriptions: WebhookSubscriptionService,
     private readonly metrics: MetricsService,
     private readonly anonymize: AnonymizeService,
     private readonly dataLake: DataLakeService,
@@ -120,11 +122,27 @@ export class B2BController {
     @Body() body: { enterpriseId: string; url: string },
   ) {
     await this.assertEnterpriseMembership(user.id, body.enterpriseId);
+    const subscription = await this.webhookSubscriptions.register(
+      body.enterpriseId,
+      body.url,
+      user.id,
+    );
     return {
       status: 'registered',
-      enterpriseId: body.enterpriseId,
-      url: body.url,
+      subscriptionId: subscription.id,
+      enterpriseId: subscription.enterpriseId,
+      url: subscription.url,
     };
+  }
+
+  @Get('webhook/subscriptions/:enterpriseId')
+  @ApiOperation({ summary: 'List the active webhook subscriptions of an enterprise' })
+  async listWebhookSubscriptions(
+    @CurrentUser() user: { id: string },
+    @Param('enterpriseId') enterpriseId: string,
+  ) {
+    await this.assertEnterpriseMembership(user.id, enterpriseId);
+    return this.webhookSubscriptions.listActive(enterpriseId);
   }
 
   @Post('webhook/test')

--- a/src/api/src/modules/b2b/b2b.module.ts
+++ b/src/api/src/modules/b2b/b2b.module.ts
@@ -2,6 +2,8 @@ import { Module } from "@nestjs/common";
 import { B2BController } from "./b2b.controller";
 import { BillingService } from "./billing.service";
 import { WebhookService } from "./webhook.service";
+import { WebhookSubscriptionService } from "./webhook-subscription.service";
+import { EnterpriseWebhookWorker } from "./enterprise-webhook.worker";
 import { MetricsService } from "./metrics.service";
 import { AnonymizeService } from "./anonymize.service";
 import { DataLakeService } from "./datalake.service";
@@ -16,6 +18,8 @@ import { RoleGuard } from "../../common/guards/role.guard";
   providers: [
     BillingService,
     WebhookService,
+    WebhookSubscriptionService,
+    EnterpriseWebhookWorker,
     MetricsService,
     AnonymizeService,
     DataLakeService,
@@ -28,6 +32,7 @@ import { RoleGuard } from "../../common/guards/role.guard";
   exports: [
     BillingService,
     WebhookService,
+    WebhookSubscriptionService,
     MetricsService,
     AnonymizeService,
     DataLakeService,

--- a/src/api/src/modules/b2b/enterprise-webhook.worker.spec.ts
+++ b/src/api/src/modules/b2b/enterprise-webhook.worker.spec.ts
@@ -1,0 +1,82 @@
+import { EnterpriseWebhookWorker } from './enterprise-webhook.worker';
+import { EnterpriseWebhookJob } from './webhook-subscription.service';
+
+jest.mock('bullmq', () => {
+  const mockWorkerOn = jest.fn();
+  const MockWorker = jest.fn(() => ({ on: mockWorkerOn }));
+  return { Worker: MockWorker };
+});
+
+describe('EnterpriseWebhookWorker', () => {
+  let worker: EnterpriseWebhookWorker;
+  let mockWebhook: any;
+  let mockSubscriptions: any;
+
+  const job = {
+    data: {
+      subscriptionId: 'sub-1',
+      url: 'https://hooks.example.com/styx',
+      event: {
+        type: 'CONTRACT_RESOLVED',
+        enterpriseId: 'ent-001',
+        subject: 'pseudonym-abc',
+        outcome: 'COMPLETED',
+        occurredAt: '2026-08-15T00:00:00.000Z',
+      },
+    } as EnterpriseWebhookJob,
+  } as any;
+
+  // The processor is the second argument the Worker constructor receives.
+  function processor(): (job: any) => Promise<void> {
+    const { Worker } = require('bullmq');
+    return (Worker as jest.Mock).mock.calls[0][1];
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockWebhook = { dispatchEnterpriseMetricEvent: jest.fn() };
+    mockSubscriptions = { recordDelivery: jest.fn().mockResolvedValue(undefined) };
+    worker = new EnterpriseWebhookWorker(mockWebhook, mockSubscriptions);
+  });
+
+  it('initializes on the enterprise webhook queue', () => {
+    worker.onModuleInit();
+    const { Worker } = require('bullmq');
+    expect(Worker).toHaveBeenCalledWith(
+      'ENTERPRISE_WEBHOOK_QUEUE',
+      expect.any(Function),
+      expect.objectContaining({ concurrency: 4 }),
+    );
+  });
+
+  it('delivers the signed event and records the success', async () => {
+    mockWebhook.dispatchEnterpriseMetricEvent.mockResolvedValueOnce(true);
+    worker.onModuleInit();
+
+    await processor()(job);
+
+    expect(mockWebhook.dispatchEnterpriseMetricEvent).toHaveBeenCalledWith(
+      'https://hooks.example.com/styx',
+      job.data.event,
+    );
+    expect(mockSubscriptions.recordDelivery).toHaveBeenCalledWith('sub-1', true);
+  });
+
+  it('records the miss and fails the job when the endpoint refuses', async () => {
+    mockWebhook.dispatchEnterpriseMetricEvent.mockResolvedValueOnce(false);
+    worker.onModuleInit();
+
+    await expect(processor()(job)).rejects.toThrow('sub-1');
+    expect(mockSubscriptions.recordDelivery).toHaveBeenCalledWith('sub-1', false);
+  });
+
+  it('records the miss when the SSRF guard rejects a rebound host', async () => {
+    mockWebhook.dispatchEnterpriseMetricEvent.mockRejectedValueOnce(
+      new Error('Webhook URL resolves to a loopback, private, or link-local address'),
+    );
+    worker.onModuleInit();
+
+    await expect(processor()(job)).rejects.toThrow('loopback');
+    expect(mockSubscriptions.recordDelivery).toHaveBeenCalledWith('sub-1', false);
+  });
+});

--- a/src/api/src/modules/b2b/enterprise-webhook.worker.ts
+++ b/src/api/src/modules/b2b/enterprise-webhook.worker.ts
@@ -1,0 +1,66 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Job, Worker } from 'bullmq';
+import {
+  ENTERPRISE_WEBHOOK_QUEUE_NAME,
+  getRedisConnectionConfig,
+} from '../../../config/queue.config';
+import {
+  EnterpriseWebhookJob,
+  WebhookSubscriptionService,
+} from './webhook-subscription.service';
+import { WebhookService } from './webhook.service';
+
+@Injectable()
+export class EnterpriseWebhookWorker implements OnModuleInit {
+  private readonly logger = new Logger(EnterpriseWebhookWorker.name);
+  private worker!: Worker;
+
+  constructor(
+    private readonly webhook: WebhookService,
+    private readonly subscriptions: WebhookSubscriptionService,
+  ) {}
+
+  onModuleInit() {
+    this.worker = new Worker<EnterpriseWebhookJob>(
+      ENTERPRISE_WEBHOOK_QUEUE_NAME,
+      async (job: Job<EnterpriseWebhookJob>) => this.process(job),
+      { connection: getRedisConnectionConfig(), concurrency: 4 },
+    );
+
+    this.worker.on('failed', (job, err) => {
+      this.logger.error(`Enterprise webhook job ${job?.id} failed: ${err.message}`);
+    });
+
+    this.logger.log('Enterprise webhook worker initialized');
+  }
+
+  private async process(job: Job<EnterpriseWebhookJob>): Promise<void> {
+    const { subscriptionId, url, event } = job.data;
+
+    // dispatchEnterpriseMetricEvent already signs, retries with backoff, and
+    // re-runs the SSRF guard against whatever the host resolves to NOW — a URL
+    // that was safe at registration can be repointed at an internal address
+    // afterwards, so the check belongs here as well as there. That guard REJECTS
+    // by throwing, so the failure record is written before the error is re-raised;
+    // otherwise a rebound host would leave last_delivery_* frozen at its last
+    // success and the support signal would lie.
+    let delivered: boolean;
+    try {
+      delivered = await this.webhook.dispatchEnterpriseMetricEvent(
+        url,
+        event as unknown as Record<string, unknown>,
+      );
+    } catch (error) {
+      await this.subscriptions.recordDelivery(subscriptionId, false);
+      throw error;
+    }
+
+    await this.subscriptions.recordDelivery(subscriptionId, delivered);
+
+    if (!delivered) {
+      // Surface as a job failure so BullMQ's own retry/backoff owns the next
+      // attempt; the subscription row already records that this one missed.
+      throw new Error(`Enterprise webhook delivery failed for subscription ${subscriptionId}`);
+    }
+  }
+}

--- a/src/api/src/modules/b2b/webhook-subscription.service.spec.ts
+++ b/src/api/src/modules/b2b/webhook-subscription.service.spec.ts
@@ -1,0 +1,155 @@
+import { BadRequestException } from '@nestjs/common';
+import { AnonymizeService } from './anonymize.service';
+import { WebhookService } from './webhook.service';
+import { WebhookSubscriptionService } from './webhook-subscription.service';
+
+jest.mock('bullmq');
+import { Queue } from 'bullmq';
+const MockQueue = Queue as jest.MockedClass<typeof Queue>;
+
+describe('WebhookSubscriptionService', () => {
+  let service: WebhookSubscriptionService;
+  let mockAdd: jest.Mock;
+  let mockPool: { query: jest.Mock };
+  let mockWebhook: { assertDeliverableUrl: jest.Mock };
+  let mockAnonymize: { hashUserId: jest.Mock };
+
+  const row = {
+    id: 'sub-1',
+    enterprise_id: 'ent-001',
+    url: 'https://hooks.example.com/styx',
+    active: true,
+    last_delivery_at: null,
+    last_delivery_ok: null,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAdd = jest.fn().mockResolvedValue({ id: 'job-1' });
+    MockQueue.prototype.add = mockAdd;
+    mockPool = { query: jest.fn().mockResolvedValue({ rows: [] }) };
+    mockWebhook = { assertDeliverableUrl: jest.fn().mockResolvedValue(undefined) };
+    mockAnonymize = { hashUserId: jest.fn().mockReturnValue('pseudonym-abc') };
+    service = new WebhookSubscriptionService(
+      mockPool as any,
+      mockWebhook as unknown as WebhookService,
+      mockAnonymize as unknown as AnonymizeService,
+    );
+  });
+
+  describe('register', () => {
+    it('should validate the URL through the SSRF guard before persisting', async () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [row] });
+
+      const result = await service.register('ent-001', row.url, 'user-1');
+
+      expect(mockWebhook.assertDeliverableUrl).toHaveBeenCalledWith(row.url);
+      expect(result).toEqual({
+        id: 'sub-1',
+        enterpriseId: 'ent-001',
+        url: row.url,
+        active: true,
+        lastDeliveryAt: null,
+        lastDeliveryOk: null,
+      });
+      expect(mockPool.query.mock.calls[0][0]).toContain('INSERT INTO webhook_subscriptions');
+      expect(mockPool.query.mock.calls[0][1]).toEqual(['ent-001', row.url, 'user-1']);
+    });
+
+    it('should refuse an internal address as a 400 rather than storing it', async () => {
+      mockWebhook.assertDeliverableUrl.mockRejectedValueOnce(
+        new Error('Webhook URL must not target loopback, private, or link-local addresses'),
+      );
+
+      await expect(
+        service.register('ent-001', 'http://169.254.169.254/latest/meta-data', 'user-1'),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+
+    it('should reactivate an existing row instead of creating a duplicate', async () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [row] });
+
+      await service.register('ent-001', row.url, 'user-2');
+
+      const sql = mockPool.query.mock.calls[0][0];
+      expect(sql).toContain('ON CONFLICT (enterprise_id, url) DO UPDATE');
+      expect(sql).toContain('SET active = TRUE');
+    });
+  });
+
+  describe('enqueueContractResolved', () => {
+    it('should enqueue one job per active subscription', async () => {
+      mockPool.query.mockResolvedValueOnce({
+        rows: [row, { ...row, id: 'sub-2', url: 'https://hooks.example.com/second' }],
+      });
+
+      const count = await service.enqueueContractResolved({
+        enterpriseId: 'ent-001',
+        userId: 'user-9',
+        outcome: 'COMPLETED',
+        occurredAt: '2026-08-15T00:00:00.000Z',
+      });
+
+      expect(count).toBe(2);
+      expect(mockAdd).toHaveBeenCalledTimes(2);
+      expect(mockAdd.mock.calls[0][0]).toBe('enterprise-webhook');
+      expect(mockAdd.mock.calls[0][1]).toEqual({
+        subscriptionId: 'sub-1',
+        url: row.url,
+        event: {
+          type: 'CONTRACT_RESOLVED',
+          enterpriseId: 'ent-001',
+          subject: 'pseudonym-abc',
+          outcome: 'COMPLETED',
+          occurredAt: '2026-08-15T00:00:00.000Z',
+        },
+      });
+    });
+
+    it('should send the salted pseudonym, never the raw user id', async () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [row] });
+
+      await service.enqueueContractResolved({
+        enterpriseId: 'ent-001',
+        userId: 'user-9',
+        outcome: 'FAILED',
+        occurredAt: '2026-08-15T00:00:00.000Z',
+      });
+
+      expect(mockAnonymize.hashUserId).toHaveBeenCalledWith('user-9', 'ent-001');
+      expect(JSON.stringify(mockAdd.mock.calls[0][1])).not.toContain('user-9');
+    });
+
+    it('should not touch the queue when the enterprise has no subscriptions', async () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+      const count = await service.enqueueContractResolved({
+        enterpriseId: 'ent-001',
+        userId: 'user-9',
+        outcome: 'COMPLETED',
+        occurredAt: '2026-08-15T00:00:00.000Z',
+      });
+
+      expect(count).toBe(0);
+      expect(mockAdd).not.toHaveBeenCalled();
+    });
+
+    it('should only read active subscriptions', async () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+      await service.listActive('ent-001');
+
+      expect(mockPool.query.mock.calls[0][0]).toContain('WHERE enterprise_id = $1 AND active');
+    });
+  });
+
+  describe('recordDelivery', () => {
+    it('should stamp the outcome of the last delivery attempt', async () => {
+      await service.recordDelivery('sub-1', false);
+
+      expect(mockPool.query.mock.calls[0][0]).toContain('UPDATE webhook_subscriptions');
+      expect(mockPool.query.mock.calls[0][1]).toEqual(['sub-1', false]);
+    });
+  });
+});

--- a/src/api/src/modules/b2b/webhook-subscription.service.ts
+++ b/src/api/src/modules/b2b/webhook-subscription.service.ts
@@ -1,0 +1,167 @@
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { Queue } from 'bullmq';
+import { Pool } from 'pg';
+import {
+  ENTERPRISE_WEBHOOK_QUEUE_NAME,
+  getDefaultQueueOptions,
+} from '../../../config/queue.config';
+import { AnonymizeService } from './anonymize.service';
+import { WebhookService } from './webhook.service';
+
+export interface WebhookSubscription {
+  id: string;
+  enterpriseId: string;
+  url: string;
+  active: boolean;
+  lastDeliveryAt: string | null;
+  lastDeliveryOk: boolean | null;
+}
+
+/**
+ * What an enterprise consumer actually receives.
+ *
+ * `subject` is the salted pseudonym from AnonymizeService — the same one the HR
+ * export uses, so an employer can follow one employee's engagement over time
+ * without ever holding their identity. There is deliberately no goal, category,
+ * stake amount, or proof reference in here: the employer funds the pot and is
+ * entitled to know that engagement happened, not to what a person is working on.
+ */
+export interface EnterpriseWebhookEvent {
+  type: 'CONTRACT_RESOLVED';
+  enterpriseId: string;
+  subject: string;
+  outcome: 'COMPLETED' | 'FAILED';
+  occurredAt: string;
+}
+
+export interface EnterpriseWebhookJob {
+  subscriptionId: string;
+  url: string;
+  event: EnterpriseWebhookEvent;
+}
+
+@Injectable()
+export class WebhookSubscriptionService {
+  private readonly logger = new Logger(WebhookSubscriptionService.name);
+  private readonly queue: Queue;
+
+  constructor(
+    private readonly pool: Pool,
+    private readonly webhook: WebhookService,
+    private readonly anonymize: AnonymizeService,
+  ) {
+    this.queue = new Queue(ENTERPRISE_WEBHOOK_QUEUE_NAME, getDefaultQueueOptions());
+  }
+
+  /**
+   * Persist a registration after putting the URL through the same SSRF guard the
+   * delivery path uses. Validating at registration matters independently: without
+   * it an internal address would sit in the table until a contract resolved, and
+   * the rejection would then surface as an outbox failure on someone's settlement
+   * rather than as a 400 on the call that made the mistake.
+   */
+  async register(
+    enterpriseId: string,
+    url: string,
+    registeredBy: string,
+  ): Promise<WebhookSubscription> {
+    try {
+      await this.webhook.assertDeliverableUrl(url);
+    } catch (error: any) {
+      throw new BadRequestException(error?.message || 'Invalid webhook URL');
+    }
+
+    const result = await this.pool.query(
+      `INSERT INTO webhook_subscriptions (enterprise_id, url, registered_by)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (enterprise_id, url) DO UPDATE
+         SET active = TRUE,
+             registered_by = EXCLUDED.registered_by,
+             updated_at = NOW()
+       RETURNING id, enterprise_id, url, active, last_delivery_at, last_delivery_ok`,
+      [enterpriseId, url, registeredBy],
+    );
+
+    return this.toSubscription(result.rows[0]);
+  }
+
+  async listActive(enterpriseId: string): Promise<WebhookSubscription[]> {
+    const result = await this.pool.query(
+      `SELECT id, enterprise_id, url, active, last_delivery_at, last_delivery_ok
+       FROM webhook_subscriptions
+       WHERE enterprise_id = $1 AND active
+       ORDER BY created_at ASC`,
+      [enterpriseId],
+    );
+    return result.rows.map((row: any) => this.toSubscription(row));
+  }
+
+  /**
+   * Fan a resolved contract out to every active subscription of the owning
+   * enterprise.
+   *
+   * Only ENQUEUES: this runs inside the contract-resolution outbox drain, which
+   * is synchronous with settlement, so an unreachable customer endpoint must not
+   * be able to slow or fail the money path. Delivery (and its retries) belongs to
+   * EnterpriseWebhookWorker. What can still fail here — Redis, the database — is
+   * genuine infrastructure, and the outbox is the right place to retry it.
+   *
+   * Returns the number of jobs enqueued so the caller can log a real number
+   * instead of assuming a fan-out happened.
+   */
+  async enqueueContractResolved(input: {
+    enterpriseId: string;
+    userId: string;
+    outcome: 'COMPLETED' | 'FAILED';
+    occurredAt: string;
+  }): Promise<number> {
+    const subscriptions = await this.listActive(input.enterpriseId);
+    if (subscriptions.length === 0) {
+      return 0;
+    }
+
+    const event: EnterpriseWebhookEvent = {
+      type: 'CONTRACT_RESOLVED',
+      enterpriseId: input.enterpriseId,
+      subject: this.anonymize.hashUserId(input.userId, input.enterpriseId),
+      outcome: input.outcome,
+      occurredAt: input.occurredAt,
+    };
+
+    for (const subscription of subscriptions) {
+      const job: EnterpriseWebhookJob = {
+        subscriptionId: subscription.id,
+        url: subscription.url,
+        event,
+      };
+      await this.queue.add('enterprise-webhook', job);
+    }
+
+    this.logger.log(
+      `Enqueued ${subscriptions.length} enterprise webhook delivery(ies) for ${input.enterpriseId} [${input.outcome}]`,
+    );
+    return subscriptions.length;
+  }
+
+  async recordDelivery(subscriptionId: string, ok: boolean): Promise<void> {
+    await this.pool.query(
+      `UPDATE webhook_subscriptions
+       SET last_delivery_at = NOW(),
+           last_delivery_ok = $2,
+           updated_at = NOW()
+       WHERE id = $1`,
+      [subscriptionId, ok],
+    );
+  }
+
+  private toSubscription(row: any): WebhookSubscription {
+    return {
+      id: row.id,
+      enterpriseId: row.enterprise_id,
+      url: row.url,
+      active: row.active,
+      lastDeliveryAt: row.last_delivery_at ?? null,
+      lastDeliveryOk: row.last_delivery_ok ?? null,
+    };
+  }
+}

--- a/src/api/src/modules/b2b/webhook.service.ts
+++ b/src/api/src/modules/b2b/webhook.service.ts
@@ -52,6 +52,16 @@ export class WebhookService {
     return result.success;
   }
 
+  /**
+   * Run a URL through the delivery-time SSRF guard without sending anything.
+   * Registration uses this so an internal address is refused at the call that
+   * supplies it, rather than at the settlement that would later try to reach it.
+   * Throws with the guard's own message; resolves for anything deliverable.
+   */
+  async assertDeliverableUrl(url: string): Promise<void> {
+    await this.assertSafeWebhookUrl(url);
+  }
+
   async deliverWithRetry(
     url: string,
     payload: Record<string, unknown>,

--- a/src/api/src/modules/contracts/contracts.module.ts
+++ b/src/api/src/modules/contracts/contracts.module.ts
@@ -32,6 +32,7 @@ import { EscrowModule } from "../payments/escrow.module";
 import { PayModule } from "../pay/pay.module";
 import { ReferralModule } from "../referrals/referral.module";
 import { EmailModule } from "../email/email.module";
+import { B2BModule } from "../b2b/b2b.module";
 import Redis from "ioredis";
 import { resolveCacheRedisConfig } from "../../config/runtime";
 
@@ -55,6 +56,10 @@ const redisProvider = {
     ReferralModule,
     EmailModule,
     PayModule,
+    // Contract resolution fans out to enterprise webhook subscribers; B2BModule
+    // owns that store and its delivery queue. It imports nothing, so this edge
+    // is one-way and needs no forwardRef.
+    B2BModule,
     forwardRef(() => PaymentsModule),
     EscrowModule,
   ],

--- a/src/api/src/modules/contracts/contracts.service.spec.ts
+++ b/src/api/src/modules/contracts/contracts.service.spec.ts
@@ -1271,6 +1271,84 @@ describe("ContractsService", () => {
     });
   });
 
+  // ── B2B webhook fan-out ────────────────────────────────────────
+
+  describe("enterprise webhook side effect", () => {
+    const contractRow = {
+      user_id: "user-9",
+      stake_amount: 100,
+      payment_intent_id: null,
+      metadata: {},
+    };
+
+    function effectsFor(userRow: Record<string, unknown>) {
+      return (service as any).buildContractResolutionSideEffects({
+        contractId: "contract-1",
+        outcome: "COMPLETED",
+        contractRow,
+        userRow,
+        escrowAccountId: null,
+        revenueAccountId: null,
+        bountyPoolAccountId: null,
+      });
+    }
+
+    it("should enqueue a webhook effect when the contract owner has an enterprise", () => {
+      const effect = effectsFor({
+        account_id: "acct-1",
+        enterprise_id: "ent-001",
+      }).find((e: any) => e.effectType === "B2B_WEBHOOK_CONTRACT_RESOLVED");
+
+      expect(effect).toBeDefined();
+      expect(effect.dedupeKey).toBe(
+        "contract-resolution:contract-1:COMPLETED:b2b-webhook",
+      );
+      expect(effect.payload).toEqual(
+        expect.objectContaining({
+          enterpriseId: "ent-001",
+          userId: "user-9",
+        }),
+      );
+      expect(typeof effect.payload.occurredAt).toBe("string");
+    });
+
+    it("should enqueue nothing for a consumer contract", () => {
+      const effects = effectsFor({ account_id: "acct-1", enterprise_id: null });
+      expect(
+        effects.some(
+          (e: any) => e.effectType === "B2B_WEBHOOK_CONTRACT_RESOLVED",
+        ),
+      ).toBe(false);
+    });
+
+    it("should hand the fan-out to the subscription service on dispatch", async () => {
+      const enqueueContractResolved = jest.fn().mockResolvedValue(1);
+      (service as any).enterpriseWebhooks = { enqueueContractResolved };
+
+      await (service as any).dispatchContractResolutionSideEffect({
+        id: "fx-1",
+        contract_id: "contract-1",
+        outcome: "FAILED",
+        effect_type: "B2B_WEBHOOK_CONTRACT_RESOLVED",
+        dedupe_key: "contract-resolution:contract-1:FAILED:b2b-webhook",
+        payload: {
+          enterpriseId: "ent-001",
+          userId: "user-9",
+          occurredAt: "2026-08-15T00:00:00.000Z",
+        },
+        status: "PROCESSING",
+        attempts: 1,
+      });
+
+      expect(enqueueContractResolved).toHaveBeenCalledWith({
+        enterpriseId: "ent-001",
+        userId: "user-9",
+        outcome: "FAILED",
+        occurredAt: "2026-08-15T00:00:00.000Z",
+      });
+    });
+  });
+
   // ── getContractProofs ──────────────────────────────────────────
 
   describe("getContractProofs", () => {

--- a/src/api/src/modules/contracts/contracts.service.ts
+++ b/src/api/src/modules/contracts/contracts.service.ts
@@ -32,6 +32,7 @@ import { resolveWebPublicUrl } from "../../config/runtime";
 
 import { NotificationsService } from "../notifications/notifications.service";
 import { CompliancePolicyService } from "../compliance/compliance-policy.service";
+import { WebhookSubscriptionService } from "../b2b/webhook-subscription.service";
 import {
   calculateIntegrity,
   getAllowedTiers,
@@ -92,7 +93,8 @@ type ContractResolutionSideEffectType =
   | "LEDGER_STAKE_CAPTURE"
   | "LEDGER_BOUNTY_POOL_TOPUP"
   | "TRUTH_CONTRACT_RESOLVED"
-  | "NOTIFY_CONTRACT_RESOLVED";
+  | "NOTIFY_CONTRACT_RESOLVED"
+  | "B2B_WEBHOOK_CONTRACT_RESOLVED";
 
 interface ContractResolutionSideEffectRow {
   id: string;
@@ -160,6 +162,9 @@ export class ContractsService {
     private readonly settlementService?: SettlementService,
     @Optional()
     private readonly referralService?: any,
+    @Optional()
+    @Inject(WebhookSubscriptionService)
+    private readonly enterpriseWebhooks?: WebhookSubscriptionService,
   ) {}
 
   private stakeAmountToCents(stakeAmount: number | string): number {
@@ -511,6 +516,28 @@ export class ContractsService {
       },
     });
 
+    // B2B engagement signal. Only for a contract whose owner belongs to an
+    // enterprise — a consumer contract has nobody to notify. The pseudonym is
+    // derived downstream (WebhookSubscriptionService) rather than here, so no
+    // employee identifier is ever written into an outbox payload that an operator
+    // can read; `userId` is the key that derives it, and it never leaves Styx.
+    if (userRow?.enterprise_id) {
+      effects.push({
+        contractId,
+        outcome,
+        effectType: "B2B_WEBHOOK_CONTRACT_RESOLVED",
+        dedupeKey: `${baseKey}:b2b-webhook`,
+        payload: {
+          enterpriseId: userRow.enterprise_id,
+          userId: contractRow.user_id,
+          // Stamped at resolution, not at delivery: a retry hours later must
+          // still report when the contract actually resolved.
+          occurredAt: new Date().toISOString(),
+          sideEffectKey: `${baseKey}:b2b-webhook`,
+        },
+      });
+    }
+
     return effects;
   }
 
@@ -805,6 +832,20 @@ export class ContractsService {
         }
 
         await this.notifications?.create(payload);
+        return;
+      }
+      case "B2B_WEBHOOK_CONTRACT_RESOLVED": {
+        // Undefined only where ContractsService is constructed directly (unit
+        // tests); the wired app always has it via ContractsModule -> B2BModule.
+        if (!this.enterpriseWebhooks) {
+          return;
+        }
+        await this.enterpriseWebhooks.enqueueContractResolved({
+          enterpriseId: payload.enterpriseId,
+          userId: payload.userId,
+          outcome: effect.outcome as "COMPLETED" | "FAILED",
+          occurredAt: payload.occurredAt,
+        });
         return;
       }
       default:

--- a/src/web/__tests__/security-surface.test.ts
+++ b/src/web/__tests__/security-surface.test.ts
@@ -1,0 +1,231 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// The env has to stay applied across the whole callback, not just the require:
+// SNAPSHOT is read when next.config.js is loaded, but NODE_ENV and
+// NEXT_PUBLIC_API_URL are read inside headers()/rewrites() when they are called.
+async function withConfig<T>(
+  env: Record<string, string | undefined>,
+  use: (config: any) => Promise<T> | T,
+): Promise<T> {
+  jest.resetModules();
+  const previous: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(env)) {
+    previous[key] = process.env[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    // next.config.js is CommonJS and lives outside the tsc program's include
+    // globs, so it is pulled in with require() rather than an import.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return await use(require("../next.config.js"));
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+function headersFor(env: Record<string, string | undefined>): Promise<any> {
+  return withConfig(env, (config) => config.headers());
+}
+
+function directives(csp: string): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const part of csp.split(";")) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const space = trimmed.indexOf(" ");
+    if (space === -1) {
+      map.set(trimmed, "");
+    } else {
+      map.set(trimmed.slice(0, space), trimmed.slice(space + 1));
+    }
+  }
+  return map;
+}
+
+describe("next.config security headers", () => {
+  it("applies the header set to every path in a server build", async () => {
+    const rules = await headersFor({
+      NEXT_PUBLIC_STYX_SNAPSHOT: undefined,
+      NODE_ENV: "production",
+    });
+
+    expect(rules).toHaveLength(1);
+    expect(rules[0].source).toBe("/:path*");
+
+    const keys = rules[0].headers.map((h: { key: string }) => h.key);
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        "Content-Security-Policy",
+        "X-Content-Type-Options",
+        "Referrer-Policy",
+        "X-Frame-Options",
+        "Permissions-Policy",
+      ]),
+    );
+  });
+
+  it("locks down the framing, object, and base-uri directives", async () => {
+    const rules = await headersFor({
+      NEXT_PUBLIC_STYX_SNAPSHOT: undefined,
+      NODE_ENV: "production",
+    });
+    const csp = directives(
+      rules[0].headers.find(
+        (h: { key: string }) => h.key === "Content-Security-Policy",
+      ).value,
+    );
+
+    expect(csp.get("default-src")).toBe("'self'");
+    expect(csp.get("frame-ancestors")).toBe("'none'");
+    expect(csp.get("object-src")).toBe("'none'");
+    expect(csp.get("base-uri")).toBe("'self'");
+    expect(csp.get("form-action")).toBe("'self'");
+  });
+
+  it("never ships 'unsafe-eval' in a production build", async () => {
+    const rules = await headersFor({
+      NEXT_PUBLIC_STYX_SNAPSHOT: undefined,
+      NODE_ENV: "production",
+    });
+    const csp = directives(
+      rules[0].headers.find(
+        (h: { key: string }) => h.key === "Content-Security-Policy",
+      ).value,
+    );
+
+    expect(csp.get("script-src")).toBe("'self' 'unsafe-inline'");
+    expect(csp.has("upgrade-insecure-requests")).toBe(true);
+  });
+
+  it("allows the bundler's eval source maps and HMR sockets in dev only", async () => {
+    const rules = await headersFor({
+      NEXT_PUBLIC_STYX_SNAPSHOT: undefined,
+      NODE_ENV: "development",
+    });
+    const csp = directives(
+      rules[0].headers.find(
+        (h: { key: string }) => h.key === "Content-Security-Policy",
+      ).value,
+    );
+
+    expect(csp.get("script-src")).toContain("'unsafe-eval'");
+    expect(csp.get("connect-src")).toContain("ws:");
+    // upgrade-insecure-requests would break http://localhost.
+    expect(csp.has("upgrade-insecure-requests")).toBe(false);
+  });
+
+  it("keeps the proof-media origins reachable for Fury review", async () => {
+    const rules = await headersFor({
+      NEXT_PUBLIC_STYX_SNAPSHOT: undefined,
+      NODE_ENV: "production",
+    });
+    const csp = directives(
+      rules[0].headers.find(
+        (h: { key: string }) => h.key === "Content-Security-Policy",
+      ).value,
+    );
+
+    // R2 presigned URLs live on a deploy-time host; blanking these blanks the
+    // reviewer's evidence pane.
+    expect(csp.get("img-src")).toContain("https:");
+    expect(csp.get("media-src")).toContain("https:");
+    expect(csp.get("font-src")).toContain("https://cdnjs.cloudflare.com");
+  });
+
+  it("emits no headers under the static snapshot export", async () => {
+    const rules = await headersFor({
+      NEXT_PUBLIC_STYX_SNAPSHOT: "true",
+      NODE_ENV: "production",
+    });
+    expect(rules).toEqual([]);
+  });
+
+  it("still evaluates rewrites on both build paths", async () => {
+    await withConfig(
+      { NEXT_PUBLIC_STYX_SNAPSHOT: "true", NODE_ENV: "production" },
+      async (snapshot) => {
+        expect(snapshot.output).toBe("export");
+        await expect(snapshot.rewrites()).resolves.toEqual([]);
+      },
+    );
+
+    await withConfig(
+      {
+        NEXT_PUBLIC_STYX_SNAPSHOT: undefined,
+        NEXT_PUBLIC_API_URL: "https://api.example.com/",
+        STYX_API_PUBLIC_URL: undefined,
+        NODE_ENV: "production",
+      },
+      async (server) => {
+        expect(server.output).toBeUndefined();
+        await expect(server.rewrites()).resolves.toEqual([
+          {
+            source: "/api/:path*",
+            destination: "https://api.example.com/:path*",
+          },
+        ]);
+      },
+    );
+  });
+});
+
+describe(".well-known/security.txt", () => {
+  const file = path.join(
+    __dirname,
+    "..",
+    "public",
+    ".well-known",
+    "security.txt",
+  );
+
+  function fields(): Map<string, string[]> {
+    const map = new Map<string, string[]>();
+    for (const line of fs.readFileSync(file, "utf8").split("\n")) {
+      if (!line.trim() || line.trimStart().startsWith("#")) continue;
+      const colon = line.indexOf(":");
+      const name = line.slice(0, colon).trim();
+      const value = line.slice(colon + 1).trim();
+      map.set(name, [...(map.get(name) || []), value]);
+    }
+    return map;
+  }
+
+  it("carries every field RFC 9116 requires plus the optional Policy pointer", () => {
+    const parsed = fields();
+    expect(parsed.get("Contact")).toHaveLength(1);
+    expect(parsed.get("Expires")).toHaveLength(1);
+    expect(parsed.get("Preferred-Languages")).toEqual(["en"]);
+    expect(parsed.get("Canonical")).toHaveLength(1);
+    expect(parsed.get("Policy")).toHaveLength(1);
+  });
+
+  it("has not expired and stays inside the one-year recommendation", () => {
+    const expires = new Date(fields().get("Expires")![0]);
+    expect(Number.isNaN(expires.getTime())).toBe(false);
+
+    const now = Date.now();
+    expect(expires.getTime()).toBeGreaterThan(now);
+    // RFC 9116 §2.5.5: less than a year out, so a stale file is visibly stale.
+    expect(expires.getTime()).toBeLessThan(now + 366 * 24 * 60 * 60 * 1000);
+  });
+
+  it("points every URI at https", () => {
+    const parsed = fields();
+    for (const name of ["Contact", "Canonical", "Policy"]) {
+      for (const value of parsed.get(name)!) {
+        expect(value.startsWith("https://")).toBe(true);
+      }
+    }
+  });
+});

--- a/src/web/next.config.js
+++ b/src/web/next.config.js
@@ -17,6 +17,76 @@ function getApiUrl() {
 // conditional because static export forbids a server: no rewrites, no image optimizer.
 const SNAPSHOT = process.env.NEXT_PUBLIC_STYX_SNAPSHOT === "true";
 
+// The p5 sketches in the pitch deck fetch a typeface from this CDN at runtime
+// (components/PitchDeck/ui/slides/p5Sketches.ts). It is the only third-party
+// origin the browser is allowed to reach.
+const FONT_CDN = "https://cdnjs.cloudflare.com";
+
+/**
+ * Content-Security-Policy for the app.
+ *
+ * script-src carries 'unsafe-inline' because Next hydrates through inline
+ * <script> tags (self.__next_f.push(...)) that carry no nonce. Nonces would have
+ * to be minted per request in proxy.ts and threaded into the document — and the
+ * snapshot build (output:"export") has no request at all, so the same policy
+ * could not hold on both build paths. 'unsafe-inline' is therefore a property of
+ * the framework here, not an oversight; tightening it is a nonce/middleware
+ * project, not a header edit.
+ *
+ * style-src is the same story for Tailwind's injected critical CSS plus the
+ * inline <style> block in components/PitchDeck/PitchDeck.tsx.
+ *
+ * img-src / media-src allow any https origin because Fury review renders proof
+ * media from Cloudflare R2 presigned URLs (fury.controller.ts -> generateViewUrl),
+ * whose host is deploy-time configuration. Narrowing these to 'self' would blank
+ * the reviewer's evidence pane.
+ *
+ * No Strict-Transport-Security here: max-age is not revocable by a later deploy,
+ * and the web host is env-driven (WEB_URL). HSTS belongs on the edge that owns
+ * the domain, once a domain is actually pinned.
+ */
+function buildContentSecurityPolicy(isDev) {
+  const directives = [
+    "default-src 'self'",
+    "base-uri 'self'",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+    "form-action 'self'",
+    // Dev needs 'unsafe-eval' for the bundler's eval-based source maps.
+    `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: https:",
+    "media-src 'self' blob: https:",
+    `font-src 'self' data: ${FONT_CDN}`,
+    // Dev needs the websocket origins for hot reload.
+    `connect-src 'self' ${FONT_CDN}${isDev ? " ws: wss:" : ""}`,
+    "worker-src 'self' blob:",
+    "manifest-src 'self'",
+  ];
+  if (!isDev) {
+    directives.push("upgrade-insecure-requests");
+  }
+  return directives.join("; ");
+}
+
+function securityHeaders(isDev) {
+  return [
+    {
+      key: "Content-Security-Policy",
+      value: buildContentSecurityPolicy(isDev),
+    },
+    { key: "X-Content-Type-Options", value: "nosniff" },
+    { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+    // Redundant with frame-ancestors for modern browsers, kept for the ones that
+    // only honour the legacy header.
+    { key: "X-Frame-Options", value: "DENY" },
+    {
+      key: "Permissions-Policy",
+      value: "camera=(), microphone=(), geolocation=(), payment=(), usb=()",
+    },
+  ];
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   outputFileTracingRoot: repoRoot,
@@ -40,6 +110,19 @@ const nextConfig = {
   ...(!SNAPSHOT && process.env.STYX_DOCKER_BUILD === "true"
     ? { output: "standalone" }
     : {}),
+  async headers() {
+    // Next ignores headers() under output:"export" — there is no server to emit
+    // them — so returning [] in snapshot mode keeps the export honest instead of
+    // advertising a policy that nothing enforces. The snapshot's headers belong
+    // to whatever serves out/ (a Cloudflare Pages _headers file).
+    if (SNAPSHOT) return [];
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders(process.env.NODE_ENV !== "production"),
+      },
+    ];
+  },
   async rewrites() {
     // Static export has no proxy layer. In snapshot mode the client answers from
     // bundled fixtures and never calls /api at all.

--- a/src/web/public/.well-known/security.txt
+++ b/src/web/public/.well-known/security.txt
@@ -1,0 +1,20 @@
+# Styx vulnerability disclosure (RFC 9116).
+#
+# Contact is GitHub's private advisory form rather than a mailbox: .github/SECURITY.md
+# already routes reports there ("Do NOT open a public GitHub issue"), and this repo is
+# public — an address published here would be the only new attack surface the file adds.
+#
+# Canonical names the Cloudflare Pages snapshot host (the default project in
+# scripts/demo/snapshot.sh). It is the one public origin that serves THIS Next app;
+# the Render web service URL is deploy-time configuration (WEB_URL) and has no fixed
+# value to publish. Add a second Canonical line when that host is pinned.
+#
+# Served as a static file from src/web/public/ so it survives the snapshot build too:
+# NEXT_PUBLIC_STYX_SNAPSHOT uses output:"export", which has no server to run a route
+# handler, but copies public/ verbatim into out/.
+
+Contact: https://github.com/4444J99/peer-audited--behavioral-blockchain/security/advisories/new
+Expires: 2027-08-01T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://styx-demo-snapshot.pages.dev/.well-known/security.txt
+Policy: https://github.com/4444J99/peer-audited--behavioral-blockchain/blob/main/.github/SECURITY.md


### PR DESCRIPTION
Three independent Omega / PUBLIC_PROCESS buildables. They share no code; they are one PR because each is small.

## 1. `/.well-known/security.txt` (RFC 9116)

There was no machine-readable route to the disclosure policy — `.github/SECURITY.md` is only findable by a human who already navigated to the repo.

**Placement.** Static file at `src/web/public/.well-known/security.txt`, not a route handler. The repo had no existing well-known path to follow, and the SNAPSHOT build is `output:"export"` — no server, so a route handler would not exist there. Next copies `public/` verbatim into `out/`, so one file covers `next start`, the Docker standalone image, and the static export.

**Contact.** GitHub's private advisory form, which is exactly what `SECURITY.md` already routes reports to ("Do NOT open a public GitHub issue"). No email was invented, and on a public repo a published address would have been the only new attack surface the file added.

**Canonical.** `https://styx-demo-snapshot.pages.dev/...` — the default Pages project in `scripts/demo/snapshot.sh`, the one public origin that actually serves this Next app. The Render web URL is deploy-time config (`WEB_URL`) with no fixed value to publish; the file says so in a comment and notes where a second `Canonical` line goes once that host is pinned.

## 2. CSP + companions in `src/web/next.config.js`

The config set no security headers at all. Added `headers()` returning CSP, `X-Content-Type-Options`, `Referrer-Policy`, `X-Frame-Options`, and `Permissions-Policy` for `/:path*`.

Three directive decisions worth reviewing, each commented at the directive rather than left to be rediscovered:

- **`script-src 'unsafe-inline'` is required, not sloppy.** Next hydrates through inline `<script>` tags (`self.__next_f.push(...)`) carrying no nonce. Nonces would have to be minted per request in `proxy.ts` and threaded into the document — and the snapshot build has no request at all, so the same policy could not hold on both build paths. Tightening this is a nonce/middleware project, not a header edit. `style-src` is the same story for Tailwind's injected critical CSS plus the inline `<style>` in `components/PitchDeck/PitchDeck.tsx`.
- **`img-src`/`media-src` allow `https:`** because `/fury` renders proof media from Cloudflare R2 presigned URLs (`fury.controller.ts` → `generateViewUrl`) whose host is deploy-time configuration. `'self'` there would blank the reviewer's evidence pane.
- **`font-src`/`connect-src` allow `cdnjs.cloudflare.com`** — the p5 sketches fetch a typeface from it (`components/PitchDeck/ui/slides/p5Sketches.ts`). It is the only third-party origin allowed.

`'unsafe-eval'` and the HMR websockets are dev-only; `upgrade-insecure-requests` is production-only.

**No HSTS.** `max-age` is not revocable by a later deploy and the web host is still env-driven. HSTS belongs on the edge that owns the domain, once a domain is pinned.

**Snapshot safety.** `headers()` returns `[]` when `NEXT_PUBLIC_STYX_SNAPSHOT=true`. Next ignores `headers()` under `output:"export"` regardless, so this changes nothing functionally — it keeps the export from advertising a policy nothing enforces. `__tests__/security-surface.test.ts` loads the config under both env shapes and asserts `output`, `headers()`, and `rewrites()` on each, so the "config still evaluates" requirement is a test, not a claim.

## 3. Webhook subscription persistence — now wired

`POST /b2b/webhook/register` echoed `{status:'registered'}` and stored nothing. No `webhook_subscriptions` table existed, and `WebhookService` was reachable only from the manual `/b2b/webhook/test` route — nothing in the contract lifecycle ever called it.

- **Migration `069_webhook_subscriptions.sql`** — one row per `(enterprise_id, url)`, soft-deactivated rather than deleted, with `last_delivery_at`/`last_delivery_ok` as the only support signal when an enterprise reports "we stopped receiving events" (the payload itself is never retained).
- **`WebhookSubscriptionService`** — register / listActive / enqueue / recordDelivery. Registration runs the URL through the delivery-time SSRF guard first, via a new public `WebhookService.assertDeliverableUrl`. That matters independently: without it an internal address would sit in the table until a contract resolved, and the rejection would surface as an outbox failure on someone's *settlement* rather than as a `400` on the call that made the mistake.
- **Dispatch on a real lifecycle event** — a new `B2B_WEBHOOK_CONTRACT_RESOLVED` effect in the existing contract-resolution outbox, emitted whenever the resolving contract's owner has an `enterprise_id`.
- **`EnterpriseWebhookWorker`** on a new `ENTERPRISE_WEBHOOK_QUEUE`, following the `PUSH_DISPATCH_QUEUE` pattern already in the repo.
- **`GET /b2b/webhook/subscriptions/:enterpriseId`** so a registered subscription is readable back, under the same tenant-membership check as every other B2B route.

**Why the queue is load-bearing here.** The outbox drain runs synchronously inside `resolveContract` and *rethrows* — a failing effect propagates out of contract resolution. `deliverWithRetry` does 3 attempts with exponential backoff and a 10s timeout each, so delivering inline would have put an unreachable customer endpoint on the money path and let a third party's outage surface as a 500 on a user's settlement. The outbox effect therefore only enqueues; delivery and its retries are the worker's. What can still fail at outbox time (Redis, the database) is genuine infrastructure, which is exactly what the outbox's retry/quarantine machinery is for.

**Privacy firewall.** The event carries the `AnonymizeService` pseudonym (`subject`), never the user id, and no goal, category, stake amount, or proof reference — the employer funds the pot and learns that engagement happened, not what a person is working on. `webhook-subscription.service.spec.ts` asserts the raw user id does not appear anywhere in the enqueued job.

**Wiring proof.** `B2BModule` provides + exports `WebhookSubscriptionService` and provides `EnterpriseWebhookWorker`; `ContractsModule` imports `B2BModule` (which imports nothing, so the edge is one-way and needs no `forwardRef`); `ContractsService` takes it `@Optional` and calls it from the outbox dispatcher. Callers grep clean: `B2BController` → `register`/`listActive`, `ContractsService.dispatchContractResolutionSideEffect` → `enqueueContractResolved`, `EnterpriseWebhookWorker` → `recordDelivery`.

`docs/api/api--spec.md` documents the new endpoint, the persistence semantics, and the `CONTRACT_RESOLVED` payload shape.

## Verification

Each predicate run bare, its own exit code read (no `| tail`).

| Command | Result |
|---|---|
| `src/api` — `npx jest src/modules/b2b src/modules/contracts database/migrations/migrate.spec.ts` | 25 suites, 386 tests, all pass |
| `src/api` — `npx jest src/modules/notifications src/modules/payments/settlement` | 10 suites, 91 tests, all pass (shared `queue.config.ts`) |
| `src/api` — `npx tsc --noEmit` | exit 0 |
| `src/web` — `npx jest __tests__/security-surface.test.ts __tests__/proxy.test.ts` | 27 tests, all pass |
| `src/web` — `npx tsc --noEmit` | exit 0 |
| `node scripts/validation/07-claim-drift-check.js` | passed |

### What is NOT verified

- **No SQL was executed.** Migration `069` and every query in `WebhookSubscriptionService` are asserted against a mocked `pg` Pool, like the rest of this suite. A green unit test says nothing about whether the DDL applies against the live schema or whether the statements run — that needs a real database.
- **No full `next build`.** It is heavy and was skipped deliberately. The config change is covered instead by evaluating `headers()` and `rewrites()` on both build paths in the new spec, plus `tsc --noEmit`. A deployed run is what would prove the headers actually land on responses.
- **Gate 06 (security invariant check) was not run** — it scans `src/web/.next` and `src/api/dist` and fails with `MISSING_SCAN_DIRS` without a prior build. CI runs it after `turbo run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmP1SLhXcZBmA7g4NM6PTY

## Summary by Sourcery

Add security hardening for the web frontend and wire up persistent, privacy-preserving B2B webhook delivery driven by contract resolution events.

New Features:
- Introduce persistent enterprise webhook subscriptions with registration, reactivation, and listing APIs.
- Fan out CONTRACT_RESOLVED events to subscribed enterprise webhooks via a dedicated BullMQ queue and worker.
- Add a machine-readable /.well-known/security.txt file exposing the vulnerability disclosure policy.

Enhancements:
- Apply a strict Content-Security-Policy and related security headers across all web routes in server builds, with explicit handling for dev-only requirements and static snapshots.

Documentation:
- Document enterprise webhook subscription semantics, CONTRACT_RESOLVED event payload, and new listing endpoint in the API spec.

Tests:
- Add tests validating next.config security headers, rewrites behavior for server and snapshot builds, and the contents of security.txt.
- Add unit tests for webhook subscription registration, SSRF validation, fan-out behavior, anonymization, delivery recording, and the enterprise webhook worker.
- Extend contract resolution tests to cover the new B2B webhook side effect and its delegation to the subscription service.
- Extend B2B controller tests to cover subscription persistence, authorization, and listing of active subscriptions.

Chores:
- Add a database migration to create the webhook_subscriptions table and supporting index.
- Introduce a new ENTERPRISE_WEBHOOK_QUEUE for enterprise webhook delivery jobs.