### PR TITLE
feat(proofs): record HOW a proof was captured, and let the server decide if it counts

### DIFF
--- a/src/api/database/migrations/070_capture_provenance.sql
+++ b/src/api/database/migrations/070_capture_provenance.sql
@@ -1,0 +1,33 @@
+-- Migration 070: record HOW a proof was captured.
+--
+-- Styx's authority is verifiability, and until now the pipeline could not answer
+-- the most basic question about a piece of evidence: did a camera produce this?
+-- The Phase-1 mobile client calls createSyntheticCaptureSession, which
+-- base64-encodes a JSON metadata blob behind a `data:video/mp4;base64,` prefix —
+-- so today's "recording" is JSON wearing an mp4 costume. That is a DISCLOSED
+-- pilot exception (the completion matrix marks native capture PILOT-EXCEPTION,
+-- and the scope lock keeps Phase 1 synthetic-only), not a secret.
+--
+-- What was missing is not the camera. It is the RECORD: nothing distinguished a
+-- synthetic capture from a real one at rest, so a future real capture and
+-- today's placeholder are indistinguishable in the database, and no reviewer,
+-- auditor or export could tell them apart after the fact.
+--
+-- capture_source is that record. It is deliberately NOT a boolean: the honest
+-- states are "a native camera produced this", "the beta placeholder produced
+-- this", and "we do not know", and collapsing the third into either of the
+-- others is how an unverified proof starts reading as verified.
+
+ALTER TABLE proofs
+  ADD COLUMN IF NOT EXISTS capture_source TEXT,
+  ADD COLUMN IF NOT EXISTS capture_nonce TEXT,
+  ADD COLUMN IF NOT EXISTS capture_verified BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_proofs_capture_source ON proofs(capture_source);
+
+COMMENT ON COLUMN proofs.capture_source IS
+  'NATIVE_CAMERA | SYNTHETIC_BETA | NULL (unknown — proofs predating this migration). NULL is a real answer, not a default.';
+COMMENT ON COLUMN proofs.capture_nonce IS
+  'The server-issued nonce echoed back at confirm time. Its presence and match are what capture_verified asserts.';
+COMMENT ON COLUMN proofs.capture_verified IS
+  'TRUE only when a NATIVE_CAMERA capture echoed the server nonce it was issued. A synthetic capture is never verified, by definition.';

--- a/src/api/src/modules/proofs/dto.ts
+++ b/src/api/src/modules/proofs/dto.ts
@@ -1,5 +1,13 @@
-import { IsString, IsEnum, IsOptional, IsObject } from 'class-validator';
+import { IsString, IsEnum, IsOptional, IsObject, IsIn } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * How a proof's media was produced. Three states, because two would lie:
+ * a proof whose origin was never recorded is UNKNOWN, and calling that
+ * "synthetic" or "native" invents a fact.
+ */
+export const CAPTURE_SOURCES = ['NATIVE_CAMERA', 'SYNTHETIC_BETA'] as const;
+export type CaptureSource = (typeof CAPTURE_SOURCES)[number];
 
 export enum ProofMediaType {
   VIDEO = 'video/mp4',
@@ -35,4 +43,25 @@ export class ConfirmUploadDto {
   @IsOptional()
   @IsObject()
   deviceMetadata?: Record<string, any>;
+
+  /**
+   * How the media was produced. Optional because clients predating this field
+   * must keep working — but an ABSENT source is recorded as unknown and is
+   * never treated as native. The server decides what the value means; the
+   * client only reports it, and reporting NATIVE_CAMERA without echoing the
+   * issued nonce does not make a proof verified.
+   */
+  @ApiPropertyOptional({
+    description: 'How the media was captured',
+    enum: CAPTURE_SOURCES,
+    example: 'SYNTHETIC_BETA',
+  })
+  @IsOptional()
+  @IsIn(CAPTURE_SOURCES)
+  captureSource?: CaptureSource;
+
+  @ApiPropertyOptional({ description: 'The nonce issued by POST /proofs/upload-url, echoed back' })
+  @IsOptional()
+  @IsString()
+  captureNonce?: string;
 }

--- a/src/api/src/modules/proofs/proofs.controller.spec.ts
+++ b/src/api/src/modules/proofs/proofs.controller.spec.ts
@@ -100,6 +100,9 @@ describe('ProofsController', () => {
         uploadUrl: 'https://r2.example/upload',
         storageKey: 'proofs/proof-1.mp4',
         expiresInSeconds: 300,
+        // The capture nonce is issued HERE, server-side, so that a later
+        // NATIVE_CAMERA claim has something only this server could have given it.
+        captureNonce: expect.any(String),
       });
 
       // The INSERT must name columns that actually exist on `proofs`
@@ -180,6 +183,96 @@ describe('ProofsController', () => {
     // Client-asserted biometric fields are intentionally no longer trusted/persisted.
     const dto = { storageKey: 'proofs/p1' };
 
+    // Capture provenance (TKT-P0-002). The product's authority is
+    // verifiability, and until now nothing recorded whether a camera produced a
+    // proof at all — today's mobile path base64-encodes JSON behind a
+    // data:video/mp4 prefix. capture_verified is asserted by the SERVER against
+    // a nonce it issued; a client cannot talk its way into it.
+    describe('capture provenance', () => {
+      const primeConfirm = (issuedNonce: string | null) => {
+        mockProofsService.getProofUploadConfirmationAccess.mockResolvedValue({
+          status: 'PENDING_UPLOAD',
+          contractId: 'c-1',
+          ownerUserId: 'user-1',
+        } as any);
+        mockR2.downloadFile.mockResolvedValue(Buffer.from('fake-media'));
+        mockAnomaly.analyze.mockResolvedValue({ rejected: false, flags: [] });
+        mockPhash.computeFrameHash.mockResolvedValue('hash-123');
+        mockPhash.isDuplicate.mockResolvedValue({ duplicate: false, closestDistance: 64 });
+        mockPool.query.mockImplementation((sql: string) => {
+          if (/SELECT capture_nonce/.test(sql)) {
+            return Promise.resolve({ rows: [{ capture_nonce: issuedNonce }] });
+          }
+          return Promise.resolve({ rows: [] });
+        });
+      };
+
+      const finalizeArgs = () => {
+        const call = mockPool.query.mock.calls.find((c: any[]) =>
+          /UPDATE proofs[\s\S]*capture_source/.test(String(c[0])),
+        );
+        expect(call).toBeDefined();
+        return call![1] as any[];
+      };
+
+      it('marks a native capture verified only when it echoes the issued nonce', async () => {
+        primeConfirm('server-issued-nonce');
+
+        await controller.confirmUpload('p-1', user, {
+          storageKey: 'proofs/p1',
+          captureSource: 'NATIVE_CAMERA',
+          captureNonce: 'server-issued-nonce',
+        } as any);
+
+        const args = finalizeArgs();
+        expect(args).toContain('NATIVE_CAMERA');
+        expect(args).toContain(true);
+      });
+
+      it('refuses to verify a native claim whose nonce does not match, and flags it', async () => {
+        primeConfirm('server-issued-nonce');
+
+        const result = await controller.confirmUpload('p-1', user, {
+          storageKey: 'proofs/p1',
+          captureSource: 'NATIVE_CAMERA',
+          captureNonce: 'attacker-guessed-nonce',
+        } as any);
+
+        const args = finalizeArgs();
+        expect(args).toContain('NATIVE_CAMERA');
+        expect(args).toContain(false);
+        expect(result.flags).toContain('CAPTURE_NONCE_MISMATCH');
+      });
+
+      it('records the synthetic beta path as synthetic, flagged and never verified', async () => {
+        primeConfirm('server-issued-nonce');
+
+        const result = await controller.confirmUpload('p-1', user, {
+          storageKey: 'proofs/p1',
+          captureSource: 'SYNTHETIC_BETA',
+          captureNonce: 'server-issued-nonce',
+        } as any);
+
+        const args = finalizeArgs();
+        expect(args).toContain('SYNTHETIC_BETA');
+        expect(args).toContain(false);
+        expect(result.flags).toContain('SYNTHETIC_CAPTURE');
+      });
+
+      it('records an unreported source as UNKNOWN rather than assuming either answer', async () => {
+        primeConfirm('server-issued-nonce');
+
+        const result = await controller.confirmUpload('p-1', user, {
+          storageKey: 'proofs/p1',
+        } as any);
+
+        const args = finalizeArgs();
+        expect(args).toContain(null);
+        expect(args).toContain(false);
+        expect(result.flags).toContain('CAPTURE_SOURCE_UNKNOWN');
+      });
+    });
+
     it('should finalize proof with anomaly flags (no client biometric data persisted)', async () => {
       mockProofsService.getProofUploadConfirmationAccess.mockResolvedValue({
         status: 'PENDING_UPLOAD',
@@ -200,7 +293,15 @@ describe('ProofsController', () => {
       // Finalize UPDATE now only persists storageKey, proofId, anomaly flags and device metadata.
       expect(mockPool.query).toHaveBeenCalledWith(
         expect.stringContaining('UPDATE proofs'),
-        expect.arrayContaining([expect.any(String), 'p-1', '["EXIF_TIMESTAMP_DISCREPANCY"]', '{}'])
+        expect.arrayContaining(['p-1', '{}'])
+      );
+      // Anomaly flags now also carry capture provenance; the EXIF flag survives
+      // alongside the unknown-source flag rather than being replaced by it.
+      const finalize = mockPool.query.mock.calls.find((c: any[]) =>
+        /UPDATE proofs[\s\S]*capture_source/.test(String(c[0])),
+      );
+      expect(JSON.parse(String((finalize![1] as any[])[2]))).toEqual(
+        expect.arrayContaining(['EXIF_TIMESTAMP_DISCREPANCY']),
       );
     });
 

--- a/src/api/src/modules/proofs/proofs.controller.ts
+++ b/src/api/src/modules/proofs/proofs.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Post, Get, Param, Body, Headers, UseGuards, BadRequestException, ConflictException, ForbiddenException, ServiceUnavailableException } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
-import { timingSafeEqual } from 'crypto';
+import { timingSafeEqual, randomBytes } from 'crypto';
 import { Pool } from 'pg';
 import { AuthGuard } from '../../../guards/auth.guard';
 import { BannedUserGuard } from '../../guards/banned-user.guard';
@@ -114,7 +114,18 @@ export class ProofsController {
       }
     }
 
-    return { proofId, uploadUrl, storageKey: key, expiresInSeconds: 300 };
+    // Issue the capture nonce here, server-side, and persist it. The mobile
+    // client already generated a nonce of its own (Date.now + Math.random) and
+    // stamped it into the watermark — but a value the client both mints and
+    // presents proves nothing. Only a nonce the SERVER issued and can compare
+    // against turns "this claims to be a live capture" into a checkable claim.
+    const captureNonce = randomBytes(16).toString('hex');
+    await this.pool.query(
+      `UPDATE proofs SET capture_nonce = $1 WHERE id = $2`,
+      [captureNonce, proofId],
+    );
+
+    return { proofId, uploadUrl, storageKey: key, expiresInSeconds: 300, captureNonce };
   }
 
   @UseGuards(AuthGuard, GeofenceGuard, ComplianceAccessGuard, BannedUserGuard)
@@ -257,6 +268,36 @@ export class ProofsController {
       );
     }
 
+    // Capture provenance. `capture_verified` is asserted by the SERVER, never
+    // reported by the client: a claim of NATIVE_CAMERA only counts when the
+    // proof echoes the nonce this server issued at upload-url time. Everything
+    // else — a synthetic beta capture, a missing source, a wrong nonce — is
+    // recorded as what it is and flagged, so an unverified proof can never read
+    // as a verified one downstream.
+    const issued = await this.pool.query(
+      `SELECT capture_nonce FROM proofs WHERE id = $1`,
+      [proofId],
+    );
+    const issuedNonce: string | null = issued.rows[0]?.capture_nonce ?? null;
+    const nonceMatches =
+      !!issuedNonce &&
+      !!dto.captureNonce &&
+      dto.captureNonce.length === issuedNonce.length &&
+      timingSafeEqual(Buffer.from(dto.captureNonce), Buffer.from(issuedNonce));
+
+    const captureSource = dto.captureSource ?? null;
+    const captureVerified = captureSource === 'NATIVE_CAMERA' && nonceMatches;
+
+    if (captureSource === 'SYNTHETIC_BETA') {
+      // The disclosed Phase-1 path. Flagged, not rejected — but never silent.
+      combinedFlags.push('SYNTHETIC_CAPTURE');
+    } else if (captureSource === null) {
+      combinedFlags.push('CAPTURE_SOURCE_UNKNOWN');
+    } else if (!nonceMatches) {
+      // Claims a live capture but cannot echo the nonce it was issued.
+      combinedFlags.push('CAPTURE_NONCE_MISMATCH');
+    }
+
     // 3. Finalize Proof with Anomaly Metadata.
     // Client-asserted biometric verification is NOT trusted: a client could set
     // biometricVerified/biometricType arbitrarily. These are only meaningful when
@@ -267,13 +308,17 @@ export class ProofsController {
            media_uri = $1,
            uploaded_at = NOW(),
            anomaly_flags = $3,
-           device_metadata = $4
+           device_metadata = $4,
+           capture_source = $5,
+           capture_verified = $6
        WHERE id = $2`,
       [
         dto.storageKey,
         proofId,
         JSON.stringify(combinedFlags),
         JSON.stringify(dto.deviceMetadata || {}),
+        captureSource,
+        captureVerified,
       ],
     );
 

--- a/src/mobile/components/CameraModule.spec.tsx
+++ b/src/mobile/components/CameraModule.spec.tsx
@@ -89,9 +89,14 @@ describe('CameraModule', () => {
         expect.stringContaining('data:video/mp4;base64,'),
         'https://r2.example.com/upload',
       );
+      // The client declares its capture source rather than letting the server
+      // guess: this build's path is synthetic, and saying so is what lets the
+      // server flag it instead of recording an unknown origin.
       expect(UploadService.confirmUpload).toHaveBeenCalledWith(
         'proof_123',
         'proofs/proof_123/video.mp4',
+        'SYNTHETIC_BETA',
+        undefined,
       );
       expect(ApiClient.submitProof).toHaveBeenCalledWith('contract-1', {
         mediaUri: 'proofs/proof_123/video.mp4',

--- a/src/mobile/components/CameraModule.tsx
+++ b/src/mobile/components/CameraModule.tsx
@@ -109,7 +109,7 @@ export const CameraModule = ({ contractId }: { contractId?: string }) => {
 
     setIsUploading(true);
     try {
-      const { uploadUrl, proofId, storageKey } = await UploadService.requestPreSignedUrl(
+      const { uploadUrl, proofId, storageKey, captureNonce } = await UploadService.requestPreSignedUrl(
         contractId,
         'video/mp4',
         `Live camera submission | capture-hash:${captureHash || 'none'} | ${captureLabel || 'n/a'}`,
@@ -120,7 +120,16 @@ export const CameraModule = ({ contractId }: { contractId?: string }) => {
         throw new Error('Video blob failed to transmit to Cloudflare R2.');
       }
 
-      const dispatchSuccess = await UploadService.confirmUpload(proofId, storageKey);
+      // This build's capture path is synthetic (createSyntheticCaptureSession),
+      // and it declares that rather than letting the server guess. The nonce is
+      // echoed regardless so the plumbing is exercised on the path that exists
+      // today, not only on the native one that arrives with #141.
+      const dispatchSuccess = await UploadService.confirmUpload(
+        proofId,
+        storageKey,
+        'SYNTHETIC_BETA',
+        captureNonce,
+      );
       if (!dispatchSuccess) {
         throw new Error('Proof upload confirmed failed during queue dispatch.');
       }

--- a/src/mobile/services/UploadService.spec.ts
+++ b/src/mobile/services/UploadService.spec.ts
@@ -143,7 +143,13 @@ describe('UploadService', () => {
       expect.objectContaining({
         method: 'POST',
         headers: expect.objectContaining({ Authorization: 'Bearer mock-jwt-token' }),
-        body: JSON.stringify({ storageKey: 'proofs/proof_123/video.mp4' }),
+        // captureSource defaults to the honest value for this build; captureNonce
+        // is absent here because the caller did not pass one, and JSON.stringify
+        // drops undefined rather than sending null.
+        body: JSON.stringify({
+          storageKey: 'proofs/proof_123/video.mp4',
+          captureSource: 'SYNTHETIC_BETA',
+        }),
       }),
     );
   });

--- a/src/mobile/services/UploadService.ts
+++ b/src/mobile/services/UploadService.ts
@@ -41,7 +41,7 @@ export class UploadService {
     contractId: string,
     fileType: string,
     description?: string,
-  ): Promise<{ uploadUrl: string; proofId: string; storageKey: string }> {
+  ): Promise<{ uploadUrl: string; proofId: string; storageKey: string; captureNonce?: string }> {
     console.log(`UploadService: Requesting Pre-Signed URL for ${fileType} (contract=${contractId})...`);
 
     const token = await SessionService.getToken();
@@ -103,7 +103,21 @@ export class UploadService {
   /**
    * Notifies the Styx API that the upload is complete, dispatching the job to the BullMQ Fury Router.
    */
-  static async confirmUpload(proofId: string, storageKey: string): Promise<boolean> {
+  /**
+   * @param captureSource How the media was produced. This client's Phase-1 path
+   *   is SYNTHETIC_BETA and says so: the server flags it, and a proof that
+   *   cannot say where it came from is worth less than one that admits it was
+   *   a placeholder. Never report NATIVE_CAMERA for a fabricated capture — the
+   *   server would still refuse to mark it verified without the issued nonce,
+   *   but the lie would be recorded as the proof's provenance.
+   * @param captureNonce The nonce returned by requestPreSignedUrl, echoed back.
+   */
+  static async confirmUpload(
+    proofId: string,
+    storageKey: string,
+    captureSource: 'NATIVE_CAMERA' | 'SYNTHETIC_BETA' = 'SYNTHETIC_BETA',
+    captureNonce?: string,
+  ): Promise<boolean> {
     console.log(`UploadService: Confirming upload for Proof [${proofId}]. Dispatching to Fury Router...`);
 
     const token = await SessionService.getToken();
@@ -113,7 +127,7 @@ export class UploadService {
         'Content-Type': 'application/json',
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
-      body: JSON.stringify({ storageKey }),
+      body: JSON.stringify({ storageKey, captureSource, captureNonce }),
     });
 
     if (!res.ok) {


### PR DESCRIPTION
Styx's authority is verifiability, and the pipeline could not answer the most basic question about a piece of evidence: **did a camera produce this?** The Phase-1 mobile path calls `createSyntheticCaptureSession`, which base64-encodes a JSON metadata blob behind a `data:video/mp4;base64,` prefix — today's "recording" is JSON wearing an mp4 costume.

That is a **disclosed** pilot exception (the completion matrix marks native capture PILOT-EXCEPTION; the Phase-1 scope lock keeps capture synthetic), so this change deliberately does **not** remove it — removing it would break the running beta and reopen a decided scope question. What was missing is the **record**: nothing distinguished a synthetic capture from a real one at rest, so a future real capture and today's placeholder are indistinguishable in the database.

- **Migration 070** adds `capture_source` / `capture_nonce` / `capture_verified`. `capture_source` is deliberately *not* a boolean: NATIVE_CAMERA, SYNTHETIC_BETA and NULL-for-unknown are three different facts, and collapsing "unknown" into either of the others is how an unverified proof starts reading as verified.
- **`upload-url` issues the nonce** server-side and persists it. The client already minted its own (`Date.now` + `Math.random`) and stamped it into the watermark — but a value the client both mints and presents proves nothing.
- **`confirm-upload` decides verification itself**: `capture_verified` is true only when a NATIVE_CAMERA claim echoes the issued nonce (timing-safe compare). Synthetic flags `SYNTHETIC_CAPTURE`, absent flags `CAPTURE_SOURCE_UNKNOWN`, a bad nonce flags `CAPTURE_NONCE_MISMATCH`. Flagged, never silently rejected.
- The mobile client **declares SYNTHETIC_BETA honestly** and echoes the nonce, so the plumbing runs on the path that exists today, not only the native one arriving with #141.

Verified: **32/32** proofs specs green (4 new provenance cases), api + mobile `tsc` clean. Honest caveat: SQL is mock-tested only, as everything in this repo is — migration 070 wants a live-DB pass.

Closes the last Gamma item (TKT-P0-002's in-repo half; device capture remains gated on #141).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmP1SLhXcZBmA7g4NM6PTY

## Summary by Sourcery

Record capture provenance for proofs and let the server assert whether a capture is verified based on a server-issued nonce.

New Features:
- Track how each proof was captured via new capture_source and capture_verified fields tied to a server-issued capture_nonce.
- Expose capture provenance and nonce information through the proofs upload and confirmation API so clients can report how media was produced.

Enhancements:
- Have the backend derive capture verification status from a nonce it issues, flagging synthetic, unknown, or nonce-mismatched captures instead of relying on client assertions.
- Update the mobile upload flow to honestly declare its synthetic beta capture path and echo the server-issued nonce when confirming uploads.

Tests:
- Add controller tests covering native, synthetic, unknown, and nonce-mismatch capture scenarios and ensure anomaly flags coexist with provenance flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capture provenance tracking for uploaded proofs.
  * Uploads now receive a server-issued capture nonce for validation.
  * Capture confirmations identify native or synthetic media and record verification status.

* **Bug Fixes**
  * Improved validation for mismatched, missing, unknown, or invalid capture details.
  * Preserved anomaly flags during proof finalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->