### PR TITLE
docs(legal,enterprise): the four missing legal drafts and the security whitepaper

### DIFF
--- a/docs/checklists/enterprise-sales-readiness.md
+++ b/docs/checklists/enterprise-sales-readiness.md
@@ -8,7 +8,7 @@ Every item must pass before we actively sell to enterprise customers.
 - [ ] **Security questionnaire pre-filled** — answers to the 50 most common enterprise security questions available as a PDF. Verify: doc exists in docs/enterprise/. Owner: H:LC
 - [ ] **SLA/SOW template finalized** — uptime guarantee, support response times, data processing terms. Verify: reviewed by counsel. Owner: H:LC
 - [ ] **Vendor security review packet compiled** — SOC 2 reports, penetration test summary, data flow diagram, infrastructure diagram, subprocessor list. Verify: packet sent to first prospect. Owner: H:LC + H:ENG
-- [ ] **HIPAA BAA ready to sign** — for healthcare enterprise customers. Verify: BAA template reviewed by counsel. Owner: H:LC
+- [ ] **HIPAA BAA ready to sign** — for healthcare enterprise customers. Verify: BAA template reviewed by counsel. Template drafted at [`../legal/hipaa-baa-template-DRAFT.md`](../legal/hipaa-baa-template-DRAFT.md); **counsel review has not happened**, and its §0 lists nine technical prerequisites that are not met — including that the schema has no PHI classification at all. Owner: H:LC
 
 ## Product & Infrastructure
 
@@ -24,7 +24,7 @@ Every item must pass before we actively sell to enterprise customers.
 - [ ] **Enterprise pricing finalized** — Starter $49/mo (5 clients), Growth $149/mo (25), Scale $349/mo (75), Enterprise $999+/mo. Verify: pricing page or proposal template. Owner: H:FO
 - [ ] **Outreach sequences tested** — 5-touch, 21-day cold email/LinkedIn sequence for ICP targets. Verify: 10+ prospects contacted, response rate measured. Owner: H:BD
 - [ ] **Case studies / social proof assets** — 3+ case studies from beta pilot practitioners. Verify: written, approved by subjects. Owner: H:GRO
-- [ ] **Security whitepaper published** — encryption, access control, infrastructure architecture, audit logging. Verify: available on website or upon request. Owner: H:ENG
+- [ ] **Security whitepaper published** — encryption, access control, infrastructure architecture, audit logging. Written at [`../enterprise/security-whitepaper.md`](../enterprise/security-whitepaper.md); every control names its implementing file and unimplemented controls are listed separately in its §12. Remaining: publish it on the website or into the prospect packet. Verify: available on website or upon request. Owner: H:ENG
 - [ ] **Pilot pipeline active** — 3+ enterprise prospects in active evaluation. Verify: CRM pipeline report. Owner: H:BD
 - [ ] **Referral partner program documented** — commission structure, onboarding process, partner portal. Verify: partner agreement template. Owner: H:BD
 

--- a/docs/checklists/phase-gate-public-process.md
+++ b/docs/checklists/phase-gate-public-process.md
@@ -74,13 +74,19 @@ This checklist defines the requirements for promoting Styx from PUBLIC_PROCESS t
 - [ ] Age verification: 18+ requirement enforced at account creation
 
 ### Legal Documents
-- [ ] Terms of Service published at styx.app/terms and reviewed by legal counsel
-- [ ] Privacy Policy published at styx.app/privacy and reviewed by legal counsel
-- [ ] Escrow Agreement published (terms governing stake holding and release)
-- [ ] Fury Auditor Agreement published (terms governing peer audit obligations)
-- [ ] Dispute Resolution Policy published (appeal process, panel review, timelines)
-- [ ] Cookie Policy and consent banner implemented (CCPA compliance for US users)
-- [ ] Gambling classification legal opinion on file (Styx is skill-based + peer-audited, not gambling)
+
+Every item here has two halves: **drafting** (buildable in-house) and **counsel sign-off** (blocked
+on retaining outside counsel — issue #315). A linked draft below means the drafting half is done; it
+does **not** mean the gate passes. Each draft carries a "DRAFT — not counsel-reviewed" banner and an
+open-questions section naming what only counsel can close.
+
+- [ ] Terms of Service published at styx.app/terms and reviewed by legal counsel — draft: [`../legal/terms-of-service.md`](../legal/terms-of-service.md)
+- [ ] Privacy Policy published at styx.app/privacy and reviewed by legal counsel — draft: [`../legal/privacy-policy.md`](../legal/privacy-policy.md)
+- [ ] Escrow Agreement published (terms governing stake holding and release) — draft: [`../legal/escrow-agreement-DRAFT.md`](../legal/escrow-agreement-DRAFT.md)
+- [ ] Fury Auditor Agreement published (terms governing peer audit obligations) — draft: [`../legal/fury-auditor-agreement-DRAFT.md`](../legal/fury-auditor-agreement-DRAFT.md) (**worker-classification risk is unresolved — see its §11**)
+- [ ] Dispute Resolution Policy published (appeal process, panel review, timelines) — **not drafted**
+- [ ] Cookie Policy and consent banner implemented (CCPA compliance for US users) — policy draft: [`../legal/cookie-policy-DRAFT.md`](../legal/cookie-policy-DRAFT.md); **the consent banner does not exist in `src/web`, and whether one is required on the current cookie set is a counsel question (see its §6)**
+- [ ] Gambling classification legal opinion on file (Styx is skill-based + peer-audited, not gambling) — blocked: issue #136
 
 ---
 

--- a/docs/departments/b2b/artifacts/security-questionnaire.md
+++ b/docs/departments/b2b/artifacts/security-questionnaire.md
@@ -12,12 +12,24 @@ date: "2026-03-08"
 
 ## Overview
 
-This document provides pre-filled answers to standard enterprise security questionnaire topics for Styx. Use this as a reference when responding to prospect security reviews, RFPs, or compliance audits. All answers reflect the current state of the platform as of 2026-03-08.
+This document provides pre-filled answers to standard enterprise security questionnaire topics for Styx. Use this as a reference when responding to prospect security reviews, RFPs, or compliance audits.
 
 **Product:** Styx — Peer-Audited Behavioral Accountability Platform
 **Company:** ORGANVM (sole proprietorship, US-based)
 **Infrastructure:** Render (Oregon, US), Cloudflare, Stripe
 **Data classification:** PII, financial (escrow), behavioral/health data
+
+> **This document answers the questionnaire. [`security-whitepaper.md`](../../../enterprise/security-whitepaper.md)
+> describes the architecture.** The two are deliberately non-overlapping: operational facts
+> (hosting, subprocessors, retention, backup/DR, incident response, vendor risk) live here;
+> mechanism (the hash-chained TruthLog, the ledger invariants, guards, geofencing, device
+> attestation, redaction, honeypots, consensus) lives in the whitepaper, with a file path for every
+> claim. Where an answer below needs mechanism to be credible, it links rather than restates — a
+> restated control is a control that goes stale silently. Send both documents to a prospect; send
+> the whitepaper alone to an engineer.
+>
+> The whitepaper's **§12 Roadmap** is the authoritative list of what is *not* implemented. Where
+> this questionnaire says "planned" or "not yet", §12 is the source of truth.
 
 ---
 
@@ -33,14 +45,17 @@ This document provides pre-filled answers to standard enterprise security questi
 
 ## 2. Authentication & Authorization
 
+Full mechanism, with file paths: [`security-whitepaper.md` §4](../../../enterprise/security-whitepaper.md#4-authentication-and-authorization).
+
 | Question | Answer |
 |----------|--------|
-| What authentication method is used? | Email/password with bcrypt hashing (cost factor 12). JWT tokens for session management (short-lived access tokens + refresh tokens). |
-| Is multi-factor authentication (MFA) supported? | Planned for launch. Email-based OTP for consumer accounts. TOTP (authenticator app) for practitioner and enterprise accounts. |
-| Is single sign-on (SSO) supported? | SAML 2.0 SSO is planned for the Enterprise tier ($999+/mo). Not yet implemented. |
-| What authorization model is used? | Role-based access control (RBAC) with four roles: Admin, Practitioner, Client, Fury. Each role has scoped permissions. Practitioners can only view their own clients. Furies can only view assigned contracts. |
-| How are API tokens managed? | JWT access tokens expire after 15 minutes. Refresh tokens expire after 7 days. Tokens are signed with RS256 (asymmetric keys). Revocation is supported via a token blacklist in Redis. |
-| Are passwords stored securely? | Yes. Passwords are hashed with bcrypt (cost factor 12). Plaintext passwords are never stored or logged. Password reset uses time-limited, single-use tokens. |
+| What authentication method is used? | Email/password with bcrypt hashing. JWT tokens for session management (15-minute access tokens + 7-day refresh tokens, rotated on each refresh). |
+| Is multi-factor authentication (MFA) supported? | **No — not implemented.** Whitepaper §12. |
+| Is single sign-on (SSO) supported? | **SAML 2.0 is not implemented.** An enterprise token-exchange path exists that verifies a pre-shared HS256 assertion against a dedicated secret; it is not SAML and should not be described as such. Whitepaper §4.1 and §12. |
+| What authorization model is used? | Role-based access control. Roles in the codebase: `USER`, `FURY`, `PRACTITIONER`, `ADMIN`. The distinguishing property is that role and ban status are re-read from the database on every request rather than trusted from the session token, so a demotion or ban takes effect immediately instead of at token expiry. Whitepaper §4.3. |
+| How are API tokens managed? | Access tokens expire after 15 minutes; refresh tokens after 7 days, and only their SHA-256 hash is stored. Signing is **HS256 (symmetric)** — not RS256. There is **no revocation blacklist**; revocation is achieved by refresh-token rotation plus the per-request database role/ban check. Whitepaper §4.1, §12. |
+| Are passwords stored securely? | Yes. bcrypt (`bcryptjs`), cost factor **10**. Plaintext passwords are never stored or logged. Login runs a bcrypt compare against a fixed dummy hash even for non-existent accounts so response timing does not disclose account existence. Whitepaper §4.1. |
+| How is CSRF handled? | Double-submit token derived cryptographically from the session token, so a fabricated cookie value cannot validate. Whitepaper §4.2. |
 
 ## 3. Infrastructure & Hosting
 
@@ -55,6 +70,8 @@ This document provides pre-filled answers to standard enterprise security questi
 | Is the infrastructure multi-tenant or single-tenant? | Multi-tenant application layer with logical data isolation. Each practitioner's data is scoped by organization ID. Database queries enforce tenant isolation via row-level filtering. Enterprise single-tenant deployments are not currently available. |
 
 ## 4. Data Residency & Privacy
+
+Pseudonymization, media redaction, and the export/erasure implementation: [`security-whitepaper.md` §8](../../../enterprise/security-whitepaper.md#8-privacy-engineering) and [§7.1](../../../enterprise/security-whitepaper.md#71-auditors-never-see-raw-media). Note the one structural caveat it records: the append-only audit log is immutable by database trigger, so erasure anonymizes the user record rather than rewriting log history.
 
 | Question | Answer |
 |----------|--------|
@@ -90,16 +107,21 @@ This document provides pre-filled answers to standard enterprise security questi
 
 ## 7. Compliance & Certifications
 
+The complete list of what is **not** implemented is [`security-whitepaper.md` §12](../../../enterprise/security-whitepaper.md#12-roadmap--not-yet-implemented). Do not answer a compliance question from this section without checking it.
+
 | Question | Answer |
 |----------|--------|
 | Is the platform SOC 2 Type II certified? | Not yet. SOC 2 Type II audit is planned post-launch (targeting Q4 2026). Current security practices are designed to meet SOC 2 Trust Service Criteria. |
-| Is the platform HIPAA compliant? | HIPAA Business Associate Agreements (BAAs) are planned for the Enterprise tier ($999+/mo). Current security controls (encryption, access controls, audit logging) support HIPAA requirements, but BAAs are not yet executed. Practitioners handling PHI should consult their compliance officer. |
+| Is the platform HIPAA compliant? | No — and "HIPAA compliant" is not a status that exists as a certification. Styx is not a covered entity. HIPAA Business Associate Agreements are planned for the Enterprise tier ($999+/mo); **none has been executed**, and the template is an un-reviewed draft ([`../legal/hipaa-baa-template-DRAFT.md`](../../../legal/hipaa-baa-template-DRAFT.md)), whose §0 lists the technical prerequisites that are not yet met. Practitioners handling PHI should consult their compliance officer. |
+| Is there a security whitepaper? | Yes — [`security-whitepaper.md`](../../../enterprise/security-whitepaper.md). It names the implementing file for every control it claims and lists unimplemented controls separately in §12. |
 | Is the platform PCI DSS compliant? | Styx itself does not process or store payment card data. All payment processing is handled by Stripe, which is PCI DSS Level 1 certified. Styx operates in SAQ A-EP scope (redirect/iframe integration). |
 | Is there a privacy policy? | Yes. Published at styx.app/privacy. Covers data collection, usage, sharing, retention, and user rights. |
 | Is there a terms of service? | Yes. Published at styx.app/terms. Covers user obligations, financial stakes, dispute resolution, and liability limitations. |
 | Are data processing agreements (DPAs) available? | DPAs are available for Enterprise tier customers upon request. |
 
 ## 8. Penetration Testing & Vulnerability Management
+
+Supply-chain and release-gate detail: [`security-whitepaper.md` §10](../../../enterprise/security-whitepaper.md#10-software-supply-chain-and-secure-development).
 
 | Question | Answer |
 |----------|--------|
@@ -130,7 +152,7 @@ All subprocessors are US-based. No data is shared with subprocessors for adverti
 |----------|--------|
 | Who has access to production systems? | Sole founder (admin). No shared accounts. No contractor access to production databases. |
 | Is the principle of least privilege enforced? | Yes. Application-level RBAC scopes all database queries by role. Infrastructure access is limited to the founder via Render and Cloudflare dashboards with MFA enabled. |
-| Are access logs maintained? | Yes. Render and Cloudflare maintain access logs. Application-level audit logs track all financial transactions, Fury verdicts, and admin actions. |
+| Are access logs maintained? | Yes. Render and Cloudflare maintain access logs. Application-level audit logging is the hash-chained, append-only TruthLog — financial transactions, Fury verdicts, admin actions, and device-attestation rejections all append to it, and it carries a database trigger that rejects `UPDATE` and `DELETE`. Mechanism and its limits: [`security-whitepaper.md` §2](../../../enterprise/security-whitepaper.md#2-the-truthlog-a-hash-chained-append-only-event-log). |
 | Are background checks performed? | Not applicable (sole founder). Fury auditors undergo identity verification (government ID) but are not employees. |
 | Is there security awareness training? | Not applicable at current scale (sole founder). Planned for when team expands. |
 

--- a/docs/departments/leg/REGE.md
+++ b/docs/departments/leg/REGE.md
@@ -77,7 +77,14 @@ Daily work involves reviewing Terms of Service violation flags and monitoring fo
 | L8 | Founder Agreement | `docs/legal/legal--founder-agreement-draft.md` | SHAPE | 90 | — | active |
 | L9 | Performance Wagering Analysis | `docs/legal/legal--performance-wagering.md` | SHAPE | 90 | — | active |
 | L10 | State Exclusion List | `docs/departments/leg/artifacts/state-exclusion-list.md` | SHAPE | 90 | — | dormant |
-| L11 | Fury Auditor Agreement Template | `docs/departments/leg/artifacts/fury-auditor-agreement.md` | SHAPE | 60 | — | dormant |
+| L11 | Fury Auditor Agreement Template | `docs/legal/fury-auditor-agreement-DRAFT.md` | SHAPE | 60 | 2026-08-15 | draft — counsel review pending (#315); §11 worker-classification risk open |
+| L13 | HIPAA BAA Template | `docs/legal/hipaa-baa-template-DRAFT.md` | SHAPE | 90 | 2026-08-15 | draft — do not execute; §0 lists unmet prerequisites |
+| L16 | Stake Custody and Escrow Agreement | `docs/legal/escrow-agreement-DRAFT.md` | SHAPE | 60 | 2026-08-15 | draft — counsel review pending (#315, #136) |
+| L17 | Cookie and Local Storage Policy | `docs/legal/cookie-policy-DRAFT.md` | SHAPE | 90 | 2026-08-15 | draft — consent banner not implemented (§6) |
+
+The L11 path moved to `docs/legal/` when the agreement was first drafted (2026-08-15). The
+`docs/departments/leg/artifacts/` directory holds an older partial mirror of the LEG estate and no
+copy of this artifact; `docs/legal/` is where the phase gate looks for it.
 
 ## 4. Generative Prompts (GEN:)
 

--- a/docs/enterprise/README.md
+++ b/docs/enterprise/README.md
@@ -9,6 +9,7 @@ Materials for selling Styx to therapists, coaches, clinics, and corporate wellne
 - **Ideal Customer Profile (ICP)** — Who we're selling to: breakup recovery coaches, therapists specializing in relationship trauma, corporate EAPs
 - **Outreach templates** — Cold email sequences, LinkedIn messages, conference follow-ups
 - **Security questionnaire** — Pre-filled answers to common enterprise security questions (SOC 2, data handling, encryption)
+- **[Security whitepaper](security-whitepaper.md)** — The architecture behind those answers: the hash-chained TruthLog, the double-entry ledger invariants, auth and role guards, the jurisdiction/geofence matrix, App Attest and Play Integrity verification, media redaction, and the honeypot/consensus peer-audit model. Every control names its implementing file; §12 lists what is *not* implemented. The questionnaire links here rather than restating it
 - **SLA template** — Service Level Agreement defining uptime guarantees and support response times
 - **Demo scripts** — How to walk a prospect through the platform
 - **Pricing proposals** — Templates for each B2B tier ($49 Starter / $149 Growth / $349 Scale / $999+ Enterprise)

--- a/docs/enterprise/security-questionnaire.md
+++ b/docs/enterprise/security-questionnaire.md
@@ -12,12 +12,24 @@ date: "2026-03-08"
 
 ## Overview
 
-This document provides pre-filled answers to standard enterprise security questionnaire topics for Styx. Use this as a reference when responding to prospect security reviews, RFPs, or compliance audits. All answers reflect the current state of the platform as of 2026-03-08.
+This document provides pre-filled answers to standard enterprise security questionnaire topics for Styx. Use this as a reference when responding to prospect security reviews, RFPs, or compliance audits.
 
 **Product:** Styx — Peer-Audited Behavioral Accountability Platform
 **Company:** ORGANVM (sole proprietorship, US-based)
 **Infrastructure:** Render (Oregon, US), Cloudflare, Stripe
 **Data classification:** PII, financial (escrow), behavioral/health data
+
+> **This document answers the questionnaire. [`security-whitepaper.md`](security-whitepaper.md)
+> describes the architecture.** The two are deliberately non-overlapping: operational facts
+> (hosting, subprocessors, retention, backup/DR, incident response, vendor risk) live here;
+> mechanism (the hash-chained TruthLog, the ledger invariants, guards, geofencing, device
+> attestation, redaction, honeypots, consensus) lives in the whitepaper, with a file path for every
+> claim. Where an answer below needs mechanism to be credible, it links rather than restates — a
+> restated control is a control that goes stale silently. Send both documents to a prospect; send
+> the whitepaper alone to an engineer.
+>
+> The whitepaper's **§12 Roadmap** is the authoritative list of what is *not* implemented. Where
+> this questionnaire says "planned" or "not yet", §12 is the source of truth.
 
 ---
 
@@ -33,14 +45,17 @@ This document provides pre-filled answers to standard enterprise security questi
 
 ## 2. Authentication & Authorization
 
+Full mechanism, with file paths: [`security-whitepaper.md` §4](security-whitepaper.md#4-authentication-and-authorization).
+
 | Question | Answer |
 |----------|--------|
-| What authentication method is used? | Email/password with bcrypt hashing (cost factor 12). JWT tokens for session management (short-lived access tokens + refresh tokens). |
-| Is multi-factor authentication (MFA) supported? | Planned for launch. Email-based OTP for consumer accounts. TOTP (authenticator app) for practitioner and enterprise accounts. |
-| Is single sign-on (SSO) supported? | SAML 2.0 SSO is planned for the Enterprise tier ($999+/mo). Not yet implemented. |
-| What authorization model is used? | Role-based access control (RBAC) with four roles: Admin, Practitioner, Client, Fury. Each role has scoped permissions. Practitioners can only view their own clients. Furies can only view assigned contracts. |
-| How are API tokens managed? | JWT access tokens expire after 15 minutes. Refresh tokens expire after 7 days. Tokens are signed with RS256 (asymmetric keys). Revocation is supported via a token blacklist in Redis. |
-| Are passwords stored securely? | Yes. Passwords are hashed with bcrypt (cost factor 12). Plaintext passwords are never stored or logged. Password reset uses time-limited, single-use tokens. |
+| What authentication method is used? | Email/password with bcrypt hashing. JWT tokens for session management (15-minute access tokens + 7-day refresh tokens, rotated on each refresh). |
+| Is multi-factor authentication (MFA) supported? | **No — not implemented.** Whitepaper §12. |
+| Is single sign-on (SSO) supported? | **SAML 2.0 is not implemented.** An enterprise token-exchange path exists that verifies a pre-shared HS256 assertion against a dedicated secret; it is not SAML and should not be described as such. Whitepaper §4.1 and §12. |
+| What authorization model is used? | Role-based access control. Roles in the codebase: `USER`, `FURY`, `PRACTITIONER`, `ADMIN`. The distinguishing property is that role and ban status are re-read from the database on every request rather than trusted from the session token, so a demotion or ban takes effect immediately instead of at token expiry. Whitepaper §4.3. |
+| How are API tokens managed? | Access tokens expire after 15 minutes; refresh tokens after 7 days, and only their SHA-256 hash is stored. Signing is **HS256 (symmetric)** — not RS256. There is **no revocation blacklist**; revocation is achieved by refresh-token rotation plus the per-request database role/ban check. Whitepaper §4.1, §12. |
+| Are passwords stored securely? | Yes. bcrypt (`bcryptjs`), cost factor **10**. Plaintext passwords are never stored or logged. Login runs a bcrypt compare against a fixed dummy hash even for non-existent accounts so response timing does not disclose account existence. Whitepaper §4.1. |
+| How is CSRF handled? | Double-submit token derived cryptographically from the session token, so a fabricated cookie value cannot validate. Whitepaper §4.2. |
 
 ## 3. Infrastructure & Hosting
 
@@ -55,6 +70,8 @@ This document provides pre-filled answers to standard enterprise security questi
 | Is the infrastructure multi-tenant or single-tenant? | Multi-tenant application layer with logical data isolation. Each practitioner's data is scoped by organization ID. Database queries enforce tenant isolation via row-level filtering. Enterprise single-tenant deployments are not currently available. |
 
 ## 4. Data Residency & Privacy
+
+Pseudonymization, media redaction, and the export/erasure implementation: [`security-whitepaper.md` §8](security-whitepaper.md#8-privacy-engineering) and [§7.1](security-whitepaper.md#71-auditors-never-see-raw-media). Note the one structural caveat it records: the append-only audit log is immutable by database trigger, so erasure anonymizes the user record rather than rewriting log history.
 
 | Question | Answer |
 |----------|--------|
@@ -90,16 +107,21 @@ This document provides pre-filled answers to standard enterprise security questi
 
 ## 7. Compliance & Certifications
 
+The complete list of what is **not** implemented is [`security-whitepaper.md` §12](security-whitepaper.md#12-roadmap--not-yet-implemented). Do not answer a compliance question from this section without checking it.
+
 | Question | Answer |
 |----------|--------|
 | Is the platform SOC 2 Type II certified? | Not yet. SOC 2 Type II audit is planned post-launch (targeting Q4 2026). Current security practices are designed to meet SOC 2 Trust Service Criteria. |
-| Is the platform HIPAA compliant? | HIPAA Business Associate Agreements (BAAs) are planned for the Enterprise tier ($999+/mo). Current security controls (encryption, access controls, audit logging) support HIPAA requirements, but BAAs are not yet executed. Practitioners handling PHI should consult their compliance officer. |
+| Is the platform HIPAA compliant? | No — and "HIPAA compliant" is not a status that exists as a certification. Styx is not a covered entity. HIPAA Business Associate Agreements are planned for the Enterprise tier ($999+/mo); **none has been executed**, and the template is an un-reviewed draft ([`../legal/hipaa-baa-template-DRAFT.md`](../legal/hipaa-baa-template-DRAFT.md)), whose §0 lists the technical prerequisites that are not yet met. Practitioners handling PHI should consult their compliance officer. |
+| Is there a security whitepaper? | Yes — [`security-whitepaper.md`](security-whitepaper.md). It names the implementing file for every control it claims and lists unimplemented controls separately in §12. |
 | Is the platform PCI DSS compliant? | Styx itself does not process or store payment card data. All payment processing is handled by Stripe, which is PCI DSS Level 1 certified. Styx operates in SAQ A-EP scope (redirect/iframe integration). |
 | Is there a privacy policy? | Yes. Published at styx.app/privacy. Covers data collection, usage, sharing, retention, and user rights. |
 | Is there a terms of service? | Yes. Published at styx.app/terms. Covers user obligations, financial stakes, dispute resolution, and liability limitations. |
 | Are data processing agreements (DPAs) available? | DPAs are available for Enterprise tier customers upon request. |
 
 ## 8. Penetration Testing & Vulnerability Management
+
+Supply-chain and release-gate detail: [`security-whitepaper.md` §10](security-whitepaper.md#10-software-supply-chain-and-secure-development).
 
 | Question | Answer |
 |----------|--------|
@@ -130,7 +152,7 @@ All subprocessors are US-based. No data is shared with subprocessors for adverti
 |----------|--------|
 | Who has access to production systems? | Sole founder (admin). No shared accounts. No contractor access to production databases. |
 | Is the principle of least privilege enforced? | Yes. Application-level RBAC scopes all database queries by role. Infrastructure access is limited to the founder via Render and Cloudflare dashboards with MFA enabled. |
-| Are access logs maintained? | Yes. Render and Cloudflare maintain access logs. Application-level audit logs track all financial transactions, Fury verdicts, and admin actions. |
+| Are access logs maintained? | Yes. Render and Cloudflare maintain access logs. Application-level audit logging is the hash-chained, append-only TruthLog — financial transactions, Fury verdicts, admin actions, and device-attestation rejections all append to it, and it carries a database trigger that rejects `UPDATE` and `DELETE`. Mechanism and its limits: [`security-whitepaper.md` §2](security-whitepaper.md#2-the-truthlog-a-hash-chained-append-only-event-log). |
 | Are background checks performed? | Not applicable (sole founder). Fury auditors undergo identity verification (government ID) but are not employees. |
 | Is there security awareness training? | Not applicable at current scale (sole founder). Planned for when team expands. |
 

--- a/docs/enterprise/security-whitepaper.md
+++ b/docs/enterprise/security-whitepaper.md
@@ -1,0 +1,559 @@
+---
+generated: true
+department: B2B
+artifact_id: B4
+governing_sop: "SOP--enterprise-security.md"
+phase: hardening
+product: styx
+date: "2026-08-15"
+---
+
+# Styx Security Whitepaper
+
+**STYX -- THE BLOCKCHAIN OF TRUTH**
+
+_Last updated: 2026-08-15_
+
+**Scope of this document.** This whitepaper describes the security architecture of Styx as it is
+**implemented in the codebase today**. Every control below names the file that enforces it, so a
+reviewer can read the source rather than trust the prose. Anything not yet implemented appears only
+in [§12 Roadmap](#12-roadmap--not-yet-implemented) and is labelled as such. Claims about controls we
+do not have are the failure mode this document exists to prevent; if you find a claim here that the
+code does not support, that is a defect — report it as one.
+
+**Companion documents.** [`security-questionnaire.md`](security-questionnaire.md) answers the
+standard enterprise questionnaire topics (hosting, subprocessors, retention, incident response) and
+defers to this whitepaper for architecture. [`compliance-packaging.md`](compliance-packaging.md)
+covers commercial packaging of compliance artifacts.
+
+---
+
+## 1. What Styx Is, in Security Terms
+
+Styx is a behavioral commitment platform. A user creates an **Oath** (a habit commitment), places a
+financial **stake** behind it, and submits proof of compliance. Anonymous peer auditors (**Furies**)
+review that proof and vote; a weighted consensus of their votes determines whether the Oath was kept.
+The stake is then returned or forfeited according to the outcome **and** the user's jurisdiction.
+
+That shape produces four security problems that a conventional SaaS application does not have:
+
+| Problem | Why it is unusual | Primary control |
+|---|---|---|
+| The audit trail is the product | A disputed verdict is worth money, so the log itself is an attack target | Hash-chained TruthLog (§2) |
+| Money must never be created | Settlement is automated; a bug that mints value is a solvency event | Double-entry ledger invariants (§3) |
+| Auditors are adversaries | A Fury is paid per audit and can profit by voting without looking | Honeypots + weighted consensus (§7) |
+| The legal answer varies by state | The same forfeited stake is revenue in one state and an illegal wager in another | Jurisdiction tiering + fail-closed geofence (§5) |
+
+The rest of this document works through those four, plus the conventional controls (auth, media
+privacy, device integrity) that support them.
+
+---
+
+## 2. The TruthLog: A Hash-Chained, Append-Only Event Log
+
+**Implementation:** `src/api/services/ledger/truth-log.service.ts`
+**Schema:** `src/api/database/schema.sql` (table `event_log`)
+
+Every consequential platform action — a settlement, a Fury verdict, a bounty payment, a penalty, a
+device-attestation rejection, an admin jurisdiction change, a GDPR erasure — is appended to a single
+global event log whose entries are cryptographically linked.
+
+### 2.1 The chain construction
+
+Each entry stores a `current_hash` computed as:
+
+```
+SHA256( sequence_index | event_type | timestamp | previous_hash | JSON(payload) )
+```
+
+The preimage deliberately includes `event_type` and the explicit `sequence_index`, not just the
+payload: an attacker who rewrote an event's *type* while leaving its payload intact, or who
+reordered entries, would otherwise produce a chain that still verified.
+
+### 2.2 What verification actually proves
+
+`verifyChain()` walks the log in ascending `sequence_index` order and recomputes every hash. The
+detail that matters: it recomputes each entry against the **running recomputed head**, not against
+the `previous_hash` value stored in the row. A forger who rewrites one payload and then re-links
+every subsequent `previous_hash`/`current_hash` pair to agree internally produces a chain that is
+self-consistent — and it still fails verification, because the recomputed head diverges from the
+forged links at the point of tampering.
+
+`verifyChain()` returns `{ valid, checked, corrupted[] }`. It runs:
+
+- **daily at 03:00 UTC** via `AdminScheduler.verifyHashChain()`
+  (`src/api/src/modules/admin/admin.scheduler.ts`), which logs at ERROR level on corruption; and
+- **on demand** at `GET /admin/integrity/chain`
+  (`src/api/src/modules/admin/admin.controller.ts`), an `ADMIN`-only route.
+
+### 2.3 Database-level immutability
+
+Append-only is not merely a convention in the application layer. `event_log` carries a
+`BEFORE UPDATE OR DELETE` trigger (`prevent_event_log_mutation`) that raises an exception on any
+mutation attempt. An `UPDATE` issued directly against the database — by a future code path, a
+migration, or a psql session — fails rather than silently forking the chain.
+
+### 2.4 Concurrency
+
+Appends are serialized by a transaction-scoped Postgres advisory lock
+(`pg_advisory_xact_lock`), so two concurrent writers cannot compute the same head. When a caller
+supplies its own `PoolClient`, the append **enlists in the caller's transaction** — so a Fury
+verdict and its log entry commit or roll back atomically, and a rolled-back business write cannot
+leave an orphaned "this happened" event behind.
+
+### 2.5 Honest limits
+
+- The chain is **tamper-evident, not tamper-proof.** It detects modification of history; it does
+  not prevent an actor with database write access from truncating the log's tail. There is no
+  external anchoring (no notarization to a public chain or third-party timestamping service).
+- Verification is **whole-chain**: `verifyChain()` reads every row. It is a scheduled job, not a
+  per-request check.
+- "Blockchain of Truth" is the product's name and its architectural metaphor. Styx runs **no
+  distributed ledger, no consensus network, and no cryptocurrency.** The chain is a hash-linked
+  table in a single Postgres database. Any reader who needs the distinction stated plainly has it
+  here.
+
+---
+
+## 3. The Double-Entry Ledger and the Phantom Money Test
+
+**Implementation:** `src/api/services/ledger/ledger.service.ts`
+
+All value movement — stakes, Fury bounties, Fury penalties, platform revenue — is posted through
+`recordTransaction()`, which writes a row carrying a single integer-cent `amount`, a
+`debit_account_id`, and a `credit_account_id`.
+
+### 3.1 Posting-time invariants
+
+`recordTransaction()` rejects, before any write:
+
+- a non-positive amount,
+- a non-integer amount (all money is integer cents; no floats reach the ledger), and
+- a posting whose debit and credit accounts are the same.
+
+### 3.2 Idempotency is enforced by the database, not by a check
+
+Settlement workers retry. An application-level "does this posting already exist?" check loses the
+race under concurrency. Instead, callers pass a deterministic `idempotencyKey` and the insert uses
+`ON CONFLICT (idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING` against a partial
+unique index (migration 030). A duplicate posting is collapsed by the database; the caller receives
+the pre-existing entry's id and observes idempotent success rather than a second payment.
+
+### 3.3 What `verifyLedgerIntegrity()` actually checks
+
+This is worth stating precisely, because the obvious formulation is worthless. In this schema each
+row debits and credits the *same* amount, so a global "sum of debits equals sum of credits" check is
+tautologically true and detects nothing. The implemented check asserts the three invariants that
+corruption, a bad migration, or a manual write bypassing `recordTransaction()` **can** violate:
+
+1. **Positive-amount** — no entry may have `amount <= 0` (money minted or destroyed on a posting).
+2. **Distinct-leg** — no entry may debit and credit the same account (a no-op row that masks a
+   lost posting).
+3. **Referential** — every account reference must resolve to a real row in `accounts` (an orphaned
+   reference is money in an account that does not exist).
+
+Any violation returns `balanced: false` with per-invariant counts. When
+`STYX_ENFORCE_HARD_INTEGRITY=true`, the check runs inside every posting transaction and a violation
+throws, rolling back the posting and — where a `QuarantineService` is wired — quarantining the
+account.
+
+The reporting fields `totalDebits`/`totalCredits` are retained for the audit trail. They are equal
+by construction and are **not** used to decide `balanced`.
+
+### 3.4 Honest limits
+
+- Hard-integrity enforcement is **environment-gated** (`STYX_ENFORCE_HARD_INTEGRITY`), not
+  unconditional, because the check is a full-table scan on each posting.
+- The invariants are structural. They prove no phantom entry exists; they do not prove that a
+  business rule chose the *right* accounts for a given settlement.
+
+---
+
+## 4. Authentication and Authorization
+
+**Implementation:** `src/api/src/modules/auth/`, `src/api/src/common/guards/`, `src/api/src/guards/`
+
+### 4.1 Credentials and sessions
+
+| Control | As implemented |
+|---|---|
+| Password hashing | `bcryptjs`, cost factor **10** (`BCRYPT_ROUNDS`) |
+| Access token | JWT, **HS256**, `expiresIn: 15m`, signed with `JWT_SECRET` (startup fails if unset) |
+| Refresh token | 32 random bytes; only its SHA-256 hash is stored in `refresh_tokens`; **7-day** expiry |
+| Refresh rotation | Each refresh revokes the presented token and issues a new pair |
+| Login timing | A bcrypt compare runs against a fixed dummy hash even when no user exists, so response time does not disclose account existence |
+| Enterprise SSO assertions | Verified against a **dedicated** `ENTERPRISE_SSO_SECRET`, never `JWT_SECRET`. If the dedicated secret is unprovisioned, enterprise SSO is rejected outright rather than falling back to the shared session key |
+
+Verification pins the algorithm (`algorithms: ['HS256']`), which closes the `alg: none` and
+algorithm-confusion class.
+
+### 4.2 Browser session cookies
+
+`AuthController.issueBrowserSessionCookies()` sets exactly three cookies:
+
+| Cookie | httpOnly | Purpose | Max age |
+|---|---|---|---|
+| `styx_auth_token` | yes | Access token | 15 minutes |
+| `styx_refresh_token` | yes | Refresh token | 7 days |
+| `styx_csrf_token` | **no** | Double-submit CSRF token | 15 minutes |
+
+All three are `secure` in production and `sameSite: lax`. The CSRF token is *derived from* the
+access token (`deriveCsrfToken`), so the guard validates it against the session rather than trusting
+an arbitrary attacker-supplied cookie value. It is deliberately readable by JavaScript — that is the
+double-submit pattern, not an oversight.
+
+### 4.3 Authorization
+
+Role checks are enforced by `RoleGuard` with the `@Roles(...)` decorator. Two properties matter:
+
+- **The role is read from the database on every check, not from the JWT claim.** Access tokens live
+  15 minutes; a Fury can be demoted or a user banned inside that window, and a stale claim would
+  otherwise grant privileged access until expiry.
+- **Ban status is checked in the same query.** A `BANNED` user is rejected by `RoleGuard` regardless
+  of role, and again by `BannedUserGuard` on mutation endpoints.
+
+Roles in use in the codebase: `USER` (the column default), `FURY`, `PRACTITIONER`, `ADMIN`.
+
+Every guard in the estate **fails closed**: `RoleGuard`, `BannedUserGuard`, and
+`ComplianceAccessGuard` all throw `ForbiddenException('Authentication required')` when
+`request.user` is absent rather than falling through to allow.
+
+### 4.4 Transport and request hardening
+
+`src/api/src/main.ts` applies, at bootstrap: `helmet()` security headers; a 1 MB body limit on JSON
+and urlencoded payloads; a global `ValidationPipe` with `whitelist: true` (unrecognized properties
+are stripped, not passed through); an explicit CORS allowlist from `CORS_ORIGINS` (in production,
+an unset value starts the API with **no** cross-origin browser access rather than `*`); and a
+request-correlation ID surfaced on every response. Rate limiting is `ThrottlerModule` at 60 requests
+per 60 seconds. OpenAPI/Swagger is served **only** when `NODE_ENV !== 'production'`.
+
+---
+
+## 5. Jurisdiction Control: Geofencing and the Tier Matrix
+
+**Implementation:** `src/api/services/geofencing.ts`, `src/api/services/security/geofence.service.ts`,
+`src/api/src/common/guards/geofence.guard.ts`,
+`src/api/src/modules/compliance/compliance-policy.service.ts`
+**Legal companion:** [`../legal/state-jurisdiction-matrix-DRAFT.md`](../legal/state-jurisdiction-matrix-DRAFT.md)
+
+A forfeited stake is platform revenue in some US states and an unlawful wager in others. Styx
+therefore classifies every request's jurisdiction before permitting a monetized action.
+
+### 5.1 The three tiers
+
+| Tier | Meaning | Effect on a failed Oath |
+|---|---|---|
+| `TIER_1` FULL_ACCESS | Predominance-doctrine states | Stake may be **captured** as revenue |
+| `TIER_2` REFUND_ONLY | Licensing / material-element states | Stake **must be refunded** |
+| `TIER_3` HARD_BLOCK | Prohibited or unresolvable | Monetized actions blocked entirely |
+
+`STATE_TIERS` enumerates all 50 states plus DC explicitly.
+
+### 5.2 Fail-closed by construction
+
+`classifyJurisdiction()` returns `TIER_3` for: a null geo result, any non-US country, a state code
+that fails strict normalization, and **any US state not explicitly listed in `STATE_TIERS`**. Every
+`TIER_1` jurisdiction must be enumerated; there is no permissive default. `normalizeStateCode()`
+accepts only a two-letter A–Z code or a known full state name — free text, ZIP codes, and garbage
+resolve to `null`, which fails closed.
+
+### 5.3 Settlement disposition follows the tier
+
+`resolveStakeDisposition()` (`src/api/services/escrow/disposition.ts`) is a single pure function
+that every escrow provider delegates to, so the Stripe rail and the internal-ledger rail cannot
+drift apart:
+
+- Oath **completed** → `REFUND`, always, in every tier.
+- Oath **failed** → `CAPTURE` in `TIER_1` only; `REFUND` in `TIER_2` and (defensively) `TIER_3`.
+
+### 5.4 Honest limits
+
+- IP-to-state resolution uses the bundled **GeoLite2** database via `geoip-lite`. It is an IP
+  heuristic. A VPN or a mobile carrier's egress can misplace a user; the control is a compliance
+  guardrail, not identity-grade location proof. The `x-styx-state` override header is **ignored in
+  production** and the attempt is logged.
+- There are **two** sources of jurisdiction truth: the compile-time `STATE_TIERS` map and a runtime
+  `jurisdictions` DB registry that admins can update (with TruthLog audit). Reconciliation policy
+  between them is an open governance question, tracked in the state-jurisdiction matrix.
+- The tier assignments themselves are **not counsel-signed** (issue #317). Where our own 50-state
+  survey and the code disagreed, the code was tightened to the more restrictive value — tightening
+  needs no counsel, relaxing does.
+
+---
+
+## 6. Device Integrity: App Attest and Play Integrity
+
+**Implementation:** `src/api/services/security/device-attestation.service.ts` (~1,100 lines)
+
+Proof submission comes from mobile clients. A rooted device, an emulator, or a repackaged binary
+can fabricate sensor and media evidence, so Styx verifies the *device and app* server-side before
+trusting a client.
+
+### 6.1 iOS — Apple App Attest
+
+Registration parses the CBOR attestation object with a **strict, purpose-built decoder** (no
+indefinite lengths, no tags, no floats, text-string map keys only, depth-capped at 16 — a hardened
+subset rather than a general-purpose CBOR library), then verifies:
+
+- the certificate chain against the Apple App Attest root CA (`APPLE_APP_ATTEST_ROOT_CA_PEM`);
+- the nonce binding — `SHA256(authData || SHA256(challenge))` against the credential certificate's
+  `1.2.840.113635.100.8.2` extension;
+- `rpIdHash == SHA256(APPLE_APP_ATTEST_APP_ID)`, the aaguid, and the initial counter;
+- `keyId == SHA256(credential public key)`.
+
+Only then is the **real** public key stored. Assertions are verified with `crypto.verify` against
+that stored key over `SHA256(authenticatorData || SHA256(clientDataJSON))`, with **strict counter
+monotonicity**: a replayed or rolled-back counter is REJECTED outright, never downgraded to a
+"weak but verified" verdict. `rpIdHash` comparison is constant-time.
+
+### 6.2 Android — Google Play Integrity
+
+The Play Integrity token is treated as an untrusted JWS. Signature verification against a key fetched
+and cached from the Google JWKS endpoint, expiry, and the **signed payload's** package name against
+`ANDROID_PACKAGE_NAME` are all checked **before any verdict field is read**. The client-claimed
+`requestPackageName` is never trusted on its own.
+
+Verdicts map as: `MEETS_STRONG_INTEGRITY` or `MEETS_DEVICE_INTEGRITY` → `STRONG`;
+`MEETS_BASIC_INTEGRITY` → `WEAK`; anything else → `NONE` (unverified). A `STRONG` verdict is
+**downgraded to `WEAK`** on soft risk signals — a verdict older than 15 minutes, a missing timestamp,
+or an app not `PLAY_RECOGNIZED`. `NONE` is never upgraded.
+
+### 6.3 Fail-closed configuration, and the one exception
+
+Missing attestation configuration throws at verification time. The single exception:
+**non-production** with `DEVICE_ATTESTATION_DEV_BYPASS=true` returns a simulated verdict labelled
+`deviceIntegrity: 'DEV_BYPASS'` — never `'STRONG'` — performs no writes, and appends a
+`DEVICE_ATTESTATION_DEV_BYPASS` event to the TruthLog. The bypass is ignored entirely when
+`NODE_ENV === 'production'`.
+
+Every rejection path (unknown key, counter replay, rpId mismatch, package mismatch, expired token)
+appends a typed event to the TruthLog with its risk flags.
+
+---
+
+## 7. Peer Audit Integrity: Redaction, Consensus, Honeypots, Collusion
+
+This is the section a conventional security review will not have seen before. The peer-audit layer
+has its own adversary model: the reviewer.
+
+### 7.1 Auditors never see raw media
+
+**Implementation:** `src/api/services/media/redaction.service.ts`,
+`src/api/src/modules/fury/fury.controller.ts`, `src/api/src/modules/proofs/proofs.service.ts`
+
+Proof media is processed into a redacted derivative before review. Two profiles exist:
+`FACE_BLUR` (FFmpeg face detection plus blur, falling back to a conservative **full-frame** blur when
+the detection filter is unavailable — the fallback is deliberately over-broad so PII is redacted
+even when detection fails) and `VOICE_PIVOT` (pitch shift to defeat voice identification while
+preserving intelligibility).
+
+The serving rule is keyed on the **presence of the masked asset**, never on a `redaction_status`
+string. That is a scar, not a preference: the status string takes at least four different values
+across the codebase (`MASKED`, `COMPLETED`, `NOT_APPLICABLE`, `null`), and a comparison against one
+of them fell through to the unredacted original on the production path. The current code reads
+`row.masked_media_uri ?? null` and, absent a masked asset, serves **no URL at all**.
+
+Auditors also see the subject only as a `subject_alias`, never as an identity.
+
+### 7.2 Weighted consensus
+
+**Implementation:** `src/api/src/modules/fury/consensus.engine.ts`,
+`src/api/services/fury-router/fury-router.worker.ts`,
+`src/shared/fury-logic/consensus.resolver.ts`
+
+Each proof is routed to `FURY_CONSENSUS_SIZE = 3` reviewers, selected at random from the eligible
+pool. Eligibility enforces five isolation rules in a single query — the reviewer must hold the
+`FURY` role with an integrity score of at least 20, and must **not** be the submitter, in the
+submitter's last-known state (geographic isolation), in the submitter's social guild, in the
+submitter's enterprise, or one of the submitter's accountability partners. Votes are weighted by the reviewer's history (completed audits, agreement
+with final consensus, false-accusation rate) into a voting power of 1.0–2.0×. A verdict resolves
+only when one side exceeds **66%** of total power; otherwise the outcome is `SPLIT`/`UNCERTAIN` and
+no verdict is forced. The shared `ConsensusResolver` applies the same symmetric band
+(>0.66 → BREACH, <0.33 → CLEAN, else UNCERTAIN).
+
+### 7.3 Honeypots
+
+**Implementation:** `src/shared/fury-logic/honeypot.engine.ts`,
+`src/api/services/intelligence/honeypot.service.ts`
+
+Synthetic proofs with a known-correct answer are injected into the audit stream on a **6-hourly
+cron**. A Fury who votes against the known answer is flagged, and the penalty is financial, not
+merely reputational.
+
+Generation avoids the obvious weaknesses: identifiers are `randomUUID()` (non-enumerable), sender
+hashes are 20 random bytes, and content is drawn from randomized template pools using
+`crypto.randomInt` — a CSPRNG with a uniform distribution, chosen specifically to avoid both
+`Math.random` predictability and the modulo bias of `randomBytes(1)[0] % n`. A honeypot that is
+detectable by its text is not a honeypot.
+
+### 7.4 The money side of an audit
+
+**Implementation:** `src/api/src/modules/fury/fury.worker.ts`
+
+`AUDITOR_STAKE_AMOUNT` is **200 cents ($2.00)**. A correct Fury is credited that amount from
+`FURY_BOUNTY_POOL`; an incorrect one — including a honeypot failure — is debited that amount to
+`SYSTEM_REVENUE`. Every posting carries a deterministic idempotency key
+(`consensus:{proofId}:{furyId}:bounty|penalty`) and `metadata.consensusProofId`, and the worker
+refuses to re-run the money block if any entry for that proof already exists. Each payment and
+penalty also appends `FURY_BOUNTY_PAID` / `FURY_PENALTY_CHARGED` to the TruthLog.
+
+### 7.5 Collusion detection
+
+**Implementation:** `src/api/services/security/collusion-detection.service.ts`
+
+A windowed analysis over recent audit history looks for four ring signals: pairs that co-vote at an
+abnormal rate, pairs whose verdicts are always identical, pairs whose votes land inside a tight
+temporal window (5 minutes), and pairs that appear together on assignments far more often than the
+pool size predicts. `AntiSybilService` (`src/api/src/modules/security/anti-sybil.service.ts`)
+separately correlates shared device fingerprints, shared payment instruments, and shared IPs, and
+carries an appeal path for legitimate shared-device cases.
+
+---
+
+## 8. Privacy Engineering
+
+### 8.1 Pseudonymization is keyed
+
+**Implementation:** `src/api/services/security/anonymization.service.ts`
+
+Analytics and export paths pass user records through `AnonymizationService`. Email is replaced with
+a **keyed HMAC-SHA256** over the normalized address — not a bare SHA-256, which is rainbow-table
+reversible and forms a stable cross-record join key. Names are replaced with a salted pseudonym
+token (`user-1a2b3c4d`), not initials, because initials still narrow re-identification in a small
+cohort. Phone is redacted outright and `stripe_customer_id` is deleted.
+
+The keying secret (`ANONYMIZE_SALT` or `APP_SECRET`) **fails closed in production**: if neither is
+set, the service refuses to emit a guessable hash rather than degrading silently. A clearly-labelled
+non-secret fallback exists for local development only.
+
+### 8.2 Data subject rights
+
+**Implementation:** `src/api/src/modules/users/gdpr.service.ts`
+
+`exportUserData()` assembles a structured export of the user's own records. Deletion is a two-phase
+process: a deletion request marks the account, and `processPendingDeletions()` acts only on requests
+older than **30 days**, running the erasure statements, cancelling any stored subscription, and
+appending TruthLog events throughout.
+
+Note the intentional tension with §2: TruthLog entries are immutable by database trigger. Erasure
+anonymizes the user record; it does not rewrite history. Payload minimization at append time — not
+retroactive deletion — is what keeps the two compatible.
+
+### 8.3 Secret hygiene in the repository
+
+The repository is public. A `secret-scan` CI workflow blocks any commit containing
+credential-shaped strings, and a line that is a verified false positive must carry an explicit
+`// allow-secret` marker — a deliberate, reviewable annotation rather than a silent suppression.
+
+---
+
+## 9. Financial Rails and Escrow
+
+**Implementation:** `src/api/services/escrow/stripe.service.ts`,
+`src/api/src/modules/payments/fbo-account.service.ts`
+**Legal companion:** [`../legal/escrow-agreement-DRAFT.md`](../legal/escrow-agreement-DRAFT.md)
+
+Styx never receives, stores, or transmits card numbers; Stripe holds all payment instruments.
+
+A stake is taken as a Stripe PaymentIntent with `capture_method: 'manual'` — an **authorization
+hold**, not a transfer of funds into a Styx-controlled account. At settlement the hold is either
+captured (in whole or in part) or released. Both operations carry Stripe idempotency keys, and the
+capture key incorporates the capture *amount*, because a fixed key reused with a different
+`amount_to_capture` makes Stripe replay the first request rather than perform the new one.
+
+FBO (For Benefit Of) connected accounts are registered per ISO-3166-2 jurisdiction and selected by
+the contract owner's geofence-maintained state, so custody routing follows jurisdiction. Rotation
+selects the **newest** active account, since the normal register-then-deactivate sequence leaves two
+rows active for a window.
+
+### 9.1 AML
+
+`src/api/src/modules/compliance/aml-screening.service.ts` implements: screening against an
+**internal** watchlist table; structuring detection (three or more stake postings, each under
+$3,000, inside a 24-hour window, aggregating to $10,000 or more); rapid-movement detection over a
+48-hour window; risk classification; and SAR drafting with history.
+
+Two limits, both material:
+
+- **The watchlist is internal.** There is no live OFAC feed and no third-party sanctions-list
+  integration. A user is screened against rows we put there ourselves.
+- **`detectStructuring()` does not currently execute.** Its query selects
+  `entries.amount_cents`, and the `entries` table's column is `amount`
+  (`src/api/database/schema.sql`).
+  The call therefore throws at runtime rather than returning a pattern. Every specification in this
+  estate mocks the `pg` Pool, so the unit tests pass and the defect is invisible to them — which is
+  precisely why it is disclosed here rather than left for a customer's auditor to find. Treat
+  structuring detection as **not in service** until the column reference is fixed and exercised
+  against a real database.
+
+### 9.2 Identity verification
+
+Identity verification runs through Stripe Identity. The webhook signature is verified before any
+field in the payload is trusted — a forged callback cannot flip a user to verified. A `MOCK`
+provider path exists for development and is gated unreachable in production.
+
+---
+
+## 10. Software Supply Chain and Secure Development
+
+| Control | As implemented |
+|---|---|
+| Static analysis | GitHub CodeQL (`.github/workflows/codeql.yml`) on pull requests |
+| Secret scanning | `.github/workflows/secret-scan.yml` blocks credential-shaped strings |
+| Dependency alerts | GitHub Dependabot |
+| Type safety | TypeScript strict mode; `tsc --noEmit` in CI |
+| Branch protection | Enforced and diffed by `scripts/branch-protection.sh` and `scripts/branch-protection-diff.mjs` |
+| Release gates | `scripts/validation/` — phantom-money check, simulator-spoof check, full-loop check, redacted-build check, security-invariant check, claim-drift check, compliance-artifact check, Fury-crucible simulation, realm-sync check |
+
+The **claim-drift check** (`scripts/validation/07-claim-drift-check.js`) is the gate that governs
+this document's category: it fails the build when a status document references a repository path
+that does not exist. The **compliance-artifact check**
+(`scripts/validation/08-compliance-artifact-check.sh`) blocks deploys when a required compliance
+artifact is absent, expired, or fails its content-hash comparison against the recorded value.
+
+---
+
+## 11. Operational Posture
+
+Styx is operated by a single founder. That is a material fact for an enterprise reviewer and is
+stated rather than obscured: there is no separation-of-duties between the developer and the
+production operator, no on-call rotation, and no security team.
+
+The compensating controls are structural rather than organizational — the append-only TruthLog
+records admin actions, `RoleGuard` reads authority from the database on every request, ledger
+postings are idempotent and invariant-checked, and every release gate above runs in CI rather than
+by hand. Hosting, database management, patching, and backups are Render's responsibility under a
+managed-platform model; Cloudflare fronts all public traffic. See
+[`security-questionnaire.md`](security-questionnaire.md) §3, §5, §6, and §10 for hosting,
+backup/DR, incident response, and access-control specifics.
+
+---
+
+## 12. Roadmap — Not Yet Implemented
+
+Everything in this section is **absent from the codebase today**. It is listed so that a reviewer
+can distinguish a gap we know about from one we are hiding.
+
+| Item | Status |
+|---|---|
+| SOC 2 Type II | Not started. No auditor engaged. |
+| Third-party penetration test | Not performed. |
+| Multi-factor authentication | Not implemented. |
+| SAML 2.0 SSO | Not implemented. The `exchangeEnterpriseToken` path verifies a pre-shared HS256 assertion, which is not SAML. |
+| Asymmetric (RS256) token signing | Not implemented. Session JWTs are HS256. |
+| Token revocation list | Not implemented. Revocation is by refresh-token rotation and the database-read role/ban check, not a blacklist. |
+| External anchoring of the TruthLog | Not implemented. No notarization to an external timestamping service. |
+| Live sanctions-list (OFAC) screening | Not implemented. Screening is against an internal watchlist. |
+| Structuring detection in service | **Broken, not merely absent.** `detectStructuring()` queries a column that does not exist (§9.1). Needs a fix and an integration test, not a roadmap entry. |
+| HIPAA Business Associate Agreements | Template drafted ([`../legal/hipaa-baa-template-DRAFT.md`](../legal/hipaa-baa-template-DRAFT.md)), **not counsel-reviewed, none executed**. |
+| Counsel sign-off on jurisdiction tiering | Open — issues #315 (retain counsel) and #317 (matrix sign-off). |
+| Responsible disclosure policy | Not published. No `security.txt` yet. |
+| Disaster-recovery test | Not performed. |
+
+---
+
+## 13. Reporting a Vulnerability
+
+Until a published disclosure policy exists (§12), report suspected vulnerabilities by opening a
+GitHub security advisory on `4444J99/peer-audited--behavioral-blockchain`. Please do not open a
+public issue containing exploit detail.

--- a/docs/legal/cookie-policy-DRAFT.md
+++ b/docs/legal/cookie-policy-DRAFT.md
@@ -1,0 +1,162 @@
+---
+generated: true
+department: LEG
+artifact_id: L17
+governing_sop: "SOP--legal-documentation.md"
+phase: hardening
+product: styx
+date: "2026-08-15"
+---
+
+# Cookie and Local Storage Policy (Draft)
+
+**STYX -- THE BLOCKCHAIN OF TRUTH**
+
+_Last updated: 2026-08-15_
+_Effective date: [TBD -- prior to beta launch]_
+
+> **DRAFT — NOT COUNSEL-REVIEWED.**
+> This is an internal draft authored from the platform's own implementation. It has **not** been
+> reviewed by qualified legal counsel and is **not** a legally binding instrument. Outside counsel
+> has not been retained (issue **#315**). Do not publish it at `styx.app/cookies` until counsel has
+> reviewed it and until the enumeration below has been re-derived against the shipping build.
+
+Named by the phase gate at `docs/checklists/phase-gate-public-process.md` §2 → Legal Documents:
+*"Cookie Policy and consent banner implemented (CCPA compliance for US users)."* This document is
+the policy half. **The consent banner is not implemented** — see §6.
+
+**Why this is a separate document.** `docs/legal/privacy-policy.md` contains no cookie section — the
+word does not appear in it — so there was nothing to extend. When the Privacy Policy goes to counsel,
+this document should be reviewed alongside it, and counsel may prefer to fold it in as a section
+rather than publish it separately.
+
+---
+
+## 1. What This Covers
+
+This policy describes the cookies and browser storage the Styx web application uses. It covers two
+mechanisms:
+
+- **Cookies** — small values the server sets in your browser and the browser sends back with each
+  request.
+- **Local storage** — values the application stores in your browser and reads back locally. Local
+  storage is **never transmitted to our servers**, but it is disclosed here because it is your
+  device and you are entitled to know what is on it.
+
+## 2. Cookies We Set
+
+The web application sets exactly **three** cookies. All three are strictly necessary to operate an
+authenticated session. **There are none other.**
+
+| Name | Purpose | Readable by scripts | Lifetime |
+|---|---|---|---|
+| `styx_auth_token` | Your session access token. Identifies you to the API on each request. | No (`httpOnly`) | 15 minutes |
+| `styx_refresh_token` | Renews your session without making you log in again. | No (`httpOnly`) | 7 days |
+| `styx_csrf_token` | Cross-site request forgery protection. The application reads it and echoes it back on write requests so we can confirm the request came from our own pages. | **Yes** — deliberately | 15 minutes |
+
+All three are set with the `Secure` attribute in production (transmitted only over HTTPS) and
+`SameSite=Lax` (not sent on cross-site requests from other websites).
+
+`styx_csrf_token` is script-readable by design. That is the "double-submit" CSRF pattern: the value
+is derived cryptographically from your session token, so an attacker who can guess or fabricate a
+cookie value cannot produce one that validates against your session. Its readability is a property
+of the defence, not a weakness in it.
+
+All three cookies are cleared when you log out.
+
+## 3. Cookies We Do Not Set
+
+We state these explicitly because their absence is the point:
+
+- **No advertising cookies.** None. We run no advertising and no ad networks.
+- **No third-party tracking cookies.** No Google Analytics, no Meta Pixel, no advertising SDK, no
+  cross-site tracker.
+- **No analytics cookies.** Product analytics, where collected, are collected server-side, not by a
+  browser tag.
+- **No cookies that identify you across other websites.**
+
+Consequently there is **no sale or sharing of personal information** through cookies within the
+meaning of the CCPA/CPRA, and no "Do Not Sell or Share My Personal Information" cookie mechanism to
+offer, because there is nothing to opt out of.
+
+## 4. Local Storage
+
+The web application stores the following in your browser's local storage. These values stay on your
+device.
+
+| Key | Purpose | Category |
+|---|---|---|
+| `styx_email_notifs`, `styx_push_notifs` | Your notification preferences as shown in Settings | Preference |
+| `styx_cloak_enabled` | Whether the privacy cloak display mode is on | Preference |
+| `styx-chat-messages` | Your in-app assistant conversation, so it survives a page reload | Functional |
+| `styx.snapshot.persona` | Which surface persona the demo view is showing | Functional |
+| `styx.guidedTour.audience`, `styx.guidedTour.open` | Guided-tour state, so the tour does not restart on every page | Functional |
+| `styx.guidedTour.sessionId`, `styx.guidedTour.name` | A random per-session identifier for guided-tour feedback | Functional |
+| `styx.guidedTour.telemetry` | Set to `off` to disable guided-tour telemetry | **Opt-out control** |
+
+Clearing your browser's site data removes all of these. Doing so logs you out and resets these
+preferences; it does not delete anything from your account.
+
+## 5. Your Choices
+
+- **Blocking cookies.** You may block or delete cookies in your browser. Blocking
+  `styx_auth_token` or `styx_refresh_token` will prevent you from staying logged in — they are
+  strictly necessary, so there is no functional version of the site without them. Blocking
+  `styx_csrf_token` will cause write requests to be rejected.
+- **Guided-tour telemetry.** Set `styx.guidedTour.telemetry` to `off` (the tour's own settings
+  control does this) and no tour telemetry is sent.
+- **Everything else.** Because we set no advertising, analytics, or third-party cookies, there is
+  no further consent to grant or withdraw. If that ever changes, this policy changes first, and a
+  consent mechanism ships with it.
+
+## 6. Consent Banner — Not Yet Implemented
+
+> **INTERNAL NOTE — remove before publication, but do not remove the underlying gap.**
+>
+> The phase gate names *"Cookie Policy and consent banner implemented"*. **No consent banner exists
+> in the web application** — a search of `src/web` finds no consent component of any kind.
+>
+> The substantive question for counsel is whether one is required *given the enumeration above*.
+> Strictly-necessary cookies do not require opt-in consent under CCPA/CPRA, and there are no
+> advertising, analytics, or third-party cookies to consent to. On the facts as implemented today,
+> the honest position is that a banner may be unnecessary and a **link to this policy in the site
+> footer** may be sufficient.
+>
+> That is an argument, not a determination. Counsel must decide. Two conditions would flip it
+> immediately: (a) adding any analytics or advertising tag, or (b) serving the EU/UK, where the
+> ePrivacy Directive's consent requirement is broader than CCPA's. The Platform is US-only today
+> (non-US traffic is hard-blocked by the geofence), which is why (b) does not currently bite.
+>
+> Whichever way counsel decides, the footer link is required either way and is not yet present.
+
+## 7. Changes
+
+We will update this policy when the cookies or storage keys we use change, and update the date at
+the top. Material changes will be notified in the application.
+
+## 8. Contact
+
+Questions about this policy: [contact address TBD — see `docs/legal/privacy-policy.md` for the
+canonical contact block once it is finalized].
+
+---
+
+## Drafting Notes (internal — remove before publication)
+
+| Item | Status |
+|---|---|
+| Outside counsel retained | **No** — issue #315 |
+| Consent banner implemented | **No** — §6 |
+| Footer link to this policy | **Not present** |
+| Published at `styx.app/cookies` | **No** |
+| Enumeration re-derived against shipping build | **Required before publication** — the tables in §2 and §4 are exhaustive as of 2026-08-15 and go stale the moment a cookie or storage key is added |
+
+**Source of every entry in this draft:**
+`src/api/src/modules/auth/auth.controller.ts` (§2 — the three cookies, their flags and lifetimes),
+`src/web/services/api-client.ts` (§2 — the double-submit CSRF pattern),
+`src/web/app/settings/page.tsx`, `src/web/components/chat/ChatInterface.tsx`,
+`src/web/components/guided-tour/GuidedTour.tsx`, `src/web/lib/guided-tour/feedback.ts`,
+`src/web/services/snapshot.ts` (§4 — the local storage keys).
+A search for advertising, analytics, and third-party tags across `src/web` returned nothing, which
+is the basis for §3. **Re-run that search before publishing** — §3 is the strongest claim in this
+document and the easiest to invalidate by adding one script tag.

--- a/docs/legal/escrow-agreement-DRAFT.md
+++ b/docs/legal/escrow-agreement-DRAFT.md
@@ -1,0 +1,205 @@
+---
+generated: true
+department: LEG
+artifact_id: L16
+governing_sop: "SOP--legal-documentation.md"
+phase: hardening
+product: styx
+date: "2026-08-15"
+---
+
+# Stake Custody and Escrow Agreement (Draft)
+
+**STYX -- THE BLOCKCHAIN OF TRUTH**
+
+_Last updated: 2026-08-15_
+_Effective date: [TBD -- prior to real-money activation]_
+
+> **DRAFT — NOT COUNSEL-REVIEWED.**
+> This is an internal draft authored from the platform's own implementation. It has **not** been
+> reviewed by qualified legal counsel and is **not** a legally binding instrument. Outside counsel
+> has not yet been retained (issue **#315**); the gambling-classification opinion this agreement
+> depends on is issue **#136**. Do not publish, execute, or present this document to a user,
+> a regulator, or a payment processor until counsel has reviewed and revised it.
+
+Named by the phase gate at `docs/checklists/phase-gate-public-process.md` §2 → Legal Documents:
+*"Escrow Agreement published (terms governing stake holding and release)."*
+
+Companion documents: `docs/legal/terms-of-service.md` (§ Definitions, § Vault),
+`docs/legal/legal--performance-wagering.md` (the classification analysis this agreement rests on),
+`docs/legal/appendices/fbo-architecture.md` (the fund-flow diagram),
+`docs/legal/state-jurisdiction-matrix-DRAFT.md` (the tier assignments §4 depends on).
+
+---
+
+## 1. Purpose and Parties
+
+This Agreement governs how [ORGANVM Entity TBD] ("Company", "we", "us") holds and releases the
+financial deposit a User places behind an Oath ("Stake"). It is incorporated by reference into the
+Terms of Service and applies to every Oath created on the Platform.
+
+**"User"** is the individual who creates an Oath and places a Stake.
+**"Platform"** is the Styx behavioral contract platform.
+**"Processor"** is Stripe, Inc., the payment services provider through which all Stakes are
+authorized, captured, and released.
+**"Vault"** is the term the Terms of Service uses for the custody arrangement described in §2. It is
+a product term, not a separate legal entity.
+
+## 2. What a Stake Actually Is
+
+**This section is the one most likely to be misunderstood, so it states the mechanism before the
+consequences.**
+
+### 2.1 A Stake is an authorization hold, not a transfer
+
+When a User creates an Oath, the Company does **not** take possession of the User's money. The
+Company creates a payment authorization with the Processor using a manual-capture instruction. The
+effect on the User's payment instrument is a **hold** — the amount is reserved against the User's
+available credit or balance and is unavailable to the User for the duration of the Oath, but it is
+**not** debited, and it does **not** move into any account controlled by the Company.
+
+Funds move exactly once, at settlement, and only in the direction §3 specifies.
+
+### 2.2 Consequences of §2.1
+
+- **No interest, yield, or appreciation accrues on a Stake**, because there is no principal in a
+  Company-held account to accrue on.
+- **A Stake is not a deposit** with the Company in the banking sense, is not insured, and is not a
+  claim against the Company's assets.
+- **A Stake is not an investment.** A successful Oath results in no money changing hands at all.
+  There is no mechanism by which a User can receive more than they staked.
+- The Company's records of Stakes are an internal double-entry ledger (§6). Ledger balances are an
+  accounting record; the authoritative record of the hold is the Processor's.
+
+### 2.3 For-Benefit-Of accounts
+
+Where a Stake is captured (§3.2), settlement routes through a For Benefit Of ("FBO") connected
+account registered with the Processor for the User's jurisdiction. FBO accounts are registered per
+ISO-3166-2 subdivision and selected at settlement from the User's recorded jurisdiction. Captured
+funds held in an FBO account are held off the Company's balance sheet.
+
+> **OPEN QUESTION FOR COUNSEL — FBO characterization.** Whether the FBO structure is sufficient to
+> keep captured Stakes off the Company's balance sheet as a matter of law, and whether it triggers
+> money transmitter licensing in any jurisdiction, is not resolved. This draft describes the
+> mechanism; it does not opine on its legal characterization.
+
+## 3. Release of a Stake
+
+### 3.1 Successful Oath
+
+If the Oath resolves as completed, the authorization is **released in full**. No amount is captured.
+The hold on the User's payment instrument lifts on the Processor's own schedule, which is typically
+within three to five business days and is outside the Company's control.
+
+### 3.2 Failed Oath
+
+If the Oath resolves as failed, the disposition of the Stake depends on the User's jurisdiction:
+
+| Jurisdiction tier | Disposition of a failed Oath's Stake |
+|---|---|
+| **TIER_1** (full access) | **Captured.** The authorization is captured and the amount becomes Company revenue. |
+| **TIER_2** (refund-only) | **Released.** The authorization is released in full. No amount is captured. |
+| **TIER_3** (hard-blocked) | **Released.** An Oath should never exist in this tier; if one does, the Stake is released. |
+
+This is not discretionary. It is enforced by a single function in the codebase
+(`resolveStakeDisposition` in `src/api/services/escrow/disposition.ts`) to which every payment rail
+delegates, so the answer cannot differ between the Processor rail and the internal ledger.
+
+### 3.3 Partial capture
+
+The Platform supports capturing less than the full authorized amount. Where a partial capture
+occurs, the balance of the authorization is released. The Company will disclose the basis for any
+partial capture in the User's settlement record.
+
+### 3.4 Jurisdiction is determined at settlement
+
+The tier in §3.2 is determined from the jurisdiction the Platform has recorded for the User at the
+time of settlement, resolved by IP geolocation. Jurisdiction resolution is documented, with its
+known limits, in `docs/enterprise/security-whitepaper.md` §5.
+
+> **OPEN QUESTION FOR COUNSEL — jurisdiction at creation vs. at settlement.** A User may create an
+> Oath in one tier and settle in another. The implementation reads the User's last known state at
+> settlement. Counsel must confirm whether the governing jurisdiction should instead be fixed at
+> Oath creation, and what disclosure a User is owed if the two differ.
+
+## 4. Kill Switch and Fail-Safe Disposition
+
+The Platform carries an administrative kill switch that forces **every** settlement to release
+rather than capture, regardless of tier. Its state is stored durably and re-read before each
+settlement, and if that store is unreachable the switch **defaults to on** — releasing is always
+lawful, capturing while the switch's state is unknowable is not. Where the Platform cannot
+determine a User's jurisdiction, the disposition likewise defaults to release. In every ambiguous
+case, the Stake returns to the User.
+
+The Company may exercise the kill switch without notice where it believes, in good faith, that
+continued capture would be unlawful in any jurisdiction in which it operates.
+
+## 5. Disputes and Appeals
+
+A User may appeal a failed-Oath determination through the Platform's dispute process before the
+Stake is captured. Where an appeal is pending, the authorization is held rather than captured, up to
+the limits the Processor imposes on authorization lifetime.
+
+> **OPEN QUESTION FOR COUNSEL — authorization expiry during an appeal.** Payment authorizations
+> expire (commonly seven days). An appeal that outlasts the authorization forces a choice between
+> re-authorizing, capturing before the appeal resolves, or releasing. **The Platform has no
+> implemented policy for this case today**: a contract whose settlement cannot be completed is
+> parked in a `RECONCILE_REQUIRED` state and swept every fifteen minutes; a contract that exhausts
+> its retry budget is left for an operator rather than settled automatically. Counsel must state
+> the correct default, and it must then be implemented before this Agreement is published.
+
+Nothing in this Agreement limits the User's rights against their card issuer or bank, including the
+right to dispute a charge.
+
+## 6. Records and Auditability
+
+Every movement of value is recorded as a double-entry posting in the Company's internal ledger, and
+every settlement event is appended to a hash-chained, append-only audit log. Postings carry
+deterministic idempotency keys so that a retried settlement cannot post twice. The ledger is
+subjected to automated integrity checks; the audit log's hash chain is verified on a daily schedule.
+
+The technical description of both mechanisms, including their limits, is in
+`docs/enterprise/security-whitepaper.md` §2 and §3. A User may request the settlement record for
+their own Oath.
+
+## 7. Fees
+
+No Platform Fee is charged during the beta. Where a Platform Fee applies, it is disclosed at the
+point of purchase, is separate from the Stake, and is non-refundable. **A Platform Fee is never
+taken from the Stake.**
+
+## 8. What This Agreement Does Not Do
+
+- It does not make the Company a bank, a trustee, or a fiduciary.
+- It does not create a security, an investment contract, or a financial instrument.
+- It does not guarantee the timing of a release, which depends on the Processor and the User's card
+  issuer.
+- It does not survive a determination by counsel or a regulator that the underlying model requires
+  a licence the Company does not hold. In that event the Company will release all outstanding
+  Stakes.
+
+## 9. Amendment
+
+The Company will provide notice of any material change to this Agreement before it applies to a new
+Oath. A change never applies retroactively to an Oath already in progress.
+
+---
+
+## Drafting Notes (internal — remove before publication)
+
+| Item | Status |
+|---|---|
+| Outside counsel retained | **No** — issue #315 |
+| Gambling-classification opinion on file | **No** — issue #136 |
+| Jurisdiction tier assignments signed off | **No** — issue #317 |
+| Entity formed / named | **No** — "[ORGANVM Entity TBD]" throughout |
+| Money transmitter analysis | **Not performed** |
+| Processor high-risk underwriting approved | Tracked at `docs/checklists/phase-gate-public-process.md` §2 |
+
+**Source of every factual claim about mechanism in this draft:**
+`src/api/services/escrow/stripe.service.ts` (manual-capture holds, capture, partial capture,
+idempotency), `src/api/services/escrow/disposition.ts` (§3.2 table),
+`src/api/src/modules/payments/fbo-account.service.ts` (§2.3),
+`src/api/services/escrow/dispute.service.ts` (§5),
+`src/api/services/ledger/ledger.service.ts` and `src/api/services/ledger/truth-log.service.ts` (§6).
+If any of those change, this draft is stale.

--- a/docs/legal/fury-auditor-agreement-DRAFT.md
+++ b/docs/legal/fury-auditor-agreement-DRAFT.md
@@ -1,0 +1,222 @@
+---
+generated: true
+department: LEG
+artifact_id: L11
+governing_sop: "SOP--legal-documentation.md"
+phase: hardening
+product: styx
+date: "2026-08-15"
+---
+
+# Fury Auditor Agreement (Draft)
+
+**STYX -- THE BLOCKCHAIN OF TRUTH**
+
+_Last updated: 2026-08-15_
+_Effective date: [TBD -- prior to beta launch]_
+
+> **DRAFT — NOT COUNSEL-REVIEWED.**
+> This is an internal draft authored from the platform's own implementation. It has **not** been
+> reviewed by qualified legal counsel and is **not** a legally binding instrument. Outside counsel
+> has not been retained (issue **#315**). This agreement carries a **worker-classification risk that
+> only counsel can assess** — see §11, which is the reason this document must not be executed as
+> drafted. Do not present it to a prospective auditor before counsel review.
+
+Named by the phase gate at `docs/checklists/phase-gate-public-process.md` §2 → Legal Documents:
+*"Fury Auditor Agreement published (terms governing peer audit obligations)."*
+Registered as artifact **L11** in `docs/departments/leg/REGE.md`.
+
+Companion documents: `docs/legal/terms-of-service.md` (§ Definitions — "Fury", "Bounty",
+"Integrity Score"), `docs/enterprise/security-whitepaper.md` §7 (the technical description of the
+audit pipeline every clause below describes).
+
+---
+
+## 1. The Engagement
+
+This Agreement is between [ORGANVM Entity TBD] ("Company") and you ("Auditor", "Fury"). By
+accepting an audit assignment on the Styx platform ("Platform") you agree to these terms.
+
+You are engaged as an **independent contractor**, not an employee, partner, joint venturer, or agent
+of the Company. Nothing in this Agreement creates an employment relationship.
+
+> **This characterization is the drafting risk in this document, not a settled fact. See §11.**
+
+## 2. What an Auditor Does
+
+The Platform routes redacted proof submissions to a panel of auditors. You review the material you
+are shown and render a verdict — `PASS` or `FAIL` — against the criteria displayed with the
+assignment.
+
+You are told, and you agree, that:
+
+- **You choose whether to accept any assignment.** There is no minimum number of audits, no
+  schedule, no shift, and no requirement to be available at any time.
+- **You review anonymized material.** You see a subject alias, never the subject's identity.
+- **You never receive the original media.** The Platform serves you a redacted derivative — faces
+  blurred, voices pitch-shifted. If no redacted derivative exists, the Platform serves you nothing
+  at all rather than the original. This is enforced in code, not by policy.
+- **You are one of a panel.** Each proof is reviewed by three auditors. No single verdict decides an
+  outcome.
+
+## 3. Eligibility and Isolation
+
+To receive assignments you must hold the auditor role on an active account with an Integrity Score
+of at least 20.
+
+The Platform will **not** assign you a proof where you are the submitter, are recorded in the same
+state as the submitter, share the submitter's social guild, share the submitter's enterprise, or are
+one of the submitter's accountability partners. These exclusions are applied automatically at
+routing time. You must additionally decline any assignment where you recognize the subject, and
+disclose it through the Platform.
+
+## 4. Compensation
+
+| Term | Value |
+|---|---|
+| Bounty per correct audit | **$2.00** (200 cents) |
+| Penalty per incorrect audit | **$2.00** (200 cents) |
+| Payment trigger | Panel consensus resolves the proof |
+| Payment method | Credit to your Platform ledger account |
+
+An audit is "correct" when your verdict matches the panel's resolved consensus outcome. An audit is
+"incorrect" when it does not. **Both directions are financial**: a correct audit credits your
+account from the bounty pool, and an incorrect audit debits your account to Company revenue.
+
+You are not paid for time spent, for assignments you decline, or for a proof whose panel does not
+reach consensus.
+
+### 4.1 Symmetric stake — read this before accepting an assignment
+
+The penalty is the mechanism that makes peer audit work: an auditor who votes without looking would
+otherwise earn a bounty at the same rate as one who does. It also means **you can end an audit
+session with a negative balance.** Do not accept assignments you are not prepared to review
+carefully.
+
+### 4.2 Payment integrity
+
+Every bounty and penalty is a double-entry ledger posting carrying a deterministic idempotency key,
+and every one is recorded in the Platform's append-only audit log. A retried settlement cannot pay
+you twice, and it cannot penalize you twice. You may request the ledger record for any audit you
+performed.
+
+## 5. Quality Control — Honeypots
+
+**The Platform injects synthetic proof submissions with known-correct answers into the audit
+stream.** They are designed to be indistinguishable from genuine submissions, they are injected on a
+recurring schedule, and you will not be told which assignments are synthetic.
+
+An incorrect verdict on a synthetic proof is penalized on the same terms as §4. This is disclosed to
+you here, in advance, and by accepting an assignment you consent to it.
+
+## 6. Collusion and Manipulation
+
+You may not coordinate your verdicts with any other auditor, operate more than one auditor account,
+or solicit or accept anything of value in exchange for a verdict.
+
+The Platform runs automated analysis for coordination signals — auditors who co-vote at abnormal
+rates, whose verdicts are always identical, whose votes land inside a tight time window, or who
+appear together on assignments far more often than random assignment predicts — and separately
+correlates shared device fingerprints, shared payment instruments, and shared IP addresses.
+
+A detection is not a determination. Where the Platform flags your account you will be notified and
+may appeal; a shared household device is a legitimate explanation and the Platform carries an appeal
+path for it. Where coordination is confirmed, the Company may reverse bounties, suspend, or
+permanently terminate your access.
+
+## 7. Confidentiality
+
+Everything you see in an assignment is confidential. You may not record, screenshot, copy,
+republish, or disclose any proof material, subject alias, or verdict outside the Platform.
+
+This obligation survives termination of this Agreement indefinitely, because the material's
+sensitivity does not expire.
+
+## 8. Intellectual Property
+
+Your verdicts, and any notes you submit with them, are licensed to the Company for the operation of
+the Platform, including for computing Integrity Scores and consensus outcomes. You retain no rights
+in proof material, which never belonged to you.
+
+You acquire no rights in the Platform, its software, or its data.
+
+## 9. Termination
+
+Either party may terminate this Agreement at any time, for any reason, with or without notice.
+On termination:
+
+- Bounties already earned on resolved proofs remain payable.
+- Assignments in flight are reassigned.
+- Your confidentiality obligation (§7) survives.
+
+The Company may suspend your access immediately, without prior notice, on a good-faith suspicion of
+collusion, account sharing, or disclosure of proof material.
+
+## 10. Taxes
+
+You are responsible for all taxes on amounts you receive. The Company does not withhold. Where
+required, the Company will issue an IRS Form 1099 for a calendar year in which your payments meet
+the applicable reporting threshold. You must provide accurate taxpayer information before payout.
+
+## 11. Worker Classification — The Open Risk
+
+> **THIS SECTION IS FOR COUNSEL, NOT FOR THE AUDITOR. It must be removed or rewritten before this
+> agreement is presented to anyone.**
+
+The Company characterizes auditors as independent contractors (§1). That characterization is
+**untested** and is the single largest legal exposure in this document. The relevant analysis is the
+ABC test (California, Illinois, New Jersey, Massachusetts, and others) and the federal
+economic-reality test. Applying the ABC test to the facts as implemented:
+
+| Prong | Facts as the Platform actually operates | Assessment |
+|---|---|---|
+| **(A)** Free from control and direction | Auditors set no schedule, accept no minimum volume, and can decline any assignment. **But** the Company sets the review criteria, sets the price unilaterally, routes the work, grades the output against a hidden answer key (§5), and penalizes disagreement financially. | **Contested.** The honeypot-and-penalty mechanism is a strong control signal. |
+| **(B)** Work outside the usual course of business | Peer audit **is** the product. Styx does not exist without Fury verdicts. | **Fails on its face.** |
+| **(C)** Independently established trade | Auditors have no independent auditing business, no other clients, no ability to set their own rate, and cannot subcontract. | **Fails.** |
+
+**Prong B is not arguable.** Any state applying a strict ABC test is likely to classify Furies as
+employees on these facts. The disclosed exposure is payroll taxes, minimum wage (note that the $2.00
+bounty is per audit, not per hour, and an auditor who reviews carefully may earn below minimum wage
+for time spent), overtime, workers' compensation, and unemployment insurance — retroactively.
+
+**Open questions counsel must answer before this Agreement is executed:**
+
+1. Does the ABC test's prong B foreclose contractor classification for Furies in ABC-test states?
+   If so, is the answer geographic exclusion, an employment model, or a redesign of the engagement?
+2. Does the honeypot-and-penalty mechanism (§5) constitute control under prong A, and does
+   disclosing it in advance change that?
+3. Is a symmetric financial penalty on a contractor's own funds (§4.1) enforceable? Is it a
+   wage deduction in any state?
+4. Is an arbitration clause with a class-action waiver appropriate and enforceable here? **This
+   draft deliberately contains no arbitration clause** — drafting one without counsel would be
+   worse than omitting it.
+5. What is the 1099 threshold exposure at projected auditor volumes, and does the ledger-credit
+   payment model (§4) create constructive receipt before withdrawal?
+
+The registry (`docs/departments/leg/REGE.md`) already schedules this analysis as quarterly item
+**Q4** and generative prompt `GEN:fury-classification-review`, with the output landing on this
+document. This section is the placeholder that review fills.
+
+---
+
+## Drafting Notes (internal — remove before publication)
+
+| Item | Status |
+|---|---|
+| Outside counsel retained | **No** — issue #315 |
+| Worker-classification memo | **Not performed** — §11 is the open question, not the answer |
+| Arbitration clause | **Deliberately absent** — requires counsel |
+| Entity formed / named | **No** — "[ORGANVM Entity TBD]" throughout |
+| Non-compete | **Deliberately absent** — the REGE backlog names one; enforceability against a $2.00-per-audit contractor is doubtful and it is not drafted here |
+
+**Source of every factual claim about mechanism in this draft:**
+`src/api/services/fury-router/fury-router.worker.ts` (§3 isolation rules, panel routing),
+`src/api/src/modules/fury/consensus.engine.ts` (§2 panel size, weighted consensus),
+`src/api/src/modules/fury/fury.worker.ts` and `src/shared/libs/integrity.ts`
+(§4 the $2.00 bounty/penalty and its idempotency),
+`src/api/src/modules/fury/fury.controller.ts` and `src/api/services/media/redaction.service.ts`
+(§2 redacted-derivative-only serving),
+`src/shared/fury-logic/honeypot.engine.ts` and `src/api/services/intelligence/honeypot.service.ts` (§5),
+`src/api/services/security/collusion-detection.service.ts` and
+`src/api/src/modules/security/anti-sybil.service.ts` (§6).
+If any of those change, this draft is stale.

--- a/docs/legal/hipaa-baa-template-DRAFT.md
+++ b/docs/legal/hipaa-baa-template-DRAFT.md
@@ -1,0 +1,263 @@
+---
+generated: true
+department: LEG
+artifact_id: L13
+governing_sop: "SOP--legal-documentation.md"
+phase: hardening
+product: styx
+date: "2026-08-15"
+---
+
+# HIPAA Business Associate Agreement — Template (Draft)
+
+**STYX -- THE BLOCKCHAIN OF TRUTH**
+
+_Last updated: 2026-08-15_
+_Effective date: [TBD -- not executable in its current state]_
+
+> **DRAFT — NOT COUNSEL-REVIEWED. DO NOT EXECUTE.**
+> This is an internal template authored from the platform's own implementation. It has **not** been
+> reviewed by qualified legal counsel and is **not** a legally binding instrument. Outside counsel
+> has not been retained (issue **#315**). **No BAA has ever been executed with any customer**, and
+> §0 below lists the technical prerequisites that are not yet met. Signing this document as drafted
+> would create obligations the Platform cannot currently satisfy.
+
+Named by the enterprise gate at `docs/checklists/enterprise-sales-readiness.md`:
+*"HIPAA BAA ready to sign — for healthcare enterprise customers. Verify: BAA template reviewed by
+counsel."* That verification has **not** occurred.
+
+Companion documents: `docs/legal/dpa-template.md` (the general data processing agreement — for
+customers who are **not** covered entities, that document, not this one, is the right instrument),
+`docs/legal/regulatory-risk-register.md` (the HIPAA exposure analysis),
+`docs/enterprise/security-whitepaper.md` (the technical controls §5 references).
+
+---
+
+## 0. Read This Before Anything Else
+
+**Styx is not a HIPAA covered entity.** It is not a healthcare provider, a health plan, or a
+healthcare clearinghouse. It stores no diagnostic codes, no treatment plans, and no clinical notes.
+The regulatory risk register's standing position is that ordinary B2B practitioner use of Styx does
+**not** create a business associate relationship, because practitioners use the Platform as a
+supplementary behavioral tool rather than a clinical record system.
+
+This template exists for the narrower case where a **covered-entity customer determines otherwise**
+about its own use — and needs a BAA before it will buy. It is not an assertion that Styx is HIPAA
+compliant, and it must never be presented as one.
+
+### 0.1 Prerequisites that are NOT met today
+
+| Prerequisite | Status |
+|---|---|
+| Counsel review of this template | **Not done** — issue #315 |
+| Legal opinion on whether B2B use creates a business associate relationship | **Not obtained** — named as mitigation item (5) in `regulatory-risk-register.md` |
+| Multi-factor authentication on practitioner accounts | **Not implemented** |
+| Encryption-key custody separate from the hosting vendor | **Not implemented** — keys are vendor-managed (Render, Cloudflare, Stripe) |
+| Sub-processor BAAs (Render, Cloudflare) | **Not executed** |
+| SOC 2 Type II | **Not started** |
+| Independent penetration test | **Not performed** |
+| Breach-notification runbook exercised | **Not exercised** |
+| A "PHI" data classification distinct from general behavioral data | **Does not exist** in the schema |
+
+The last row is the load-bearing one. **The Platform has no mechanism to segregate, label, or apply
+different handling to protected health information.** Behavioral and health-adjacent data (weight,
+BMI, exercise evidence) is stored, encrypted, and access-controlled exactly like every other user
+record. Any obligation in this template that assumes PHI can be isolated is aspirational until that
+mechanism exists.
+
+---
+
+## 1. Parties and Purpose
+
+This Business Associate Agreement ("BAA") supplements the Terms of Service and any Enterprise
+subscription agreement between [ORGANVM Entity TBD] ("Business Associate", "we") and the customer
+identified in the order form ("Covered Entity", "you").
+
+It applies **only** where you are a Covered Entity or Business Associate under 45 C.F.R. Parts 160
+and 164 (the "HIPAA Rules") and you disclose Protected Health Information ("PHI") to us in
+connection with the Platform. Terms not defined here have the meaning given in the HIPAA Rules.
+
+## 2. Permitted Uses and Disclosures
+
+We may use and disclose PHI only:
+
+1. to perform the services described in the subscription agreement;
+2. for our own proper management and administration, or to carry out our legal responsibilities;
+3. as Required by Law; and
+4. to provide data aggregation services relating to your healthcare operations, where the
+   subscription agreement provides for them.
+
+We will not use or disclose PHI in any manner that would violate the HIPAA Rules if done by you,
+except as permitted by §2(2) above.
+
+**We will not sell PHI, and will not use or disclose PHI for marketing or advertising, under any
+circumstances.**
+
+## 3. Minimum Necessary
+
+We will request, use, and disclose only the minimum necessary PHI to accomplish the purpose of the
+request, use, or disclosure.
+
+> **OPEN QUESTION FOR COUNSEL — minimum necessary and the peer-audit model.** The Platform's core
+> function routes a client's proof submission to **anonymous third-party peer auditors** who are not
+> your workforce and are not our workforce (they are independent contractors — see
+> `fury-auditor-agreement-DRAFT.md`). The submission is redacted before it is served (faces blurred,
+> voices pitch-shifted, subject shown only as an alias), and auditors never receive the original
+> media. Counsel must determine whether a redacted behavioral proof reviewed by an anonymous
+> contractor is a disclosure of PHI at all, and if it is, whether it can ever satisfy minimum
+> necessary. **If the answer is no, peer audit must be disabled for PHI-bearing accounts before any
+> BAA is executed — and that capability does not exist today.**
+
+## 4. Safeguards
+
+We will use appropriate administrative, physical, and technical safeguards, and comply with the
+Security Rule with respect to electronic PHI, to prevent use or disclosure of PHI other than as this
+BAA provides.
+
+The safeguards **as implemented today** are described in `docs/enterprise/security-whitepaper.md`
+and summarized here without embellishment:
+
+| Safeguard | As implemented |
+|---|---|
+| Encryption at rest | AES-256, vendor-managed (Render PostgreSQL, Cloudflare R2) |
+| Encryption in transit | TLS via Cloudflare and Render; security headers (including HSTS) applied by `helmet()` at the API bootstrap |
+| Access control | Role-based; role and ban status re-read from the database on every request, not from the session token |
+| Audit logging | Hash-chained, append-only event log with a database-level immutability trigger; verified daily |
+| Media privacy | Redacted derivative only; the serving path fails closed to no URL when no redacted asset exists |
+| Integrity | Double-entry ledger with posting-time invariants and database-enforced idempotency |
+| Workforce | **Sole founder.** No separation of duties, no security team, no security-awareness training program |
+
+The final row is a material limitation and is stated rather than omitted.
+
+## 5. Subcontractors
+
+We will ensure that any subcontractor that creates, receives, maintains, or transmits PHI on our
+behalf agrees in writing to restrictions and conditions at least as restrictive as those that apply
+to us.
+
+**Current subprocessors that would touch PHI:** Render (hosting, database), Cloudflare (object
+storage, CDN), Stripe (payments and identity verification), Sentry (error tracking), and the
+transactional email provider. **None has executed a BAA with us** (§0.1). Until they have, this
+clause cannot be satisfied.
+
+Additionally: the Platform's LLM subprocessors (Google Gemini, Groq) receive contract text and
+anonymized snippets for term validation and moderation. **Counsel must determine whether any
+PHI-bearing account's data can reach those paths, and if so, they must be disabled for such
+accounts before a BAA is executed.**
+
+## 6. Reporting and Breach Notification
+
+We will report to you:
+
+- any use or disclosure of PHI not permitted by this BAA of which we become aware, without
+  unreasonable delay;
+- any Security Incident of which we become aware; and
+- any Breach of Unsecured PHI, without unreasonable delay and in no case later than **30 calendar
+  days** after discovery.
+
+A Breach report will include, to the extent known: the identification of each individual whose PHI
+was involved, the nature of the breach, the date of the breach and of its discovery, the PHI
+involved, and the remediation taken.
+
+Unsuccessful Security Incidents that result in no unauthorized access — pings, port scans, blocked
+login attempts, denied access attempts — are reported in aggregate on request rather than
+individually.
+
+## 7. Individual Rights
+
+We will, within **15 business days** of your written request:
+
+- make PHI in a Designated Record Set available to you for access under 45 C.F.R. § 164.524;
+- make PHI available for amendment and incorporate amendments under § 164.526; and
+- make available the information required for an accounting of disclosures under § 164.528.
+
+Where an individual requests access directly from us, we will forward the request to you rather than
+respond, unless the subscription agreement provides otherwise.
+
+The Platform's implemented data-subject facilities are a structured self-service export and a
+deletion request with a 30-day grace period before erasure. **Neither is scoped to a Designated
+Record Set**, and no accounting-of-disclosures facility exists. Meeting this section as written
+requires work that has not been done.
+
+## 8. Access by the Secretary
+
+We will make our internal practices, books, and records relating to the use and disclosure of PHI
+available to the Secretary of Health and Human Services for purposes of determining your compliance
+with the HIPAA Rules.
+
+## 9. Term and Termination
+
+This BAA takes effect on the effective date of the subscription agreement and terminates when all
+PHI is returned or destroyed, or when protections are extended under §9.2.
+
+### 9.1 Termination for cause
+
+You may terminate the subscription agreement immediately if we materially breach this BAA and fail
+to cure within **30 days** of written notice.
+
+### 9.2 Return or destruction of PHI
+
+On termination we will return or destroy all PHI we maintain, in any form, and retain no copies,
+where feasible.
+
+**Where it is not feasible, we will state so and extend the protections of this BAA to the retained
+PHI, limiting further uses and disclosures to the purposes that make return or destruction
+infeasible.** Two such cases exist today and are disclosed in advance:
+
+1. **The append-only audit log.** Platform events are recorded in a hash-chained log that a
+   database trigger prevents from being updated or deleted. Erasure anonymizes the user record; it
+   does not rewrite log history, because rewriting it would destroy the integrity guarantee the log
+   exists to provide. Our mitigation is payload minimization at write time, not retroactive
+   deletion.
+2. **Financial transaction records**, retained for seven years under applicable US law and
+   anonymized after account deletion.
+
+> **OPEN QUESTION FOR COUNSEL — immutable audit logs and the return-or-destroy obligation.** Whether
+> an intentionally immutable log is "infeasible to destroy" within the meaning of
+> 45 C.F.R. § 164.504(e)(2)(ii)(J), and what payload minimization is sufficient, must be answered
+> before any BAA is executed. This is a structural conflict between the Platform's integrity model
+> and HIPAA's erasure model, not an implementation gap.
+
+## 10. No Warranty of Compliance
+
+Execution of this BAA is not a representation that the Platform is "HIPAA compliant" — a status
+that does not exist as a certification. It is a contractual allocation of the obligations the HIPAA
+Rules place on a business associate. You remain responsible for your own compliance, including for
+determining whether your use of the Platform involves PHI at all.
+
+## 11. Miscellaneous
+
+- **Order of precedence.** Where this BAA conflicts with the subscription agreement or the Terms of
+  Service with respect to PHI, this BAA governs.
+- **Amendment.** The parties will amend this BAA as necessary to comply with changes to the HIPAA
+  Rules.
+- **Interpretation.** Ambiguity is resolved in favor of a meaning that permits compliance with the
+  HIPAA Rules.
+- **No third-party beneficiaries.**
+
+---
+
+## Drafting Notes (internal — remove before publication)
+
+This template is a **starting point for counsel**, not a document to be signed. Its three unresolved
+structural conflicts, in priority order:
+
+1. **Peer audit vs. minimum necessary** (§3) — the Platform's core mechanism discloses redacted
+   proof material to anonymous non-workforce contractors. If that is a PHI disclosure, the model is
+   incompatible with a BAA unless peer audit can be disabled per account, which it cannot be today.
+2. **Immutable audit log vs. return-or-destroy** (§9.2) — the integrity guarantee and the erasure
+   obligation are in direct tension.
+3. **No PHI data classification** (§0.1) — every obligation that assumes PHI can be isolated is
+   currently unimplementable.
+
+Until those are answered, the correct commercial response to a "do you have a BAA?" question is the
+one the customer-facing FAQ already gives: BAAs are planned for the Enterprise tier and are **not
+yet executed**. Do not improve on that answer.
+
+**Source of every factual claim about mechanism in this draft:**
+`src/api/services/ledger/truth-log.service.ts` and `src/api/database/schema.sql` (§9.2 immutability),
+`src/api/src/modules/users/gdpr.service.ts` (§7 export/erasure and the 30-day grace period),
+`src/api/services/media/redaction.service.ts` and `src/api/src/modules/fury/fury.controller.ts`
+(§3, §4 redaction), `src/api/src/common/guards/role.guard.ts` (§4 access control),
+`src/api/src/main.ts` (§4 transport), `docs/legal/regulatory-risk-register.md` (§0).
+If any of those change, this draft is stale.


### PR DESCRIPTION
## What this is

Docs only. No code changed, so no jest.

The phase gates name six documents that were never written. Five of them are authored here; the sixth (Dispute Resolution Policy) is now marked **not drafted** rather than silently absent.

Every one of these was buildable from substrate already in the repo. What is genuinely blocked is **counsel sign-off** — #315 (retainer), #136 (gambling-classification opinion), #317 (jurisdiction matrix sign-off) — not the drafting. Those two halves had been collapsed into one blocked checkbox, so nothing moved.

## New files

| File | What it is |
|---|---|
| `docs/legal/escrow-agreement-DRAFT.md` | Stake custody and release. Leads with the fact most likely to be misstated: a Stake is a **manual-capture authorization hold**, not a transfer into a Styx-controlled account. Release rules keyed to the jurisdiction tier, kill switch, dispute handling. |
| `docs/legal/fury-auditor-agreement-DRAFT.md` | Peer auditor engagement. §11 is a counsel-only section stating the **worker-classification risk plainly**: applied to the facts as implemented, ABC-test prong B fails on its face (peer audit *is* the product), and prong C fails too. That section is why this must not be executed as drafted. |
| `docs/legal/hipaa-baa-template-DRAFT.md` | BAA template. §0 lists nine unmet prerequisites, the load-bearing one being that **the schema has no PHI classification at all**. Two structural conflicts are named rather than papered over: peer audit vs. minimum-necessary, and the immutable audit log vs. return-or-destroy. |
| `docs/legal/cookie-policy-DRAFT.md` | Cookies and local storage. `privacy-policy.md` contains **no** cookie section — the word does not appear in it — so this is a separate document rather than an extension. Enumerates the three cookies we set and the seven local-storage keys, exhaustively. |
| `docs/enterprise/security-whitepaper.md` | The enterprise gate's whitepaper, written from the implementation. |

Each legal draft carries a **DRAFT — NOT COUNSEL-REVIEWED** banner, an `OPEN QUESTION FOR COUNSEL` block wherever the mechanism raises a question only counsel can close, and a Drafting Notes footer naming the source files every factual claim came from — so a draft goes stale loudly when the code moves.

## The whitepaper

Written entirely from `src/`. Every control names its implementing file. Covers the hash-chained TruthLog, the double-entry ledger invariants, auth/role guards, the jurisdiction/geofence matrix, App Attest + Play Integrity, redaction, honeypots, weighted consensus, collusion detection, financial rails, supply chain.

**§12 is the list of what is NOT implemented** — no MFA, no SAML (the enterprise path is a pre-shared HS256 assertion, not SAML), no RS256, no token blacklist, no external anchoring of the log, no OFAC feed, no pentest, no SOC 2, no DR test, no disclosure policy. Honest limits are stated inline, not omitted:

- The TruthLog is **tamper-evident, not tamper-proof** — it detects modification, it does not prevent truncation, and there is no external anchoring. "Blockchain of Truth" is the product name; there is no distributed ledger, no consensus network, no cryptocurrency. Said in those words in §2.5.
- Geolocation is an **IP heuristic**, and there are two sources of jurisdiction truth (the compile-time map and the admin-updatable DB registry) whose reconciliation policy is an open question.
- **Single-founder operational posture** with no separation of duties and no security team — §11.

## Two claim-drift defects found and corrected

Reading the code against the existing questionnaire turned up drift in the questionnaire itself:

1. **`docs/enterprise/security-questionnaire.md` §2 was wrong on four counts.** It claimed bcrypt cost factor **12** (actual: 10), **RS256** asymmetric signing (actual: HS256), a **Redis token blacklist** (does not exist — revocation is refresh-token rotation plus the per-request DB role/ban read), and roles **Admin/Practitioner/Client/Fury** (actual: `USER`/`FURY`/`PRACTITIONER`/`ADMIN`). All corrected.

2. **`AmlScreeningService.detectStructuring()` cannot execute.** Its query selects `entries.amount_cents`; the `entries` column is `amount` (`src/api/database/schema.sql`). The call throws at runtime, so structuring detection is **not in service**. Its spec mocks the `pg` Pool, so the unit test passes and the defect is invisible to it.

   > **This PR does not fix it.** It is docs-only, and the fix needs an integration test against a real database, not a one-line column rename that the same mocked spec would also fail to catch. Disclosed in whitepaper §9.1 and listed in §12 as *broken, not merely absent*. Worth a follow-up issue.

## De-duplication (item 3)

The questionnaire now **links** to the whitepaper for mechanism instead of restating it, on the principle that a restated control is a control that goes stale silently — which is exactly what produced defect (1) above. Operational facts (hosting, subprocessors, retention, backup/DR, incident response, vendor risk) stay in the questionnaire; mechanism moves to the whitepaper.

`docs/departments/b2b/artifacts/security-questionnaire.md` was byte-identical to the `docs/enterprise/` copy. It is updated in lockstep with path-adjusted relative links so the two do not diverge on facts.

## Wiring — linked from where the estate looks

- `docs/checklists/phase-gate-public-process.md` §2 — each legal-document line now cites its draft **and says which half of the gate remains open**. The consent-banner half is explicitly called out as not existing in `src/web`.
- `docs/checklists/enterprise-sales-readiness.md` — the HIPAA BAA and security-whitepaper lines cite the new artifacts and state what is still missing.
- `docs/enterprise/README.md` — whitepaper added to "What Lives Here".
- `docs/departments/leg/REGE.md` artifact registry — new rows L13, L16, L17. **L11's path is corrected** to `docs/legal/fury-auditor-agreement-DRAFT.md`; the `docs/departments/leg/artifacts/` path it pointed at holds no copy of that artifact.

## Verification

```
$ node scripts/validation/07-claim-drift-check.js
Claim drift check passed (65 inline code references scanned).
EXIT=0

$ python3 linkcheck.py     # one-off sweep, removed before commit
checked 130 references
ALL REFERENCES RESOLVE
EXIT=0

$ git diff --check
EXIT=0
```

The reference sweep walked all markdown links and backticked `src/`, `docs/`, `scripts/`, `.github/` paths across the eleven touched files. One unresolved path exists in the LEG registry — L10 `docs/departments/leg/artifacts/state-exclusion-list.md` — and it is **pre-existing on `origin/main`** (confirmed via `git show origin/main:docs/departments/leg/REGE.md`), untouched here.

No jest and no `tsc` run: this branch changes no TypeScript. No SQL was modified.

## Summary by Sourcery

Add generated legal draft documents and an enterprise security whitepaper, wire them into phase-gate and enterprise readiness checklists, and correct security questionnaire claims to accurately reflect the implemented authentication, authorization, logging, and HIPAA posture.

Enhancements:
- Refactor enterprise security questionnaires to delegate technical mechanism details to the whitepaper, eliminating duplicated claims and reducing future drift.
- Correct and harden questionnaire answers around bcrypt parameters, JWT signing, MFA/SSO availability, token revocation, roles, CSRF, privacy, and logging to match actual implementation, and add explicit references to non-implemented roadmap items.

Documentation:
- Introduce draft escrow, Fury auditor, HIPAA BAA, and cookie/local-storage legal documents with clear counsel-review warnings and implementation-sourced factual notes.
- Add an enterprise security whitepaper that documents core security, privacy, jurisdiction, audit, and financial controls, and explicitly lists unimplemented or broken features.
- Update legal artifact registry and phase-gate checklist to reference the new drafts, clarify which legal gates are blocked on counsel or opinions, and mark the dispute-resolution policy as not drafted.
- Clarify enterprise sales readiness checklist items for HIPAA BAA and security whitepaper by linking to the new artifacts and stating current gaps.